### PR TITLE
feat(code-mode): persistent coding sessions — runner, sandbox verbs, boundary approvals, session-surface core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Host tests
         run: pnpm exec vitest run
 
+      - name: Install tmux for the container tests
+        # The code runner's tmux suites drive a real tmux server. They are
+        # describe.if-gated on the binary, so without it they would skip
+        # silently rather than fail; install it so they actually run.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends tmux
+
       - name: Container tests
         working-directory: container/agent-runner
         run: bun test

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -36,6 +36,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
         chromium \
+        tmux \
         fonts-liberation \
         fonts-noto-color-emoji \
         libgbm1 \

--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -5,6 +5,8 @@
   "description": "Container-side agent runner for NanoClaw",
   "scripts": {
     "start": "bun src/index.ts",
+    "start:chat": "bun src/index.ts",
+    "start:code": "bun src/code-runner/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test"
   },

--- a/container/agent-runner/src/cli/mailbox-verbs.test.ts
+++ b/container/agent-runner/src/cli/mailbox-verbs.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Container-local mailbox verbs against a REGISTERED mailbox that is not
+ * SQLite — the point of the exercise.
+ *
+ * The fixture is an in-memory AgentMailbox holding only canonical records,
+ * so a verb that reached for a file, a table or a connection would fail
+ * here rather than against a store that is not SQLite files.
+ * The delivery-loop half of the same contract stays on the SQLite fixture
+ * (mailbox.test.ts): that suite is about the state machine, this one is
+ * about the transport being nobody's business.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { loadConfig } from '../config.js';
+import { getAgentMailbox, registerAgentMailbox, resetAgentMailboxForTesting } from '../mailbox/index.js';
+import { parseInboundRecord, parseSessionRoutingRecord } from '../mailbox/model.generated.js';
+import type {
+  AgentMailbox,
+  AgentMailboxFactory,
+  InboundRecord,
+  MailboxOperations,
+  OutboundRecord,
+  ProcessingStatus,
+  SessionRoutingRecord,
+} from '../mailbox/types.js';
+import { inboxRead, outboxSend, runMailboxVerb, type MailboxPaths } from './mailbox-verbs.js';
+
+loadConfig(); // defaults — the pending fetch reads maxMessagesPerPrompt
+
+let composed: AgentMailboxFactory | undefined;
+let paths: MailboxPaths;
+let store: FakeMailbox;
+
+/**
+ * Everything a verb did NOT ask for throws by name, so a verb that grows a
+ * dependency on some other operation says which one, here, instead of at
+ * runtime.
+ */
+function seamOnly(implemented: Partial<MailboxOperations>): MailboxOperations {
+  return new Proxy(implemented as Record<string, unknown>, {
+    get(target, key) {
+      if (typeof key === 'string' && !(key in target))
+        throw new Error(`fake mailbox: verb reached for an unimplemented operation ${key}`);
+      return target[key as string];
+    },
+  }) as unknown as MailboxOperations;
+}
+
+/**
+ * The smallest honest mailbox: canonical records in Maps, the seam's own
+ * selection and sequence rules, and nothing else. Unimplemented operations
+ * throw, so a verb that grew a new dependency says so.
+ */
+class FakeMailbox implements AgentMailbox {
+  readonly inbound = new Map<string, InboundRecord>();
+  readonly outbound = new Map<string, OutboundRecord>();
+  readonly acks = new Map<string, ProcessingStatus>();
+  routing: SessionRoutingRecord = parseSessionRoutingRecord({
+    channelType: 'chat',
+    platformId: 'C999',
+    threadId: null,
+  });
+  runs = 0;
+
+  readonly operations = seamOnly({
+    getPendingMessages: (limit: number, isFirstPoll: boolean): InboundRecord[] =>
+      [...this.inbound.values()]
+        .filter(
+          (m) =>
+            m.status === 'pending' &&
+            (m.processAfter === null || Date.parse(m.processAfter) <= Date.now()) &&
+            (!m.onWake || isFirstPoll) &&
+            !this.acks.has(m.id),
+        )
+        .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
+        .slice(0, limit),
+    markMessages: (ids: string[], status: ProcessingStatus): void => {
+      for (const id of ids) this.acks.set(id, status);
+    },
+    getMessageIn: (id: string): InboundRecord | undefined => this.inbound.get(id),
+    getSessionRouting: (): SessionRoutingRecord => this.routing,
+    writeMessageOut: async (message: Parameters<MailboxOperations['writeMessageOut']>[0]): Promise<number> => {
+      const max = Math.max(
+        0,
+        ...[...this.inbound.values()].map((m) => m.sequence ?? 0),
+        ...[...this.outbound.values()].map((m) => m.sequence ?? 0),
+      );
+      const sequence = max % 2 === 0 ? max + 1 : max + 2;
+      this.outbound.set(message.id, {
+        id: message.id,
+        sequence,
+        inReplyTo: message.inReplyTo ?? null,
+        timestamp: new Date().toISOString(),
+        deliverAfter: null,
+        recurrence: null,
+        kind: message.kind,
+        platformId: message.platformId ?? null,
+        channelType: message.channelType ?? null,
+        threadId: message.threadId ?? null,
+        content: message.content,
+      } as OutboundRecord);
+      return sequence;
+    },
+  });
+
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async run<T>(action: () => T | Promise<T>): Promise<T> {
+    this.runs++;
+    return action();
+  }
+}
+
+function seedInbound(
+  id: string,
+  opts: {
+    text?: string;
+    kind?: string;
+    seq?: number;
+    onWake?: boolean;
+    trigger?: boolean;
+    attachments?: unknown[];
+  } = {},
+): void {
+  store.inbound.set(
+    id,
+    parseInboundRecord({
+      id,
+      sequence: opts.seq ?? null,
+      kind: opts.kind ?? 'chat',
+      timestamp: new Date().toISOString(),
+      status: 'pending',
+      processAfter: null,
+      recurrence: null,
+      seriesId: id,
+      tries: 0,
+      trigger: opts.trigger ?? true,
+      platformId: 'C123',
+      channelType: 'chat',
+      threadId: 'T456',
+      content: JSON.stringify({
+        text: opts.text ?? `text of ${id}`,
+        sender: 'alice',
+        ...(opts.attachments ? { attachments: opts.attachments } : {}),
+      }),
+      sourceSessionId: null,
+      onWake: opts.onWake ?? false,
+    }),
+  );
+}
+
+function ackedIds(status: ProcessingStatus = 'completed'): string[] {
+  return [...store.acks.entries()]
+    .filter(([, value]) => value === status)
+    .map(([id]) => id)
+    .sort();
+}
+
+beforeEach(() => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-verbs-'));
+  paths = { containerJson: path.join(dir, 'container.json') };
+  fs.writeFileSync(paths.containerJson, JSON.stringify({ codeMode: true }));
+  store = new FakeMailbox();
+  // Capture per test, not once at import: another suite may hold the slot
+  // when this file loads, and a swap must always put back what it took.
+  composed = resetAgentMailboxForTesting();
+  registerAgentMailbox(() => store);
+});
+
+afterEach(() => {
+  resetAgentMailboxForTesting();
+  if (composed) registerAgentMailbox(composed);
+});
+
+describe('inbox read', () => {
+  it('returns pending mail chronologically and consumes it by default', async () => {
+    seedInbound('m1', { seq: 2, text: 'first' });
+    seedInbound('m2', { seq: 4, text: 'second' });
+    const res = await inboxRead({});
+    if (!res.ok) throw new Error(res.error.message);
+    const data = res.data as { messages: Array<{ id: string; text: string; sender: string }>; consumed: boolean };
+    expect(data.messages.map((m) => m.text)).toEqual(['first', 'second']);
+    expect(data.messages[0].sender).toBe('alice');
+    expect(data.consumed).toBe(true);
+    expect(ackedIds()).toEqual(['m1', 'm2']);
+
+    // Consumed mail does not reappear.
+    const again = await inboxRead({});
+    if (!again.ok) throw new Error(again.error.message);
+    expect((again.data as { messages: unknown[] }).messages).toHaveLength(0);
+  });
+
+  it('--peek reads without consuming', async () => {
+    seedInbound('m1');
+    const res = await inboxRead({ peek: true });
+    if (!res.ok) throw new Error(res.error.message);
+    expect((res.data as { messages: unknown[] }).messages).toHaveLength(1);
+    expect([...store.acks.keys()]).toEqual([]);
+  });
+
+  it('--id fetches full text regardless of ack state (the preview follow-up)', async () => {
+    seedInbound('m1', { text: 'the full long text' });
+    await inboxRead({}); // consume it
+    const res = await inboxRead({ id: 'm1' });
+    if (!res.ok) throw new Error(res.error.message);
+    expect((res.data as { message: { text: string } }).message.text).toBe('the full long text');
+  });
+
+  it('--id returns the staged attachments structured, and the text shows where each file is', async () => {
+    seedInbound('m1', {
+      text: 'Review this screenshot',
+      attachments: [{ type: 'image', name: 'screen.png', localPath: 'inbox/m1/screen.png', size: 1234 }],
+    });
+    const res = await inboxRead({ id: 'm1' });
+    if (!res.ok) throw new Error(res.error.message);
+    const { message } = res.data as { message: { text: string; attachments: unknown[] } };
+    expect(message.text).toBe('Review this screenshot');
+    expect(message.attachments).toEqual([
+      {
+        name: 'screen.png',
+        type: 'image',
+        localPath: 'inbox/m1/screen.png',
+        path: '/workspace/inbox/m1/screen.png',
+        url: null,
+      },
+    ]);
+    expect(res.human).toEndWith(
+      'Review this screenshot\n[image: screen.png — saved to /workspace/inbox/m1/screen.png]',
+    );
+
+    // A message that is only a file is still a message.
+    seedInbound('m2', { text: '', attachments: [{ type: 'image', name: 'b.png', localPath: 'inbox/m2/b.png' }] });
+    const batch = await inboxRead({});
+    if (!batch.ok) throw new Error(batch.error.message);
+    const { messages } = batch.data as { messages: Array<{ id: string; attachments: unknown[] }> };
+    expect(messages.find((m) => m.id === 'm2')?.attachments).toHaveLength(1);
+    expect(batch.human).toContain('id m2\n[image: b.png — saved to /workspace/inbox/m2/b.png]');
+  });
+
+  it('never surfaces kind=system transport envelopes', async () => {
+    seedInbound('resp', { kind: 'system', text: 'cli_response' });
+    const res = await inboxRead({});
+    if (!res.ok) throw new Error(res.error.message);
+    expect((res.data as { messages: unknown[] }).messages).toHaveLength(0);
+    // Not even acked — it belongs to the cli poll this same process is running.
+    expect([...store.acks.keys()]).toEqual([]);
+  });
+
+  it('sees an on_wake row the delivery loop has already polled past', async () => {
+    seedInbound('wake', { onWake: true, text: 'you were restarted' });
+    // The loop, past its first poll, cannot see this row at all.
+    expect(store.operations.getPendingMessages(10, false)).toHaveLength(0);
+    const res = await inboxRead({});
+    if (!res.ok) throw new Error(res.error.message);
+    expect((res.data as { messages: Array<{ text: string }> }).messages[0].text).toBe('you were restarted');
+  });
+
+  it('says so when the seam cap holds mail back — twelve waiting, ten shown, and the agent can tell', async () => {
+    for (let i = 1; i <= 12; i++) seedInbound(`m${i}`, { seq: i * 2 });
+    const res = await inboxRead({});
+    if (!res.ok) throw new Error(res.error.message);
+    const first = res.data as { messages: unknown[]; truncated: boolean };
+    expect(first.messages).toHaveLength(10);
+    expect(first.truncated).toBe(true);
+    expect(res.human).toContain('batch capped at 10');
+
+    // Reading again drains the rest, and a short batch claims no cap.
+    const again = await inboxRead({});
+    if (!again.ok) throw new Error(again.error.message);
+    const rest = again.data as { messages: unknown[]; truncated: boolean };
+    expect(rest.messages).toHaveLength(2);
+    expect(rest.truncated).toBe(false);
+    expect(again.human).not.toContain('capped');
+  });
+
+  it('a capped batch of system envelopes still announces the mail behind it', async () => {
+    // The system filter runs AFTER the cap, so "inbox empty" can be a lie
+    // told by ten transport envelopes. The note is on the pre-filter length.
+    for (let i = 1; i <= 10; i++) seedInbound(`sys${i}`, { kind: 'system', seq: i * 2 });
+    seedInbound('mail', { seq: 22, text: 'behind the envelopes' });
+    const res = await inboxRead({});
+    if (!res.ok) throw new Error(res.error.message);
+    expect((res.data as { messages: unknown[]; truncated: boolean }).truncated).toBe(true);
+    expect(res.human).toContain('inbox empty');
+    expect(res.human).toContain('batch capped at 10');
+    expect([...store.acks.keys()]).toEqual([]); // envelopes are still never acked
+  });
+
+  it('never claims mail the delivery loop is mid-delivery on', async () => {
+    seedInbound('m1');
+    store.operations.markMessages(['m1'], 'processing');
+    const res = await inboxRead({});
+    if (!res.ok) throw new Error(res.error.message);
+    expect((res.data as { messages: unknown[] }).messages).toHaveLength(0);
+    // The loop's claim is intact — the read never overwrote it.
+    expect(store.acks.get('m1')).toBe('processing');
+  });
+});
+
+describe('outbox send', () => {
+  it('writes a chat message routed to the session routing with an odd seq and JSON content', async () => {
+    seedInbound('m1', { seq: 2 }); // host wrote even seq 2
+    const res = await outboxSend({ text: 'hello from the sandbox' });
+    if (!res.ok) throw new Error(res.error.message);
+    const rows = [...store.outbound.values()];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('chat');
+    expect(rows[0].platformId).toBe('C999');
+    expect((rows[0].sequence as number) % 2).toBe(1);
+    expect((rows[0].sequence as number) > 2).toBe(true);
+    expect(JSON.parse(rows[0].content)).toEqual({ text: 'hello from the sandbox' });
+  });
+
+  it('--reply-to copies the inbound routing and sets inReplyTo', async () => {
+    seedInbound('m1', { seq: 2 });
+    const res = await outboxSend({ text: 'threaded reply', 'reply-to': 'm1' });
+    if (!res.ok) throw new Error(res.error.message);
+    const row = [...store.outbound.values()][0];
+    expect(row.platformId).toBe('C123'); // from m1, not the session routing
+    expect(row.threadId).toBe('T456');
+    expect(row.inReplyTo).toBe('m1');
+  });
+
+  it('refuses empty text and unknown reply targets', async () => {
+    expect((await outboxSend({})).ok).toBe(false);
+    expect((await outboxSend({ text: 'x', 'reply-to': 'nope' })).ok).toBe(false);
+    expect(store.outbound.size).toBe(0);
+  });
+
+  it('refuses when the session has no routing to answer', async () => {
+    store.routing = parseSessionRoutingRecord({ channelType: null, platformId: null, threadId: null });
+    const res = await outboxSend({ text: 'into the void' });
+    expect(res.ok).toBe(false);
+    expect(store.outbound.size).toBe(0);
+  });
+});
+
+describe('the seam is the only transport', () => {
+  it('scopes every verb in one mailbox run() and never reaches past operations', async () => {
+    seedInbound('m1', { seq: 2 });
+    await inboxRead({});
+    await outboxSend({ text: 'reply' });
+    // Two logical operations, two scopes — the unit an implementation is
+    // allowed to serialize and flush around.
+    expect(store.runs).toBe(2);
+  });
+});
+
+describe('runMailboxVerb dispatch', () => {
+  it('routes inbox-read, recovers a dash-joined positional id, and ignores foreign commands', async () => {
+    seedInbound('msg-17-abc', { text: 'positional target' });
+    expect(await runMailboxVerb('groups-list', {}, paths)).toBeNull();
+
+    const byPositional = await runMailboxVerb('inbox-read-msg-17-abc', {}, paths);
+    if (!byPositional?.ok) throw new Error('expected ok');
+    expect((byPositional.data as { message: { text: string } }).message.text).toBe('positional target');
+  });
+
+  it('refuses to dispatch locally in a chat-mode container — the poll loop owns consumption there', async () => {
+    seedInbound('m1');
+    fs.writeFileSync(paths.containerJson, JSON.stringify({})); // no codeMode
+    expect(await runMailboxVerb('inbox-read', {}, paths)).toBeNull();
+    fs.rmSync(paths.containerJson); // no config at all — same refusal
+    expect(await runMailboxVerb('inbox-read', {}, paths)).toBeNull();
+    expect([...store.acks.keys()]).toEqual([]); // and nothing was consumed
+  });
+});
+
+describe('non-destructive misuse', () => {
+  it('--help never consumes the inbox', async () => {
+    seedInbound('m1');
+    const res = await inboxRead({ help: true });
+    if (!res.ok) throw new Error('expected ok');
+    expect(String(res.data)).toContain('usage:');
+    expect([...store.acks.keys()]).toEqual([]);
+  });
+
+  it('unknown flags are rejected before the mailbox is opened at all', async () => {
+    seedInbound('m1');
+    const res = await inboxRead({ 'delete-all': true });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('unreachable');
+    expect(res.error.message).toContain('--delete-all');
+    expect([...store.acks.keys()]).toEqual([]);
+    expect(store.runs).toBe(0);
+
+    const send = await outboxSend({ text: 'x', dest: 'nope' });
+    expect(send.ok).toBe(false);
+    expect(store.outbound.size).toBe(0);
+    expect(store.runs).toBe(0);
+  });
+});
+
+describe('registration', () => {
+  it('resolves the mailbox at call time, so composition — not this file — picks the store', () => {
+    expect(getAgentMailbox()).toBe(store);
+  });
+});

--- a/container/agent-runner/src/cli/mailbox-verbs.ts
+++ b/container/agent-runner/src/cli/mailbox-verbs.ts
@@ -1,0 +1,359 @@
+/**
+ * Container-local mailbox verbs — `ncl inbox read` / `ncl outbox send`
+ * .
+ *
+ * The mailbox IS the transport — and since the mailbox seam, the
+ * transport is whatever the seam registered: SQLite session files by
+ * default, any other store elsewhere. So these verbs hold no storage
+ * knowledge at all. They run against `getAgentMailbox()`, which ncl.ts has
+ * already started for exactly this session, which is why local dispatch is
+ * still the right shape: one round trip, and a host trip would add latency
+ * and no authority.
+ *
+ * WHY NO HOST-SIDE HANDLER (the two-writer question). The CLI and the code
+ * runner are separate processes, and an object store has no file lock to
+ * arbitrate between them. Per-process instances are the seam's own contract
+ * — `ncl` opens the registered mailbox, does one logical
+ * operation and stops. But what the seam arbitrates and what it does not are
+ * different answers for the two verbs here, so both are stated exactly:
+ *
+ * - `outbox send` IS covered. Sequence allocation lives inside
+ *   `writeMessageOut()`, which is the whole point of the operation returning
+ *   the sequence; the SQLite driver allocates the odd container lane under
+ *   BEGIN IMMEDIATE across both files. This file used to run that
+ *   `SELECT MAX(seq)` + `INSERT` itself, correct only because a file
+ *   happened to lock, and three processes now write outbound (this verb,
+ *   ncl.ts's own cli_request, and the mailbox-channel server's `reply`).
+ *   Giving the RMW back to the driver is the real fix here.
+ *
+ * - `inbox read` is NOT covered, and an earlier version of this comment
+ *   wrongly said it was ("two writers can only ever contend on the same
+ *   message and the contended value is the same terminal ack"). Both halves
+ *   are false. The delivery loop's other write for the SAME id is
+ *   `markMessages(ids, 'processing')` — not terminal, not the same value —
+ *   and `getPendingMessages()` + `markMessages()` are two seam calls with no
+ *   transaction between them, exactly as the SELECT and the ack INSERTs were
+ *   two statements before. The hazard is pre-existing and unchanged; what
+ *   changed is only where the SQL lives.
+ *
+ * The one bad interleaving, in full: the loop reads a batch, this verb reads
+ * the same batch and acks it 'completed', then the loop's `markProcessing`
+ * overwrites that ack — the agent has already seen the mail here and the
+ * loop injects it a second time, and if that injection never earns its hook
+ * evidence the ids sit at 'processing' until the host's ~60s claim-stuck SLA
+ * recycles the container. The reverse order is safe by construction:
+ * `getPendingMessages` skips anything already carrying an ack, so a read
+ * that starts after the claim sees nothing (pinned in the tests). Nothing is
+ * ever LOST — the failure is a duplicate, at worst a recycle.
+ *
+ * The window is shut in the normal path, but by a gate rather than by
+ * arbitration: the loop claims only while the agent-state file reads idle,
+ * and this verb runs from a tool call, which is a busy turn. It is open in
+ * exactly the loop's two declared degraded paths, where a live session is
+ * treated as idle — no hook state after READY_FALLBACK_MS, and a busy stamp
+ * stale past BUSY_STALE_MS.
+ *
+ * Closed at the store: a processing claim is INSERT OR IGNORE (mailbox/
+ * sqlite/operations.ts `mark`), so a claim that races an ack this verb
+ * already wrote finds the slot taken and leaves the terminal ack alone. A
+ * message the agent consumed here is never re-injected by the loop. The
+ * interleaving below is kept as the record of what that rule closes.
+ *
+ * The one bad interleaving, in full: the loop reads a batch, this verb reads
+ * the same batch and acks it 'completed', then the loop's `markProcessing`
+ * overwrites that ack — the agent has already seen the mail here and the
+ * loop injects it a second time, and if that injection never earns its hook
+ * evidence the ids sit at 'processing' until the host's ~60s claim-stuck SLA
+ * recycles the container. The reverse order is safe by construction:
+ * `getPendingMessages` skips anything already carrying an ack, so a read
+ * that starts after the claim sees nothing (pinned in the tests). Nothing is
+ * ever LOST — the failure is a duplicate, at worst a recycle.
+ *
+ * The window is shut in the normal path, but by a gate rather than by
+ * arbitration: the loop claims only while the agent-state file reads idle,
+ * and this verb runs from a tool call, which is a busy turn. It is open in
+ * exactly the loop's two declared degraded paths, where a live session is
+ * treated as idle — no hook state after READY_FALLBACK_MS, and a busy stamp
+ * stale past BUSY_STALE_MS.
+ *
+ * TODO: closing it needs a compare-and-set the seam has
+ * no word for — "ack this id only if it carries no ack" — the same missing
+ * verb family the claim release used to be in, before it graduated onto
+ * MailboxOperations as releaseProcessingClaims(ids). This one has not, and is
+ * a coordination item for the same reason that one was. Not invented here, and deliberately not papered
+ * over with a container-private lockfile: that would put a convenience lock
+ * on the delivery path, which is the one thing the delivery loop is built
+ * never to do.
+ *
+ * Contracts honored, unchanged:
+ * - The container never writes the inbound side. "Consumed" is a terminal
+ *   processing ack, and there is no un-ack path — reading consumes unless
+ *   --peek. A consumed message remains fetchable forever via --id.
+ * - Outbound rows take the container's odd-sequence lane and carry JSON
+ *   content; routing defaults to the session's own routing (the origin
+ *   chat), kind='chat' so delivery treats it exactly like any agent reply.
+ */
+import fs from 'fs';
+
+import { getConfig } from '../config.js';
+import { getMessageIn, getPendingMessages, markCompleted, writeMessageOut, type MessageInRow } from '../db/index.js';
+import { getSessionRouting } from '../db/session-routing.js';
+import { getAgentMailbox } from '../mailbox/index.js';
+import { describeAttachments, parseAttachments, type MailAttachment } from '../code-runner/attachments.js';
+
+/**
+ * The one file these verbs still read by path — the host-written group
+ * config, which is how the dispatch below tells a code-mode container from a
+ * chat one. Not mailbox storage: that is the registered implementation's,
+ * and this file never learns where it lives.
+ */
+export interface MailboxPaths {
+  containerJson: string;
+}
+
+export const DEFAULT_PATHS: MailboxPaths = {
+  // The same override config.ts honours: the runner's hook scripts run as
+  // CLI subprocesses under a test seam, and this verb runs from a tool call
+  // in the same session — both must read the container.json the runner did.
+  containerJson: process.env.NANOCLAW_CONTAINER_JSON || '/workspace/agent/container.json',
+};
+
+const INBOX_USAGE =
+  'usage: ncl inbox read [--peek] [--id <message-id>]  (default CONSUMES pending mail; --peek looks; --id fetches one, any state)';
+const OUTBOX_USAGE = 'usage: ncl outbox send --text "..." [--reply-to <inbound-id>]';
+
+/**
+ * The mailbox verbs exist for CODE-MODE containers, whose delivery loop
+ * shares the ack contract. In a chat container the poll loop owns
+ * consumption — a local `inbox read` there would ack rows the poll loop
+ * then silently never delivers. Read the host-written config directly: this
+ * gate must not depend on the mailbox being reachable.
+ */
+function inCodeMode(paths: MailboxPaths): boolean {
+  try {
+    const config = JSON.parse(fs.readFileSync(paths.containerJson, 'utf8')) as { codeMode?: boolean };
+    return config.codeMode === true;
+  } catch {
+    return false;
+  }
+}
+
+/** Reject stray flags BEFORE touching the mailbox — a typo must never consume the inbox. */
+function unknownFlags(args: Record<string, unknown>, allowed: string[]): string[] {
+  return Object.keys(args).filter((k) => !allowed.includes(k));
+}
+
+type Frame =
+  | { id: string; ok: true; data: unknown; human?: string }
+  | { id: string; ok: false; error: { code: string; message: string } };
+
+export interface InboxMessage {
+  id: string;
+  seq: number | null;
+  kind: string;
+  timestamp: string;
+  sender: string;
+  text: string;
+  /** Files the host staged with the message (`path` is where to read each one). */
+  attachments: MailAttachment[];
+  thread_id: string | null;
+  channel_type: string | null;
+  trigger: number;
+}
+
+function toMessage(row: MessageInRow): InboxMessage {
+  let content: { text?: string; sender?: string; author?: { fullName?: string; userName?: string } };
+  try {
+    const parsed = JSON.parse(row.content);
+    content = typeof parsed === 'object' && parsed !== null ? parsed : { text: row.content };
+  } catch {
+    content = { text: row.content };
+  }
+  return {
+    id: row.id,
+    seq: row.seq,
+    kind: row.kind,
+    timestamp: row.timestamp,
+    sender: content.sender || content.author?.fullName || content.author?.userName || 'unknown',
+    text: content.text ?? row.content,
+    attachments: parseAttachments(content),
+    thread_id: row.thread_id,
+    channel_type: row.channel_type,
+    trigger: row.trigger,
+  };
+}
+
+function ok(data: unknown, human?: string): Frame {
+  return { id: `local-${Date.now()}`, ok: true, data, human };
+}
+
+function err(message: string): Frame {
+  return { id: `local-${Date.now()}`, ok: false, error: { code: 'handler-error', message } };
+}
+
+/**
+ * The batch cap `getPendingMessages` applies. The number stays
+ * private to db/messages-in.ts, so it is read the same way here — and inside
+ * `ncl` it is ALWAYS the fallback, because the CLI process never calls
+ * loadConfig(). Which is exactly why it has to be visible to the agent: the
+ * read is capped at ten, that ten is not the group's setting, and an
+ * eleventh message is silently behind it.
+ */
+const DEFAULT_INBOX_BATCH = 10;
+
+function inboxBatchCap(): number {
+  try {
+    return getConfig().maxMessagesPerPrompt;
+  } catch {
+    return DEFAULT_INBOX_BATCH;
+  }
+}
+
+function renderMessages(messages: InboxMessage[], consumed: boolean, capped = false): string {
+  const capNote = capped ? `\n(batch capped at ${inboxBatchCap()} — read again for the rest)` : '';
+  if (messages.length === 0) return `inbox empty${capNote}`;
+  const blocks = messages.map((m) =>
+    [
+      `— ${m.sender} · ${m.timestamp} · id ${m.id}${m.trigger === 0 ? ' · context-only' : ''}`,
+      ...(m.text ? [m.text] : []),
+      ...describeAttachments(m.attachments),
+    ].join('\n'),
+  );
+  const footer = consumed ? '' : '\n(peek — messages remain unread)';
+  return blocks.join('\n\n') + footer + capNote;
+}
+
+/**
+ * `ncl inbox read [--peek] [--id <id>]` — pending, unacked, non-system mail.
+ * Default CONSUMES (acks 'completed'); --peek looks without consuming;
+ * --id fetches one message by id regardless of ack state (how the agent
+ * retrieves the full text behind an injected preview).
+ *
+ * The batch is the delivery loop's own: `getPendingMessages` already applies
+ * the whole due/unclaimed contract, so an explicit read and an injection see
+ * the same mail and never the mail the loop is mid-delivery on. It is
+ * fetched as a WAKE poll (isFirstPoll) on purpose: an on_wake row the loop's
+ * first poll has already gone past is otherwise unreachable, and an explicit
+ * read is the one moment the agent has asked to see everything waiting.
+ * kind='system' rows stay invisible either way: they are transport
+ * envelopes (cli_request/cli_response, question answers), never mail, and
+ * acking one here would eat the reply `ncl` itself is polling for.
+ *
+ * Borrowing the loop's fetch borrows its CAP, which the old hand-written
+ * query did not have, so a full batch SAYS SO (`truncated` in the frame, a
+ * line in the rendered text). Reading twelve messages and being shown ten
+ * with no sign of the other two is a worse answer than either an uncapped
+ * read or a capped one that admits it. The signal is the pre-filter batch
+ * length, not the rendered count: system envelopes are dropped AFTER the
+ * cap, so ten envelopes can hide real mail behind an "inbox empty" — which
+ * then carries the note too.
+ */
+export async function inboxRead(args: Record<string, unknown>): Promise<Frame> {
+  if (args.help === true) return ok(INBOX_USAGE, INBOX_USAGE);
+  const stray = unknownFlags(args, ['peek', 'id']);
+  if (stray.length > 0)
+    return err(`unknown flag${stray.length > 1 ? 's' : ''} --${stray.join(', --')}\n${INBOX_USAGE}`);
+
+  return getAgentMailbox().run(() => {
+    if (typeof args.id === 'string' && args.id) {
+      const row = getMessageIn(args.id);
+      if (!row) return err(`no message ${args.id}`);
+      const msg = toMessage(row);
+      return ok({ message: msg }, renderMessages([msg], true));
+    }
+
+    const batch = getPendingMessages(true);
+    const truncated = batch.length >= inboxBatchCap();
+    const fresh = batch.filter((row) => row.kind !== 'system');
+    const peek = args.peek === true;
+    if (!peek && fresh.length > 0) markCompleted(fresh.map((row) => row.id));
+    const messages = fresh.map(toMessage);
+    return ok({ messages, consumed: !peek && fresh.length > 0, truncated }, renderMessages(messages, !peek, truncated));
+  });
+}
+
+/**
+ * `ncl outbox send --text "..." [--reply-to <inbound-id>]` — write one
+ * outbound chat row. Routing: --reply-to copies the triggering inbound
+ * message's routing (and sets inReplyTo for the a2a return path); otherwise
+ * the session routing — the session's origin chat, or for a coding session
+ * the channel bound to it (the host writes that route when it binds one), so
+ * a standalone send posts to the session channel.
+ */
+export async function outboxSend(args: Record<string, unknown>): Promise<Frame> {
+  if (args.help === true) return ok(OUTBOX_USAGE, OUTBOX_USAGE);
+  const stray = unknownFlags(args, ['text', 'reply-to']);
+  if (stray.length > 0)
+    return err(`unknown flag${stray.length > 1 ? 's' : ''} --${stray.join(', --')}\n${OUTBOX_USAGE}`);
+
+  const text = typeof args.text === 'string' ? args.text.trim() : '';
+  if (!text) return err(`--text is required (free-text positionals do not survive ncl arg parsing)\n${OUTBOX_USAGE}`);
+
+  return getAgentMailbox().run(async () => {
+    let channelType: string | null;
+    let platformId: string | null;
+    let threadId: string | null;
+    let inReplyTo: string | null = null;
+
+    const replyTo = typeof args['reply-to'] === 'string' ? args['reply-to'] : '';
+    if (replyTo) {
+      const source = getMessageIn(replyTo);
+      if (!source) return err(`no inbound message ${replyTo} to reply to`);
+      channelType = source.channel_type;
+      platformId = source.platform_id;
+      threadId = source.thread_id;
+      inReplyTo = replyTo;
+    } else {
+      const routing = getSessionRouting();
+      if (!routing.platform_id && !routing.channel_type) {
+        return err('no session routing — this session has no chat of its own to post to (use --reply-to <inbound-id>)');
+      }
+      channelType = routing.channel_type;
+      platformId = routing.platform_id;
+      threadId = routing.thread_id;
+    }
+
+    const id = `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    // The container's odd-sequence lane is the seam's business now: every
+    // implementation allocates it atomically (SQLite under BEGIN IMMEDIATE,
+    // an object store under a conditional write), which is exactly the race
+    // this verb used to run itself against a file that happened to lock.
+    const seq = await writeMessageOut({
+      id,
+      kind: 'chat',
+      in_reply_to: inReplyTo,
+      platform_id: platformId,
+      channel_type: channelType,
+      thread_id: threadId,
+      content: JSON.stringify({ text }),
+    });
+    return ok({ id, seq }, `sent (id ${id}, seq ${seq})`);
+  });
+}
+
+/**
+ * Local dispatch for the mailbox verbs. Returns null when the command is
+ * not mailbox-local (caller falls through to the host transport).
+ * `ncl inbox read <id>` arrives dash-joined as 'inbox-read-<id>' — the
+ * positional is recovered by slicing the known prefix (there is no local
+ * registry to do the host dispatcher's trim for us).
+ */
+export async function runMailboxVerb(
+  command: string,
+  args: Record<string, unknown>,
+  paths: MailboxPaths = DEFAULT_PATHS,
+): Promise<Frame | null> {
+  const isMailbox = command === 'inbox-read' || command.startsWith('inbox-read-') || command === 'outbox-send';
+  if (!isMailbox) return null;
+  if (!inCodeMode(paths)) {
+    // In a chat container these verbs must not exist locally — fall through
+    // to the host transport, which answers unknown-command (and a future
+    // host-side handler stays free to claim the names).
+    return null;
+  }
+  if (command === 'inbox-read') return inboxRead(args);
+  if (command.startsWith('inbox-read-')) {
+    return inboxRead({ ...args, id: args.id ?? command.slice('inbox-read-'.length) });
+  }
+  return outboxSend(args);
+}

--- a/container/agent-runner/src/cli/ncl.ts
+++ b/container/agent-runner/src/cli/ncl.ts
@@ -14,6 +14,8 @@ import type { AgentMailbox } from '../mailbox/types.js';
 
 import { readStdinJsonArgs, StdinJsonInputError } from './stdin-json.js';
 
+import { runMailboxVerb } from './mailbox-verbs.js';
+
 // ---------------------------------------------------------------------------
 // Frame types (mirrors src/cli/frame.ts on the host)
 // ---------------------------------------------------------------------------
@@ -59,7 +61,11 @@ async function writeRequest(mailbox: AgentMailbox, req: RequestFrame): Promise<v
 /**
  * Poll the mailbox for a cli_response matching our requestId.
  */
-async function pollResponse(mailbox: AgentMailbox, requestId: string, timeoutMs: number): Promise<ResponseFrame | null> {
+async function pollResponse(
+  mailbox: AgentMailbox,
+  requestId: string,
+  timeoutMs: number,
+): Promise<ResponseFrame | null> {
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
@@ -211,9 +217,7 @@ function formatHuman(resp: ResponseFrame): string {
   const header = keys.map((k, i) => k.padEnd(widths[i])).join('  ');
   const sep = widths.map((w) => '-'.repeat(w)).join('  ');
   const rows = data.map((r) =>
-    keys
-      .map((k, i) => String((r as Record<string, unknown>)[k] ?? '').padEnd(widths[i]))
-      .join('  '),
+    keys.map((k, i) => String((r as Record<string, unknown>)[k] ?? '').padEnd(widths[i])).join('  '),
   );
 
   return [header, sep, ...rows, ''].join('\n');
@@ -253,9 +257,17 @@ async function main(): Promise<void> {
   const mailbox = getAgentMailbox();
   await mailbox.start(context);
   try {
-    const requestId = generateId();
-    await writeRequest(mailbox, { id: requestId, command, args: requestArgs });
-    const resp = await pollResponse(mailbox, requestId, 30_000);
+    // mailbox verbs dispatch locally — the mailbox this
+    // process already started IS the transport, so a host round-trip would
+    // add latency and no authority. Self-gating: outside a code-mode
+    // container runMailboxVerb returns null and the host round trip below is
+    // the path.
+    let resp = await runMailboxVerb(command, requestArgs);
+    if (!resp) {
+      const requestId = generateId();
+      await writeRequest(mailbox, { id: requestId, command, args: requestArgs });
+      resp = await pollResponse(mailbox, requestId, 30_000);
+    }
 
     if (!resp) {
       process.stderr.write('ncl: command timed out after 30s\n');

--- a/container/agent-runner/src/code-runner/agent-state.test.ts
+++ b/container/agent-runner/src/code-runner/agent-state.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Attach-presence stamp : the file the code runner writes so hook
+ * subprocesses can tell attached (a prompt is answerable in the PTY) from
+ * detached (it needs the approvals path). Absence and damage both read as
+ * detached — the escalating end — and writes are atomic.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+
+import {
+  readAgentState,
+  writeAgentState,
+  ATTACH_EVIDENCE_MS,
+  ATTACH_STAMP_FRESH_MS,
+  hasLiveAttachEvidence,
+  readAttachState,
+  readAttachActivityAt,
+  readMailNotice,
+  writeAttachState,
+  writeMailNotice,
+} from './agent-state.js';
+
+let dir: string;
+let statePath: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-attach-state-'));
+  statePath = path.join(dir, 'attach-state.json');
+});
+
+describe('attach state', () => {
+  it('round-trips the client count with a timestamp', () => {
+    writeAttachState(2, statePath);
+    const state = readAttachState(statePath)!;
+    expect(state.clients).toBe(2);
+    expect(Number.isFinite(Date.parse(state.at))).toBe(true);
+
+    writeAttachState(0, statePath);
+    expect(readAttachState(statePath)!.clients).toBe(0);
+  });
+
+  it('a missing or torn file reads as absent — the detached (escalating) end', () => {
+    expect(readAttachState(statePath)).toBeNull();
+    fs.writeFileSync(statePath, '{"clien'); // torn mid-write
+    expect(readAttachState(statePath)).toBeNull();
+    fs.writeFileSync(statePath, JSON.stringify({ clients: 'two', at: new Date().toISOString() }));
+    expect(readAttachState(statePath)).toBeNull();
+  });
+
+  it('writes atomically: no tmp residue, the final rename is the only visible state', () => {
+    writeAttachState(1, statePath);
+    expect(fs.readdirSync(dir)).toEqual(['attach-state.json']);
+  });
+
+  it('carries the human evidence the boundary hook routes on', () => {
+    writeAttachState(1, statePath, { lastInputAt: 111, lastConnectAt: 222 });
+    const state = readAttachState(statePath)!;
+    expect(state.lastInputAt).toBe(111);
+    expect(state.lastConnectAt).toBe(222);
+  });
+});
+
+describe('attach activity', () => {
+  it('reads the stamp mtime; a never-stamped file reads 0 — no evidence, never an error', () => {
+    const stamp = path.join(dir, 'attach-activity');
+    expect(readAttachActivityAt(stamp)).toBe(0);
+    fs.writeFileSync(stamp, new Date().toISOString());
+    const at = readAttachActivityAt(stamp);
+    expect(at).toBeGreaterThan(0);
+    expect(Math.abs(Date.now() - at)).toBeLessThan(5_000);
+  });
+});
+
+describe('hasLiveAttachEvidence', () => {
+  const now = Date.now();
+  const fresh = () => ({ clients: 1, at: new Date(now).toISOString(), lastInputAt: now - 1000, lastConnectAt: 0 });
+
+  it('clients on the socket + a fresh stamp + recent human evidence = attached', () => {
+    expect(hasLiveAttachEvidence(fresh(), now)).toBe(true);
+    // A fresh connect alone is evidence too — a human just walked in.
+    expect(hasLiveAttachEvidence({ ...fresh(), lastInputAt: 0, lastConnectAt: now - 1000 }, now)).toBe(true);
+  });
+
+  it('absence, zero clients, and damage all read detached — the escalating end', () => {
+    expect(hasLiveAttachEvidence(null, now)).toBe(false);
+    expect(hasLiveAttachEvidence({ ...fresh(), clients: 0 }, now)).toBe(false);
+    expect(hasLiveAttachEvidence({ ...fresh(), at: 'not-a-time' }, now)).toBe(false);
+  });
+
+  it('a stale stamp is a dead life, not a report', () => {
+    const staleAt = new Date(now - ATTACH_STAMP_FRESH_MS - 1000).toISOString();
+    expect(hasLiveAttachEvidence({ ...fresh(), at: staleAt }, now)).toBe(false);
+  });
+
+  it("an orphan's socket — clients up, evidence old — is detached (the orphaned socket)", () => {
+    const orphan = {
+      ...fresh(),
+      lastInputAt: now - ATTACH_EVIDENCE_MS - 1000,
+      lastConnectAt: now - ATTACH_EVIDENCE_MS - 1000,
+    };
+    expect(hasLiveAttachEvidence(orphan, now)).toBe(false);
+    // No evidence fields at all (an old-shape stamp) is the same verdict.
+    expect(hasLiveAttachEvidence({ clients: 1, at: new Date(now).toISOString() }, now)).toBe(false);
+  });
+});
+
+describe('mail notice', () => {
+  it('round-trips the waiting sequences and stamps when', () => {
+    const noticePath = path.join(dir, 'mail-notice.json');
+    const before = Date.now();
+    writeMailNotice({ seqs: [2, 6] }, noticePath);
+    const notice = readMailNotice(noticePath)!;
+    expect(notice.seqs).toEqual([2, 6]);
+    expect(Date.parse(notice.at)).toBeGreaterThanOrEqual(before);
+  });
+
+  it('absence and damage both read as nothing waiting — the silent end, never a throw', () => {
+    const noticePath = path.join(dir, 'mail-notice.json');
+    expect(readMailNotice(noticePath)).toBeNull();
+    fs.writeFileSync(noticePath, '{"seq');
+    expect(readMailNotice(noticePath)).toBeNull();
+    // Right shape, wrong contents: a hook must not announce mail on garbage.
+    fs.writeFileSync(noticePath, JSON.stringify({ seqs: ['nope'], at: new Date().toISOString() }));
+    expect(readMailNotice(noticePath)).toBeNull();
+  });
+
+  it('creates its dir 0700 — container-private, like every other stamp here', () => {
+    const noticePath = path.join(dir, 'nested', 'mail-notice.json');
+    writeMailNotice({ seqs: [] }, noticePath);
+    expect(readMailNotice(noticePath)?.seqs).toEqual([]);
+    expect(fs.statSync(path.dirname(noticePath)).mode & 0o777).toBe(0o700);
+  });
+});
+
+describe('writeAgentState busyUntil', () => {
+  it('keeps the later hold when two writers race — never shortened, never dropped by a hold-less write', () => {
+    const file = path.join(dir, 'state.json');
+    writeAgentState({ state: 'busy', busyUntil: '2026-09-11T10:30:00.000Z' }, file);
+    writeAgentState({ state: 'busy', busyUntil: '2026-09-11T10:10:00.000Z' }, file);
+    expect(readAgentState(file)?.busyUntil).toBe('2026-09-11T10:30:00.000Z');
+    writeAgentState({ state: 'busy', busyUntil: '2026-09-11T10:45:00.000Z' }, file);
+    expect(readAgentState(file)?.busyUntil).toBe('2026-09-11T10:45:00.000Z');
+    writeAgentState({ state: 'busy' }, file);
+    expect(readAgentState(file)?.busyUntil).toBe('2026-09-11T10:45:00.000Z');
+  });
+});

--- a/container/agent-runner/src/code-runner/agent-state.ts
+++ b/container/agent-runner/src/code-runner/agent-state.ts
@@ -1,0 +1,245 @@
+/**
+ * Idle/busy state shared between the mailbox hook script and the delivery
+ * loop .
+ *
+ * The hook script (a claude subprocess) writes; the code runner's delivery
+ * loop reads. Container-private, like the attach socket — /tmp is not a
+ * shared mount. Writes are tmp+rename so a half-written file can never be
+ * parsed as state.
+ *
+ * Readiness works by ABSENCE, per child life: the code runner deletes this
+ * file on every claude spawn (respawns included), and the delivery loop
+ * refuses to inject while no hook of the CURRENT life has written state —
+ * a booting TUI must not be typed at. The loop fails open after
+ * READY_FALLBACK_MS in case hooks are broken (a malformed settings.json
+ * silently disables every hook) — injection jank beats a dead mailbox.
+ */
+import fs from 'fs';
+import path from 'path';
+
+export const AGENT_STATE_PATH = '/tmp/code-runner/agent-state.json';
+
+/** If no hook has ever fired this long after boot, assume hooks are broken and treat the session as idle. */
+export const READY_FALLBACK_MS = 60_000;
+
+/**
+ * How long a pending permission prompt holds the liveness lease .
+ *
+ * Lives here — not in the hook script — because mailbox-hook.ts EXECUTES on
+ * import (it is claude's hook subprocess entrypoint); anything that wants the
+ * constant without running a hook imports it from the state vocabulary. The
+ * CLI fires Notification/'permission_prompt' ONCE per dialog (about 6s after
+ * it appears with no operator input — verified against the pinned 2.1.197
+ * binary), and no further hook fires while the dialog waits, so the single
+ * busyUntil stamp is the whole hold: bounded, never re-armed, never
+ * immortality. Past it the container expires at the lease as before — the prompt
+ * was going nowhere anyway, and the detached-boundary approvals are the
+ * real answer.
+ */
+export const PERMISSION_PROMPT_HOLD_MS = 30 * 60_000;
+
+export interface AgentState {
+  state: 'idle' | 'busy';
+  /** ISO timestamp of the last transition. */
+  at: string;
+  /**
+   * ISO deadline of a tool call's DECLARED timeout (PreToolUse). Extends the
+   * busy leg of the liveness lease past the staleness cap — no hook fires
+   * during a tool call, so this is the only signal that long silence is
+   * work. Cleared by the next state write (PostToolUse / Stop).
+   */
+  busyUntil?: string;
+  /** Highest inbound seq the busy-notify hook has already surfaced (dedupe). */
+  notifiedSeq?: number;
+}
+
+export function readAgentState(filePath: string = AGENT_STATE_PATH): AgentState | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf8')) as AgentState;
+    if (raw.state !== 'idle' && raw.state !== 'busy') return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+function laterOf(a: string | undefined, b: string | undefined): string | undefined {
+  const ta = a === undefined ? NaN : Date.parse(a);
+  const tb = b === undefined ? NaN : Date.parse(b);
+  if (Number.isNaN(ta)) return Number.isNaN(tb) ? undefined : b;
+  if (Number.isNaN(tb)) return a;
+  return tb > ta ? b : a;
+}
+
+export function writeAgentState(
+  update: Partial<AgentState> & { state: AgentState['state'] },
+  filePath: string = AGENT_STATE_PATH,
+): void {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const previous = readAgentState(filePath);
+  // Concurrent hook subprocesses race this read-modify-write (parallel tool
+  // calls). tmp+rename prevents torn files; the max() keeps the notify
+  // high-water mark monotonic so a lost update can at worst duplicate one
+  // notification, never resurrect old ones.
+  const notifiedSeq = Math.max(previous?.notifiedSeq ?? 0, update.notifiedSeq ?? 0) || undefined;
+  // Same rule for the hold: two hooks racing (a permission prompt beside a
+  // tool call) must never shorten a hold the other just extended.
+  const busyUntil = laterOf(previous?.busyUntil, update.busyUntil);
+  const next: AgentState = {
+    ...update,
+    ...(busyUntil === undefined ? {} : { busyUntil }),
+    notifiedSeq,
+    at: new Date().toISOString(),
+  };
+  const tmp = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(next));
+  fs.renameSync(tmp, filePath);
+}
+
+/**
+ * What mail is waiting, stamped beside the agent state so the PostToolUse
+ * hook can nudge a working agent mid-turn WITHOUT opening the mailbox
+ * itself (the busy-path notify).
+ *
+ * The hook fires on every tool call. Reading the mailbox there was two
+ * cheap local file reads while the transport was always SQLite; since the
+ * mailbox seam it can be an object store, where the same read is a
+ * network listing per tool call. So the delivery loop — which already holds
+ * a live mailbox and already polls every second — is the sole writer here
+ * and hooks only ever read. Same file discipline as the agent state:
+ * container-private under /tmp, tmp+rename, and a torn or absent file
+ * parses as "nothing waiting" (fail closed: no notify, never a crash).
+ *
+ * Carries the pending SEQUENCES, not a count, so the hook keeps its
+ * high-water dedupe: only sequences above `notifiedSeq` are new.
+ */
+export const MAIL_NOTICE_PATH = '/tmp/code-runner/mail-notice.json';
+
+export interface MailNotice {
+  /** Sequences of due, wake-eligible, unclaimed, non-system inbound mail. */
+  seqs: number[];
+  /** ISO timestamp of the stamp — at most one poll interval old. */
+  at: string;
+}
+
+export function readMailNotice(filePath: string = MAIL_NOTICE_PATH): MailNotice | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf8')) as MailNotice;
+    if (!Array.isArray(raw.seqs) || raw.seqs.some((s) => typeof s !== 'number')) return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+export function writeMailNotice(notice: { seqs: number[] }, filePath: string = MAIL_NOTICE_PATH): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const next: MailNotice = { seqs: notice.seqs, at: new Date().toISOString() };
+  const tmp = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(next));
+  fs.renameSync(tmp, filePath);
+}
+
+/**
+ * Attach presence, stamped beside the agent state so HOOK SUBPROCESSES can
+ * tell attached from detached : a permission prompt with a client on the
+ * PTY is answerable with a keystroke; a detached one needs the approvals
+ * path. The code runner stamps changes observed in the tmux client list; hooks only ever read. Same file discipline as the agent
+ * state: container-private under /tmp, tmp+rename so a torn file parses as
+ * absent — and absent reads as detached, the end that escalates rather than
+ * the end that waits forever.
+ */
+export const ATTACH_STATE_PATH = '/tmp/code-runner/attach-state.json';
+
+/**
+ * How stale the stamp itself may be before a hook stops believing it. The
+ * code runner re-stamps every liveness tick (30s, index.ts), so a stamp older
+ * than this is a dead life's leftover, not a report.
+ */
+export const ATTACH_STAMP_FRESH_MS = 5 * 60_000;
+
+/**
+ * How old the newest human evidence (keystroke or connect) may be before an
+ * open attach socket stops counting as "someone is watching the PTY". Same
+ * window and same reasoning as the idle lease (liveness.ts): docker/
+ * exec-shim orphans hold the socket forever after the human's ssh dies,
+ * so a bare clients>0 would route boundary confirms to a PTY nobody watches
+ * (found in review) — only human-shaped evidence counts.
+ */
+export const ATTACH_EVIDENCE_MS = 30 * 60_000;
+
+export interface AttachState {
+  /** Number of live tmux clients at the time of the stamp. */
+  clients: number;
+  /** ISO timestamp of the stamp. */
+  at: string;
+  /** Epoch ms of the last client keystroke (0 if none) — human evidence. */
+  lastInputAt?: number;
+  /** Epoch ms of the last client connect (0 if none) — human evidence. */
+  lastConnectAt?: number;
+}
+
+export function readAttachState(filePath: string = ATTACH_STATE_PATH): AttachState | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf8')) as AttachState;
+    if (typeof raw.clients !== 'number' || !Number.isFinite(raw.clients)) return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+export function writeAttachState(
+  clients: number,
+  filePath: string = ATTACH_STATE_PATH,
+  evidence: { lastInputAt?: number; lastConnectAt?: number } = {},
+): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const next: AttachState = { clients, at: new Date().toISOString(), ...evidence };
+  const tmp = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(next));
+  fs.renameSync(tmp, filePath);
+}
+
+/**
+ * Attach-exec activity (liveness v2). The host's attach policy
+ * (src/cli/attach-resolve.ts — a hand-synced literal, same discipline as the
+ * attach-socket and tmux-socket paths) wraps every exec it routes into the
+ * container so it touches this file on the way in; the runner reads the MTIME in
+ * its liveness tick and counts it as plain activity. That closes the
+ * reaper case: a working day of attach-routed execs with no chat traffic holds the
+ * lease. A raw exec into the container deliberately stamps nothing — an operator
+ * backdoor stays invisible to the lease, stated here rather than accidental.
+ * The file is agent-writable like everything under /tmp/code-runner, but a
+ * forged stamp only extends the agent's own container — no new capability over
+ * the heartbeat file the workspace already exposes.
+ */
+export const ATTACH_ACTIVITY_PATH = '/tmp/code-runner/attach-activity';
+
+/** Epoch ms of the last attach-routed exec (mtime; 0 when never stamped). */
+export function readAttachActivityAt(filePath: string = ATTACH_ACTIVITY_PATH): number {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * "Attached" as the boundary confirm should mean it: clients on the socket,
+ * a stamp the current runner life is still refreshing, and human evidence
+ * inside the window. Anything less falls to the detached path — the approver
+ * card — which is the end that still reaches a human when the PTY's watcher
+ * is a dead ssh session's orphan. Note the stamp is agent-writable (/tmp is
+ * shared with the agent's uid), so both verdicts here stay human-gated: a
+ * forged "attached" lands on the CLI's own ask dialog, a forged "detached"
+ * lands on the approver card.
+ */
+export function hasLiveAttachEvidence(state: AttachState | null, now: number): boolean {
+  if (!state || state.clients <= 0) return false;
+  const stampedAt = Date.parse(state.at);
+  if (!Number.isFinite(stampedAt) || now - stampedAt > ATTACH_STAMP_FRESH_MS) return false;
+  const evidenceAt = Math.max(state.lastInputAt ?? 0, state.lastConnectAt ?? 0);
+  return now - evidenceAt <= ATTACH_EVIDENCE_MS;
+}

--- a/container/agent-runner/src/code-runner/attachments.ts
+++ b/container/agent-runner/src/code-runner/attachments.ts
@@ -1,0 +1,55 @@
+/**
+ * Attachments on inbound mail, as the coding session sees them.
+ *
+ * The host stages a message's files under the session dir
+ * (`inbox/<message id>/<name>`, session-manager.ts) and leaves
+ * `{ name, type, localPath }` in the content; the session dir is mounted at
+ * /workspace, so the file is at `/workspace/<localPath>` from inside. Both
+ * readers of mail — the delivery loop's prompt rendering and `ncl inbox read`
+ * — describe every attachment through here, so a screenshot with a caption
+ * is never delivered as the caption alone.
+ */
+
+/** Where the session dir is mounted inside the container. */
+export const SESSION_MOUNT = '/workspace';
+
+export interface MailAttachment {
+  name: string;
+  type: string;
+  /** The staged path relative to the session dir, when the host saved the file. */
+  localPath: string | null;
+  /** The same file as an absolute path inside the container. */
+  path: string | null;
+  /** A remote location, when the platform gave one and nothing was staged. */
+  url: string | null;
+}
+
+/** The structured attachments of a parsed content object; [] when there are none. */
+export function parseAttachments(content: unknown): MailAttachment[] {
+  if (typeof content !== 'object' || content === null) return [];
+  const raw = (content as { attachments?: unknown }).attachments;
+  if (!Array.isArray(raw)) return [];
+  const out: MailAttachment[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const a = entry as Record<string, unknown>;
+    const name = str(a.name) || str(a.filename) || 'attachment';
+    const type = str(a.type) || 'file';
+    const localPath = str(a.localPath) || null;
+    const url = str(a.url) || null;
+    out.push({ name, type, localPath, path: localPath ? `${SESSION_MOUNT}/${localPath}` : null, url });
+  }
+  return out;
+}
+
+/** One line per attachment: what it is, and where the file is. */
+export function describeAttachments(attachments: MailAttachment[]): string[] {
+  return attachments.map((a) => {
+    if (a.path) return `[${a.type}: ${a.name} — saved to ${a.path}]`;
+    return a.url ? `[${a.type}: ${a.name} (${a.url})]` : `[${a.type}: ${a.name}]`;
+  });
+}
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}

--- a/container/agent-runner/src/code-runner/boundary-hook.test.ts
+++ b/container/agent-runner/src/code-runner/boundary-hook.test.ts
@@ -1,0 +1,264 @@
+/**
+ * The boundary hook the way claude runs it: a subprocess with the PreToolUse
+ * payload on stdin. Postures short-circuit in order (bypass → allow without
+ * a request; attached-with-evidence → ask; detached → file-pair round-trip),
+ * timeout is deny, and the busy hold is stamped before the wait.
+ *
+ * Seams are argv flags, mirroring production's one loophole-free channel:
+ * a review showed env-carried seams ride the agent's own Bash line
+ * into nested CLI runs, so the hook no longer reads ANY of them from env —
+ * and one regression here pins that a forged env posture stays dead.
+ *
+ * NEVER import from boundary-hook.ts here — it executes main() on import and
+ * would exit this test run (the mailbox-hook canary lesson).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+
+import { readAgentState, writeAttachState } from './agent-state.js';
+import { decisionPath } from './boundary.js';
+
+const SCRIPT = path.join(import.meta.dir, 'boundary-hook.ts');
+
+let dir: string;
+let statePath: string;
+let attachPath: string;
+let boundaryDir: string;
+let decisionsDir: string;
+let managedPath: string;
+
+function payload(toolName: string, toolInput: Record<string, unknown>): string {
+  return JSON.stringify({ hook_event_name: 'PreToolUse', tool_name: toolName, tool_input: toolInput });
+}
+
+function spawnHook(
+  body: string,
+  opts: { extraArgs?: string[]; env?: Record<string, string> } = {},
+): ReturnType<typeof Bun.spawn> {
+  return Bun.spawn(
+    [
+      'bun',
+      SCRIPT,
+      `--state=${statePath}`,
+      `--managed-settings=${managedPath}`,
+      `--boundary-dir=${boundaryDir}`,
+      `--decisions-dir=${decisionsDir}`,
+      `--attach-state=${attachPath}`,
+      '--ttl-ms=3000',
+      '--poll-ms=25',
+      // A tmpdir can never be an RO mount; the probe has its own test below.
+      '--skip-decisions-probe',
+      ...(opts.extraArgs ?? []),
+    ],
+    {
+      stdin: Buffer.from(body),
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, ...(opts.env ?? {}) },
+    },
+  );
+}
+
+async function runHook(
+  body: string,
+  opts: { extraArgs?: string[]; env?: Record<string, string> } = {},
+): Promise<{ exitCode: number; stdout: string }> {
+  const proc = spawnHook(body, opts);
+  const stdout = await new Response(proc.stdout as ReadableStream).text();
+  const exitCode = await proc.exited;
+  return { exitCode, stdout };
+}
+
+function stampManaged(mode: 'auto' | 'bypass'): void {
+  // The same byte-shapes the host stamps (src/code-mode/permissions.ts
+  // composeManagedSettings) — the posture is read from defaultMode alone.
+  const settings =
+    mode === 'bypass'
+      ? { permissions: { defaultMode: 'bypassPermissions' } }
+      : { permissions: { defaultMode: 'default', disableBypassPermissionsMode: 'disable' } };
+  fs.writeFileSync(managedPath, JSON.stringify(settings));
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-bhook-'));
+  statePath = path.join(dir, 'state.json');
+  attachPath = path.join(dir, 'attach-state.json');
+  boundaryDir = path.join(dir, 'code-boundary');
+  decisionsDir = path.join(dir, 'code-boundary-decisions');
+  managedPath = path.join(dir, 'managed-settings.json');
+  fs.mkdirSync(decisionsDir);
+  stampManaged('auto');
+});
+
+describe('short-circuits', () => {
+  it('non-boundary calls and containers without the managed policy pass silently', async () => {
+    const ordinary = await runHook(payload('Bash', { command: 'bun test' }));
+    expect(ordinary.exitCode).toBe(0);
+    expect(ordinary.stdout).toBe('');
+    expect(fs.existsSync(boundaryDir)).toBe(false);
+
+    // No policy stamp mounted = chat mode (or a lost stamp, which also means
+    // no managed allow rules exist for a hook allow to matter against).
+    fs.rmSync(managedPath);
+    const chat = await runHook(payload('Bash', { command: 'touch /workspace/group/CLAUDE.md' }));
+    expect(chat.exitCode).toBe(0);
+    expect(chat.stdout).toBe('');
+  });
+
+  it('a bypass group is allowed through without a request — the full escape hatch', async () => {
+    stampManaged('bypass');
+    const res = await runHook(payload('Bash', { command: 'touch /workspace/group/CLAUDE.md' }));
+    expect(res.exitCode).toBe(0);
+    const out = JSON.parse(res.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe('allow');
+    expect(fs.existsSync(boundaryDir)).toBe(false); // no card, no file, no wait
+  });
+
+  it('a forged env posture is dead: NANOCLAW_CODE_PERMISSION_MODE=bypass no longer allows', async () => {
+    // A review's nested-invocation forgery: the agent controls the env
+    // of any CLI run it launches from Bash. The posture must come from the
+    // host's RO stamp only.
+    const proc = spawnHook(payload('Bash', { command: 'touch /workspace/group/CLAUDE.md' }), {
+      env: { NANOCLAW_CODE_PERMISSION_MODE: 'bypass' },
+    });
+    const requestFile = await waitForRequestFile(); // detached round-trip, not an allow
+    const request = JSON.parse(fs.readFileSync(path.join(boundaryDir, requestFile), 'utf8'));
+    fs.writeFileSync(decisionPath(decisionsDir, request.id), JSON.stringify({ decision: 'deny', reason: 'nope' }));
+    const stdout = await new Response(proc.stdout as ReadableStream).text();
+    expect(await proc.exited).toBe(0);
+    expect(JSON.parse(stdout).hookSpecificOutput.permissionDecision).toBe('deny');
+  });
+
+  it('attached with live human evidence forces the CLI dialog (ask, not silence)', async () => {
+    // Silence would leave the attached path to the static prefix rules, which
+    // cannot express the substring-shaped boundaries this hook classifies.
+    writeAttachState(1, attachPath, { lastInputAt: Date.now() });
+    const res = await runHook(payload('Edit', { file_path: '/workspace/group/CLAUDE.md' }));
+    expect(res.exitCode).toBe(0);
+    const out = JSON.parse(res.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe('ask');
+    expect(fs.existsSync(boundaryDir)).toBe(false);
+  });
+
+  it('an orphaned attach socket (stale evidence) is NOT attached — the approver card path runs', async () => {
+    // liveness.ts: exec-shim orphans hold the socket forever after the human's
+    // ssh dies. clients=1 with no recent keystroke/connect must escalate.
+    writeAttachState(1, attachPath, { lastInputAt: Date.now() - 31 * 60_000, lastConnectAt: Date.now() - 31 * 60_000 });
+    const proc = spawnHook(payload('Bash', { command: 'touch /workspace/group/CLAUDE.md' }));
+    const requestFile = await waitForRequestFile();
+    const request = JSON.parse(fs.readFileSync(path.join(boundaryDir, requestFile), 'utf8'));
+    fs.writeFileSync(decisionPath(decisionsDir, request.id), JSON.stringify({ decision: 'allow', reason: 'clicked' }));
+    const stdout = await new Response(proc.stdout as ReadableStream).text();
+    expect(await proc.exited).toBe(0);
+    expect(JSON.parse(stdout).hookSpecificOutput.permissionDecision).toBe('allow');
+  });
+});
+
+describe('the detached round-trip', () => {
+  it('writes the request, stamps the busy hold, and returns the decision file verdict', async () => {
+    writeAttachState(0, attachPath);
+    const proc = spawnHook(payload('Bash', { command: 'touch /workspace/group/CLAUDE.md' }));
+
+    // The request file appears; answer it like the host would — in the
+    // decisions dir, which production RO-mounts so only the host can.
+    const requestFile = await waitForRequestFile();
+    const request = JSON.parse(fs.readFileSync(path.join(boundaryDir, requestFile), 'utf8'));
+    expect(request.toolName).toBe('Bash');
+    expect(request.reason).toContain('custody');
+    expect(Number.isFinite(Date.parse(request.at))).toBe(true);
+
+    // The lease was stamped BEFORE the wait: busy, bounded, in the future.
+    const state = readAgentState(statePath)!;
+    expect(state.state).toBe('busy');
+    expect(Date.parse(state.busyUntil!)).toBeGreaterThan(Date.now());
+
+    fs.writeFileSync(decisionPath(decisionsDir, request.id), JSON.stringify({ decision: 'allow', reason: 'clicked' }));
+    const stdout = await new Response(proc.stdout as ReadableStream).text();
+    expect(await proc.exited).toBe(0);
+    const out = JSON.parse(stdout);
+    expect(out.hookSpecificOutput.hookEventName).toBe('PreToolUse');
+    expect(out.hookSpecificOutput.permissionDecision).toBe('allow');
+    // The hook clears the request it wrote; the decision sits in the RO mount
+    // for the host's age sweep (it cannot be deleted from inside).
+    expect(fs.readdirSync(boundaryDir)).toEqual([]);
+    expect(fs.readdirSync(decisionsDir)).toEqual([`${request.id}.decision.json`]);
+  });
+
+  it('a decision file planted in the REQUEST dir is ignored — only the RO dir decides', async () => {
+    // The self-approval: with both halves under the RW workspace, the
+    // agent forged its own allow. The hook must poll the decisions dir only.
+    const proc = spawnHook(payload('Write', { file_path: '/home/node/.claude/settings.json' }), {
+      extraArgs: ['--ttl-ms=400'],
+    });
+    const requestFile = await waitForRequestFile();
+    const request = JSON.parse(fs.readFileSync(path.join(boundaryDir, requestFile), 'utf8'));
+    fs.writeFileSync(decisionPath(boundaryDir, request.id), JSON.stringify({ decision: 'allow', reason: 'forged' }));
+    const stdout = await new Response(proc.stdout as ReadableStream).text();
+    expect(await proc.exited).toBe(0);
+    expect(JSON.parse(stdout).hookSpecificOutput.permissionDecision).toBe('deny');
+  });
+
+  it('a deny decision denies', async () => {
+    const proc = spawnHook(payload('Write', { file_path: '/home/node/.claude/settings.json' }));
+    const requestFile = await waitForRequestFile();
+    const request = JSON.parse(fs.readFileSync(path.join(boundaryDir, requestFile), 'utf8'));
+    fs.writeFileSync(decisionPath(decisionsDir, request.id), JSON.stringify({ decision: 'deny', reason: 'nope' }));
+    const stdout = await new Response(proc.stdout as ReadableStream).text();
+    expect(await proc.exited).toBe(0);
+    expect(JSON.parse(stdout).hookSpecificOutput.permissionDecision).toBe('deny');
+  });
+
+  it('no decision within the TTL is a deny ', async () => {
+    const res = await runHook(payload('Bash', { command: 'touch /workspace/group/CLAUDE.md' }), {
+      extraArgs: ['--ttl-ms=200'],
+    });
+    expect(res.exitCode).toBe(0);
+    const out = JSON.parse(res.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe('deny');
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain('no approval');
+  });
+
+  it('an unverifiable decisions dir denies without waiting — never polls a forgeable path', async () => {
+    // Without --skip-decisions-probe, a plain writable dir must fail the
+    // EROFS check (boundary.ts decisionsDirTrusted) and deny immediately.
+    const proc = Bun.spawn(
+      [
+        'bun',
+        SCRIPT,
+        `--state=${statePath}`,
+        `--managed-settings=${managedPath}`,
+        `--boundary-dir=${boundaryDir}`,
+        `--decisions-dir=${decisionsDir}`,
+        `--attach-state=${attachPath}`,
+        '--ttl-ms=3000',
+        '--poll-ms=25',
+      ],
+      {
+        stdin: Buffer.from(payload('Bash', { command: 'touch /workspace/group/CLAUDE.md' })),
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    );
+    const stdout = await new Response(proc.stdout as ReadableStream).text();
+    expect(await proc.exited).toBe(0);
+    const out = JSON.parse(stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe('deny');
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain('not the host');
+    expect(fs.existsSync(boundaryDir)).toBe(false); // no request behind a dead channel
+  });
+});
+
+async function waitForRequestFile(): Promise<string> {
+  const deadline = Date.now() + 2_000;
+  for (;;) {
+    const files = fs.existsSync(boundaryDir)
+      ? fs.readdirSync(boundaryDir).filter((f) => f.endsWith('.request.json'))
+      : [];
+    if (files.length > 0) return files[0];
+    if (Date.now() > deadline) throw new Error('request file never appeared');
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}

--- a/container/agent-runner/src/code-runner/boundary-hook.ts
+++ b/container/agent-runner/src/code-runner/boundary-hook.ts
@@ -1,0 +1,179 @@
+/**
+ * Boundary hook — the detached boundary confirm (its OWN settings entry, with the
+ * long timeout; the mailbox entries keep their timeout:10 and are never
+ * touched by this flow).
+ *
+ * PreToolUse only. The flow, in the order the postures short-circuit:
+ *
+ *   no managed policy → silent exit; not a code-mode container (chat mode
+ *                      never mounts the admin tier), or a stamp the spawn
+ *                      lost — either way there are no managed allow rules to
+ *                      override, so the CLI's own defaults hold.
+ *   not a boundary   → silent exit; ordinary sandbox work never blocks here.
+ *   bypass posture   → permissionDecision allow. The bypass
+ *                      posture is the FULL escape hatch:
+ *                      PreToolUse hooks still run under
+ *                      --dangerously-skip-permissions (verified at the pinned
+ *                      2.1.197), so without this the boundary would quietly
+ *                      resurrect for exactly the groups that opted out. The
+ *                      posture is read from the host's RO policy stamp, never
+ *                      from this process's environment — env rides the
+ *                      agent's Bash tool into nested CLI runs, and an
+ *                      env-carried 'bypass' was mintable by the agent itself
+ *                      (found in review).
+ *   attached (live)  → permissionDecision ask: force the CLI's own dialog on
+ *                      the PTY where the human is. Not a silent exit — the
+ *                      static prefix rules cannot express the substring-
+ *                      shaped boundaries this hook classifies, so deferring
+ *                      silently would gate the attached path weaker than the
+ *                      detached one. "Live" means fresh human evidence
+ *                      (agent-state.ts hasLiveAttachEvidence); an exec-shim
+ *                      orphan's socket falls through to the approver card.
+ *   detached         → verify the decision dir is the host's RO mount (the
+ *                      kernel's EROFS is the proof — boundary.ts
+ *                      decisionsDirTrusted), stamp busy with a bounded
+ *                      busyUntil (the container must survive the wait), write the
+ *                      request file, poll for the host's decision file,
+ *                      return permissionDecision allow/deny. Timeout => deny
+ *                      ; an unverifiable decision dir => deny, because
+ *                      polling a forgeable path is self-approval with extra
+ *                      steps.
+ *
+ * Test seams ride argv, not env: the production command in settings.json
+ * (settings-hooks.ts BOUNDARY_HOOK_COMMAND) carries no flags, settings.json
+ * itself is custody-gated, and env is the one channel a nested invocation
+ * inherits from the agent's own Bash line (found in review).
+ *
+ * Contract mirrors mailbox-hook.ts: payload on stdin, result on stdout,
+ * ALWAYS exit 0. And like it, this file EXECUTES on import — anything
+ * shareable lives in boundary.js (the canary lesson, agent-state.ts header).
+ */
+import fs from 'fs';
+
+import {
+  AGENT_STATE_PATH,
+  ATTACH_STATE_PATH,
+  hasLiveAttachEvidence,
+  readAttachState,
+  writeAgentState,
+} from './agent-state.js';
+import {
+  BOUNDARY_APPROVAL_TTL_MS,
+  BOUNDARY_DECISIONS_DIR,
+  BOUNDARY_DIR,
+  BOUNDARY_POLL_MS,
+  classifyBoundary,
+  decisionPath,
+  decisionsDirTrusted,
+  MANAGED_SETTINGS_PATH,
+  readPermissionPosture,
+  requestPath,
+  waitForDecision,
+  writeBoundaryRequest,
+} from './boundary.js';
+
+function argvFlag(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  return process.argv.find((a) => a.startsWith(prefix))?.slice(prefix.length);
+}
+
+const managedSettingsPath = argvFlag('managed-settings') || MANAGED_SETTINGS_PATH;
+const boundaryDir = argvFlag('boundary-dir') || BOUNDARY_DIR;
+const decisionsDir = argvFlag('decisions-dir') || BOUNDARY_DECISIONS_DIR;
+const attachStatePath = argvFlag('attach-state') || ATTACH_STATE_PATH;
+const statePath = argvFlag('state') || AGENT_STATE_PATH;
+const ttlMs = positiveInt(argvFlag('ttl-ms')) ?? BOUNDARY_APPROVAL_TTL_MS;
+const pollMs = positiveInt(argvFlag('poll-ms')) ?? BOUNDARY_POLL_MS;
+// Tests cannot make an RO mount without root; production never passes this.
+const skipDecisionsProbe = process.argv.includes('--skip-decisions-probe');
+
+/** Margin past the poll ceiling so the lease outlives the decision, not vice versa. */
+const BUSY_MARGIN_MS = 60_000;
+
+function positiveInt(raw: string | undefined): number | null {
+  const parsed = parseInt(raw ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+interface HookPayload {
+  hook_event_name?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+}
+
+function emitDecision(decision: 'allow' | 'deny' | 'ask', reason: string): void {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: decision,
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+}
+
+async function main(): Promise<void> {
+  // Settings survive a flip back to chat mode; the mailbox hook self-heals
+  // them on its first firing (it owns the settings file) — this hook only
+  // has to stay out of the chat runner's way, and a chat container has no
+  // managed policy mounted.
+  const posture = readPermissionPosture(managedSettingsPath);
+  if (posture === null) process.exit(0);
+
+  let payload: HookPayload = {};
+  try {
+    payload = JSON.parse(fs.readFileSync(0, 'utf-8')) as HookPayload;
+  } catch {
+    process.exit(0); // malformed input: no opinion, never block
+  }
+  if (payload.hook_event_name !== 'PreToolUse') process.exit(0);
+
+  const reason = classifyBoundary(payload.tool_name ?? '', payload.tool_input ?? {});
+  if (!reason) process.exit(0);
+
+  if (posture === 'bypass') {
+    emitDecision('allow', `${reason} — bypass posture: the gateway configured as approver`);
+    process.exit(0);
+  }
+
+  if (hasLiveAttachEvidence(readAttachState(attachStatePath), Date.now())) {
+    emitDecision('ask', `${reason} — a client is on the PTY; the human there is the approver `);
+    process.exit(0);
+  }
+
+  if (!skipDecisionsProbe && !decisionsDirTrusted(decisionsDir)) {
+    emitDecision('deny', `${reason} — decision dir is not the host's RO mount; denied (fails closed)`);
+    process.exit(0);
+  }
+
+  // The lease must survive the whole wait: the poll below fires no further
+  // hooks, exactly the permission-prompt shape the Notification hold covers
+  // on the attached path.
+  writeAgentState({ state: 'busy', busyUntil: new Date(Date.now() + ttlMs + BUSY_MARGIN_MS).toISOString() }, statePath);
+
+  const id = crypto.randomUUID();
+  try {
+    writeBoundaryRequest(boundaryDir, {
+      id,
+      toolName: payload.tool_name ?? '',
+      toolInput: payload.tool_input ?? {},
+      reason,
+      at: new Date().toISOString(),
+    });
+  } catch {
+    // A request the host will never see must not wait for it.
+    emitDecision('deny', `${reason} — boundary request could not be written; denied (fails closed)`);
+    process.exit(0);
+  }
+
+  const decision = await waitForDecision(decisionPath(decisionsDir, id), { ttlMs, pollMs });
+  emitDecision(decision.decision, decision.reason ?? `${reason} — ${decision.decision} by approver`);
+
+  // The request half is ours to clear; the decision half sits in the RO
+  // mount, so the host's age sweep owns it (modules/approvals/code-boundary.ts).
+  fs.rmSync(requestPath(boundaryDir, id), { force: true });
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));

--- a/container/agent-runner/src/code-runner/boundary.test.ts
+++ b/container/agent-runner/src/code-runner/boundary.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The pure boundary half: classification (over-matching asks — the
+ * fail-safe direction), the fail-closed decision file, and the poll loop's
+ * timeout=deny contract, all without a subprocess.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+
+import {
+  classifyBoundary,
+  decisionPath,
+  decisionsDirTrusted,
+  readBoundaryDecision,
+  readPermissionPosture,
+  requestPath,
+  waitForDecision,
+  writeBoundaryRequest,
+} from './boundary.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-boundary-'));
+});
+
+describe('classifyBoundary', () => {
+  it('lets ordinary sandbox work flow', () => {
+    expect(classifyBoundary('Bash', { command: 'ncl inbox read' })).toBeNull();
+    expect(classifyBoundary('Bash', { command: 'git status' })).toBeNull();
+    expect(classifyBoundary('Bash', { command: 'echo released' })).toBeNull();
+    expect(classifyBoundary('Bash', {})).toBeNull();
+    expect(classifyBoundary('Read', { file_path: '/workspace/group/CLAUDE.md' })).toBeNull(); // reads are free
+    expect(classifyBoundary('Glob', {})).toBeNull();
+  });
+
+  it('flags Edit and Write on each custody path, normalized', () => {
+    for (const file of [
+      '/workspace/code-mode-managed-settings.json',
+      '/home/node/.claude/settings.json',
+      '/workspace/group/CLAUDE.md',
+      '/workspace/group/../code-mode-managed-settings.json', // dot-dot does not launder the path
+    ]) {
+      expect(classifyBoundary('Edit', { file_path: file })).toContain('custody');
+      expect(classifyBoundary('Write', { file_path: file })).toContain('custody');
+    }
+    expect(classifyBoundary('Edit', { file_path: '/workspace/group/notes.md' })).toBeNull();
+    expect(classifyBoundary('Write', { file_path: '' })).toBeNull();
+  });
+
+  it('flags Bash commands that NAME a custody path — the redirect channel Edit/Write rules miss', () => {
+    // A review's write-through: a plain redirect rewrote the managed
+    // policy because only the Edit/Write TOOLS were gated.
+    for (const command of [
+      `echo '{}' > /workspace/code-mode-managed-settings.json`,
+      'tee /home/node/.claude/settings.json < /tmp/x',
+      `sed -i 's/a/b/' ~/.claude/settings.json`, // suffix marker covers the ~ spelling
+      'cp /tmp/x /workspace/group/CLAUDE.md',
+      'cat /workspace/code-mode-managed-settings.json', // reads over-match too: over-matching asks
+    ]) {
+      expect(classifyBoundary('Bash', { command })).toContain('custody');
+    }
+    expect(classifyBoundary('Bash', { command: 'cat /workspace/group/notes.md' })).toBeNull();
+    expect(classifyBoundary('Bash', { command: 'bun run typecheck' })).toBeNull();
+  });
+});
+
+describe('readPermissionPosture', () => {
+  it('reads bypass only from the composed escape-hatch shape; any other policy is auto', () => {
+    const file = path.join(dir, 'managed-settings.json');
+    fs.writeFileSync(file, JSON.stringify({ permissions: { defaultMode: 'bypassPermissions' } }));
+    expect(readPermissionPosture(file)).toBe('bypass');
+    fs.writeFileSync(file, JSON.stringify({ permissions: { defaultMode: 'default', allow: ['Bash'] } }));
+    expect(readPermissionPosture(file)).toBe('auto');
+    fs.writeFileSync(file, JSON.stringify({ permissions: {} }));
+    expect(readPermissionPosture(file)).toBe('auto');
+  });
+
+  it('an absent or unreadable stamp is null — not a code-mode container', () => {
+    expect(readPermissionPosture(path.join(dir, 'nope.json'))).toBeNull();
+    const file = path.join(dir, 'torn.json');
+    fs.writeFileSync(file, '{"permis');
+    expect(readPermissionPosture(file)).toBeNull();
+  });
+});
+
+describe('decisionsDirTrusted', () => {
+  // The trusted case (EROFS) needs a real RO mount, which a test cannot make
+  // without root — the hook subprocess test covers the deny it implies. Here:
+  // every refusal the agent CAN manufacture must read untrusted.
+  it('a dir this uid can write to is never trusted, and the probe leaves no litter', () => {
+    expect(decisionsDirTrusted(dir)).toBe(false);
+    expect(fs.readdirSync(dir)).toEqual([]);
+  });
+
+  it('a missing dir and a chmod-555 dir are untrusted — EACCES/ENOENT are not EROFS', () => {
+    expect(decisionsDirTrusted(path.join(dir, 'missing'))).toBe(false);
+    const locked = path.join(dir, 'locked');
+    fs.mkdirSync(locked, { mode: 0o555 });
+    try {
+      expect(decisionsDirTrusted(locked)).toBe(false);
+    } finally {
+      fs.chmodSync(locked, 0o700);
+    }
+  });
+});
+
+describe('the decision file, fail-closed', () => {
+  it('only the exact pair of verdicts parses; everything else keeps polling', () => {
+    const file = path.join(dir, 'd.json');
+    expect(readBoundaryDecision(file)).toBeNull(); // absent
+    fs.writeFileSync(file, '{"decis'); // torn
+    expect(readBoundaryDecision(file)).toBeNull();
+    fs.writeFileSync(file, JSON.stringify({ decision: 'ALLOW' })); // wrong charset/case
+    expect(readBoundaryDecision(file)).toBeNull();
+    fs.writeFileSync(file, JSON.stringify({ decision: 'deny', reason: 'no' }));
+    expect(readBoundaryDecision(file)).toEqual({ decision: 'deny', reason: 'no' });
+    fs.writeFileSync(file, JSON.stringify({ decision: 'allow' }));
+    expect(readBoundaryDecision(file)?.decision).toBe('allow');
+  });
+
+  it('request write is atomic: no tmp residue beside the request', () => {
+    writeBoundaryRequest(dir, { id: 'r1', toolName: 'Bash', toolInput: {}, reason: 'x', at: new Date().toISOString() });
+    expect(fs.readdirSync(dir)).toEqual(['r1.request.json']);
+    expect(JSON.parse(fs.readFileSync(requestPath(dir, 'r1'), 'utf8')).id).toBe('r1');
+  });
+});
+
+describe('waitForDecision', () => {
+  it('returns the decision the moment the file lands', async () => {
+    const file = decisionPath(dir, 'w1');
+    let clock = 0;
+    const result = waitForDecision(file, {
+      ttlMs: 10_000,
+      pollMs: 1,
+      now: () => clock,
+      sleep: async () => {
+        clock += 1;
+        if (clock === 3) fs.writeFileSync(file, JSON.stringify({ decision: 'allow' }));
+      },
+    });
+    await expect(result).resolves.toEqual({ decision: 'allow', reason: undefined });
+  });
+
+  it('timeout means deny  — never allow, never hang', async () => {
+    const file = decisionPath(dir, 'w2');
+    let clock = 0;
+    const result = await waitForDecision(file, {
+      ttlMs: 100,
+      pollMs: 1,
+      now: () => clock,
+      sleep: async () => {
+        clock += 50;
+      },
+    });
+    expect(result.decision).toBe('deny');
+    expect(result.reason).toContain('no approval');
+  });
+});

--- a/container/agent-runner/src/code-runner/boundary.ts
+++ b/container/agent-runner/src/code-runner/boundary.ts
@@ -1,0 +1,232 @@
+/**
+ * Boundary vocabulary — the pure half of the detached boundary confirm.
+ *
+ * The boundary hook (boundary-hook.ts, claude's PreToolUse subprocess) and
+ * its tests both import from HERE, never from the hook script: a hook script
+ * executes main() on import, and importing one into a test process exits the
+ * whole run (the mailbox-hook canary lesson, agent-state.ts header).
+ *
+ * Why a request/decision FILE PAIR under /workspace and not the mailbox: the
+ * mailbox is a MESSAGE transport, owned by the agent-mailbox seam and freely
+ * swappable under it (SQLite files, an object store) — a boundary confirm is
+ * not mail, it is a blocking decision with exactly one writer per side, and
+ * it must keep working whatever the deployment registered. The pair
+ * keeps that discipline (request: hook writes, host reads; decision: host
+ * writes, hook reads), is session-scoped, and is host-visible because
+ * /workspace IS the session dir mount — nothing new crosses the wall.
+ *
+ * The two halves live in DIFFERENT dirs because they have different writers:
+ * requests sit in the RW workspace (worst case a forged request raises a
+ * spurious card — over-asking, the fail-safe direction), but the decision dir
+ * is a host-owned nested RO mount, because "one writer per side" stated in a
+ * comment is not enforcement. A review demonstrated the enforcement
+ * gap: with both halves under the RW mount, one backgrounded Bash loop
+ * self-approved every boundary faster than the host's 5s scan could even see
+ * the request. Now the kernel is the referee — see decisionsDirTrusted.
+ */
+import fs from 'fs';
+import path from 'path';
+
+/** In-container home of requests; host-side this is `<sessDir>/code-boundary`. */
+export const BOUNDARY_DIR = '/workspace/code-boundary';
+
+/**
+ * In-container home of decisions — host-side `<sessDir>/code-boundary-decisions`,
+ * nested-RO-mounted over the RW workspace (src/code-mode/permissions.ts
+ * boundaryDecisionMounts — the container.json pattern). The RO bind is its own
+ * mount, so the agent can neither write into it nor hardlink its inodes out
+ * into the RW side (link(2) across mounts is EXDEV): a decision here was
+ * written by the host or it does not exist.
+ */
+export const BOUNDARY_DECISIONS_DIR = '/workspace/code-boundary-decisions';
+
+/**
+ * The CLI's admin policy tier — the file the HOST stamps and RO-mounts
+ * (src/code-mode/permissions.ts MANAGED_SETTINGS_CONTAINER_PATH; the two
+ * constants cannot share code across the host/container wall, so each cites
+ * the other). The hook reads the posture from HERE and never from its own
+ * environment: env travels through the agent's Bash tool into any nested CLI
+ * run, so an env-carried posture was agent-writable exactly where it mattered
+ * (found in review) — this file is not.
+ */
+export const MANAGED_SETTINGS_PATH = '/etc/claude-code/managed-settings.json';
+
+/**
+ * The posture, from the managed policy the host stamped. 'bypass' is the
+ * composed escape-hatch policy byte-shape (defaultMode bypassPermissions);
+ * any other readable policy is 'auto'; an absent or unreadable file is null —
+ * not a code-mode container (chat mode never mounts the admin tier), or a
+ * stamp the spawn lost, in which case the CLI runs with no managed allow
+ * rules and asks MORE, not less.
+ */
+export function readPermissionPosture(file: string): 'bypass' | 'auto' | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(file, 'utf8')) as {
+      permissions?: { defaultMode?: unknown };
+    };
+    return raw.permissions?.defaultMode === 'bypassPermissions' ? 'bypass' : 'auto';
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * How long the hook polls for a decision before denying on its own (timeout
+ * means deny). The host's expiry timer resolves deny at ~590s so the
+ * hook normally reads an explicit decision; this ceiling is the belt. Both
+ * sit under the hook's settings-entry timeout (settings-hooks.ts), which is
+ * the CLI's last-resort kill.
+ */
+export const BOUNDARY_APPROVAL_TTL_MS = 600_000;
+
+/** Decision-file poll cadence. */
+export const BOUNDARY_POLL_MS = 500;
+
+/**
+ * The custody paths, as the agent's tools would name them. MIRRORS the
+ * Edit/Write ask rules in the host's managed policy
+ * (src/code-mode/permissions.ts BOUNDARY_ASK_RULES) — the two lists cannot
+ * share code across the host/container wall, so each cites the other.
+ */
+export const CUSTODY_PATHS: readonly string[] = [
+  '/workspace/code-mode-managed-settings.json',
+  '/home/node/.claude/settings.json',
+  '/workspace/group/CLAUDE.md',
+];
+
+/**
+ * The custody paths as substrings of a SHELL COMMAND — the Bash channel the
+ * static Edit/Write ask rules cannot see (review: with bare 'Bash'
+ * allowed, `echo '…' > /workspace/code-mode-managed-settings.json` rewrote
+ * the managed policy through the shared inode without a single ask). Markers,
+ * not a parser: any command that so much as NAMES a custody path asks —
+ * reads included — because over-matching asks, the fail-safe direction. The
+ * `.claude/settings.json` suffix covers the `~`, `$HOME`, and absolute
+ * spellings in one stroke.
+ *
+ * This is a tripwire, not a wall. A command can reach a custody path without
+ * naming it (globs, variables, a two-line script). The WALLS are the nested
+ * RO mounts over the stamp, the decisions dir, and the group manual — the
+ * kernel refuses those writes however the path is spelled. settings.json has
+ * no wall (the in-container reconcile legitimately writes it,
+ * settings-hooks.ts), so for it this tripwire plus the managed ask rules are
+ * the whole gate; tampering there costs future hook registration but never
+ * outranks the admin tier.
+ */
+export const CUSTODY_COMMAND_MARKERS: readonly string[] = [
+  '/workspace/code-mode-managed-settings.json',
+  'code-mode-managed-settings.json',
+  '.claude/settings.json',
+  '/workspace/group/CLAUDE.md',
+];
+
+/**
+ * Classify a PreToolUse payload against the boundaries. Returns a
+ * human-readable reason when the call crosses one, null when it is ordinary
+ * inside-the-sandbox work the hook must not touch.
+ */
+export function classifyBoundary(toolName: string, toolInput: Record<string, unknown>): string | null {
+  if (toolName === 'Bash') {
+    const command = typeof toolInput.command === 'string' ? toolInput.command : '';
+    const marker = CUSTODY_COMMAND_MARKERS.find((m) => command.includes(m));
+    if (marker) return `custody-adjacent command: ${marker}`;
+    return null;
+  }
+  if (toolName === 'Edit' || toolName === 'Write') {
+    const file = typeof toolInput.file_path === 'string' ? toolInput.file_path : '';
+    if (file && CUSTODY_PATHS.includes(path.normalize(file))) return `custody-adjacent write: ${file}`;
+    return null;
+  }
+  return null;
+}
+
+export interface BoundaryRequest {
+  id: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  reason: string;
+  /** ISO timestamp of the hook's stamp — the host measures its expiry from it. */
+  at: string;
+}
+
+export interface BoundaryDecision {
+  decision: 'allow' | 'deny';
+  reason?: string;
+}
+
+export function requestPath(dir: string, id: string): string {
+  return path.join(dir, `${id}.request.json`);
+}
+
+export function decisionPath(dir: string, id: string): string {
+  return path.join(dir, `${id}.decision.json`);
+}
+
+/**
+ * A decision dir is trusted only when the KERNEL refuses our writes with
+ * EROFS — the one error the agent cannot manufacture from inside the RW
+ * workspace (a chmod-555 dir of its own making fails with EACCES, a missing
+ * dir with ENOENT, and its own dir accepts the write). The hook and the
+ * agent share a uid, so "can this process write here" is exactly "can the
+ * agent forge here"; if the probe lands, the RO mount is absent and the
+ * whole detached confirm must deny rather than poll a forgeable path.
+ */
+export function decisionsDirTrusted(dir: string): boolean {
+  const probe = path.join(dir, `.trust-probe-${process.pid}`);
+  try {
+    fs.writeFileSync(probe, '');
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EROFS';
+  }
+  try {
+    fs.rmSync(probe, { force: true });
+  } catch {
+    // Litter in an untrusted dir changes nothing about the deny below.
+  }
+  return false;
+}
+
+/** tmp+rename like every state file here — the host must never parse a torn request. */
+export function writeBoundaryRequest(dir: string, request: BoundaryRequest): void {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = requestPath(dir, request.id);
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(request));
+  fs.renameSync(tmp, file);
+}
+
+/**
+ * Fail closed on everything: a missing, torn, or creatively-shaped decision
+ * file reads as null (keep polling), and only the exact string 'allow'
+ * allows — any other present decision is a deny.
+ */
+export function readBoundaryDecision(file: string): BoundaryDecision | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(file, 'utf8')) as { decision?: unknown; reason?: unknown };
+    if (raw.decision !== 'allow' && raw.decision !== 'deny') return null;
+    return { decision: raw.decision, reason: typeof raw.reason === 'string' ? raw.reason : undefined };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Poll for the host's decision until the TTL. Timeout => deny . The
+ * clock and sleeper are injectable so tests run in milliseconds.
+ */
+export async function waitForDecision(
+  file: string,
+  opts: { ttlMs?: number; pollMs?: number; now?: () => number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<BoundaryDecision> {
+  const ttlMs = opts.ttlMs ?? BOUNDARY_APPROVAL_TTL_MS;
+  const pollMs = opts.pollMs ?? BOUNDARY_POLL_MS;
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const deadline = now() + ttlMs;
+  for (;;) {
+    const decision = readBoundaryDecision(file);
+    if (decision) return decision;
+    if (now() >= deadline) return { decision: 'deny', reason: `no approval within ${ttlMs}ms` };
+    await sleep(pollMs);
+  }
+}

--- a/container/agent-runner/src/code-runner/channel-mode.test.ts
+++ b/container/agent-runner/src/code-runner/channel-mode.test.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, expect, it } from 'bun:test';
+
+import { channelArgs, ensureChannelMcpConfig, resolveChannelMode } from './channel-mode.js';
+
+function tempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-channel-mode-'));
+}
+
+describe('resolveChannelMode', () => {
+  it('recognizes dev and org; everything else degrades to off — never half-configured', () => {
+    expect(resolveChannelMode('dev')).toBe('dev');
+    expect(resolveChannelMode('org')).toBe('org');
+    expect(resolveChannelMode('on')).toBe('off');
+    expect(resolveChannelMode(undefined)).toBe('off');
+    expect(resolveChannelMode('')).toBe('off');
+  });
+});
+
+describe('channelArgs', () => {
+  it('names the private registration file in both live modes and the development bypass in dev only', () => {
+    expect(channelArgs('dev', '/tmp/x/mcp.json')).toEqual([
+      '--mcp-config',
+      '/tmp/x/mcp.json',
+      '--dangerously-load-development-channels',
+      'server:nanoclaw-mailbox',
+    ]);
+    expect(channelArgs('org', '/tmp/x/mcp.json')).toEqual(['--mcp-config', '/tmp/x/mcp.json']);
+    expect(channelArgs('off')).toEqual([]);
+    expect(channelArgs('org')[1]).toBe('/tmp/code-runner/mcp.json');
+  });
+});
+
+describe('ensureChannelMcpConfig', () => {
+  it('writes exactly our server to the private file and is idempotent', () => {
+    const file = path.join(tempDir(), 'nested', 'mcp.json');
+    expect(ensureChannelMcpConfig(file)).toBe(true);
+    expect(ensureChannelMcpConfig(file)).toBe(false);
+    expect(JSON.parse(fs.readFileSync(file, 'utf8'))).toEqual({
+      mcpServers: { 'nanoclaw-mailbox': { command: 'bun', args: ['/app/src/code-runner/mailbox-channel.ts'] } },
+    });
+  });
+
+  it('never touches a workspace .mcp.json', () => {
+    const workspace = tempDir();
+    fs.writeFileSync(path.join(workspace, '.mcp.json'), '{"mcpServers":{"theirs":{}}}');
+    ensureChannelMcpConfig(path.join(workspace, 'private', 'mcp.json'));
+    expect(fs.readFileSync(path.join(workspace, '.mcp.json'), 'utf8')).toBe('{"mcpServers":{"theirs":{}}}');
+  });
+});

--- a/container/agent-runner/src/code-runner/channel-mode.ts
+++ b/container/agent-runner/src/code-runner/channel-mode.ts
@@ -1,0 +1,74 @@
+/**
+ * Channel-transport wiring : resolve the
+ * deployment knob, extend the CLI argv, and make sure claude can find and
+ * consent to the nanoclaw-mailbox channel server.
+ *
+ * The knob is NANOCLAW_CODE_CHANNELS:
+ *   ''/unset — off: the delivery loop types (or send-keys under tmux).
+ *   'dev'    — research-preview posture: the server loads via
+ *              --dangerously-load-development-channels (allowlist bypass for
+ *              exactly this entry; the org channelsEnabled gate still applies).
+ *   'org'    — organization policy: the org's allowedChannelPlugins policy
+ *              carries the server; no development flag on the argv.
+ *
+ * Fail-safe end: anything unrecognized is 'off' — a typo must degrade to the
+ * typing transport, never to a session whose mail silently goes nowhere
+ * (channels drop unregistered notifications without an error, so "half
+ * configured" is the one posture this module must make unrepresentable).
+ */
+import fs from 'fs';
+import path from 'path';
+
+export type ChannelMode = 'off' | 'dev' | 'org';
+
+export const CHANNEL_SERVER_NAME = 'nanoclaw-mailbox';
+/** One replaceable line, argv[0] + rest — the channel subprocess entrypoint. */
+export const CHANNEL_SERVER_COMMAND = ['bun', '/app/src/code-runner/mailbox-channel.ts'];
+
+/**
+ * Where the server registration is written: container-private, never the
+ * workspace. The workspace is the developer's tree (durable, committable, and
+ * a project `.mcp.json` there would be theirs to own); the registration is
+ * the runner's and rides the CLI's `--mcp-config` flag instead.
+ */
+export const CHANNEL_MCP_CONFIG_PATH = '/tmp/code-runner/mcp.json';
+
+export function resolveChannelMode(raw: unknown): ChannelMode {
+  return raw === 'dev' || raw === 'org' ? raw : 'off';
+}
+
+/**
+ * Extra CLI argv for the mode: the server registration file for both live
+ * modes, plus the dev flag that names exactly our entry in dev mode.
+ */
+export function channelArgs(mode: ChannelMode, configPath: string = CHANNEL_MCP_CONFIG_PATH): string[] {
+  if (mode === 'off') return [];
+  const args = ['--mcp-config', configPath];
+  if (mode === 'dev') args.push('--dangerously-load-development-channels', `server:${CHANNEL_SERVER_NAME}`);
+  return args;
+}
+
+/**
+ * Write the channel server registration the CLI loads through
+ * `--mcp-config`. A private file with exactly one server: nothing to merge,
+ * nothing of the developer's to preserve. tmp+rename so the CLI never reads
+ * a torn file.
+ */
+export function ensureChannelMcpConfig(configPath: string = CHANNEL_MCP_CONFIG_PATH): boolean {
+  const desired = {
+    mcpServers: {
+      [CHANNEL_SERVER_NAME]: { command: CHANNEL_SERVER_COMMAND[0], args: CHANNEL_SERVER_COMMAND.slice(1) },
+    },
+  };
+  const content = `${JSON.stringify(desired, null, 2)}\n`;
+  try {
+    if (fs.readFileSync(configPath, 'utf8') === content) return false;
+  } catch {
+    // absent or unreadable — write it
+  }
+  fs.mkdirSync(path.dirname(configPath), { recursive: true, mode: 0o700 });
+  const tmp = `${configPath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, content);
+  fs.renameSync(tmp, configPath);
+  return true;
+}

--- a/container/agent-runner/src/code-runner/channel-spool.test.ts
+++ b/container/agent-runner/src/code-runner/channel-spool.test.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, expect, it } from 'bun:test';
+
+import { listSpoolEntries, writeSpoolEntry } from './channel-spool.js';
+
+function tempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-spool-'));
+}
+
+describe('channel spool', () => {
+  it('round-trips entries and lists them in write order', () => {
+    const dir = tempDir();
+    const a = writeSpoolEntry({ content: 'first', meta: { ids: 'm1' } }, dir);
+    const b = writeSpoolEntry({ content: 'second', meta: { ids: 'm2' } }, dir);
+    expect(listSpoolEntries(dir)).toEqual([a, b]);
+    expect(JSON.parse(fs.readFileSync(a, 'utf8'))).toEqual({ content: 'first', meta: { ids: 'm1' } });
+  });
+
+  it('never lists tmp files and reads a missing dir as empty', () => {
+    const dir = tempDir();
+    writeSpoolEntry({ content: 'kept', meta: {} }, dir);
+    fs.writeFileSync(path.join(dir, 'zz.json.tmp-123'), 'torn');
+    expect(listSpoolEntries(dir)).toHaveLength(1);
+    expect(listSpoolEntries(path.join(dir, 'absent'))).toEqual([]);
+  });
+});

--- a/container/agent-runner/src/code-runner/channel-spool.ts
+++ b/container/agent-runner/src/code-runner/channel-spool.ts
@@ -1,0 +1,57 @@
+/**
+ * The spool between the mailbox delivery loop and the channel server
+ * .
+ *
+ * The loop OWNS delivery — claims, acks, retries, the whole two-DB contract —
+ * and the channel server is a dumb emitter: the loop drops one JSON file per
+ * delivery here, the server watches, forwards it as a channel notification,
+ * and unlinks. Files are the seam because the server is a separate process
+ * claude spawns (an MCP subprocess), and a crash on either side must never
+ * lose a delivery the contract thinks is in flight: an unemitted spool file
+ * is re-emitted on the server's next scan; a claim that never acks is
+ * released and re-spooled by the loop — duplicates-over-loss, exactly the
+ * paste transport's trade.
+ *
+ * tmp+rename per file (house discipline): the watcher can never read a torn
+ * spool entry. Names are zero-padded sequence numbers so emission order is
+ * write order.
+ */
+import fs from 'fs';
+import path from 'path';
+
+export const CHANNEL_SPOOL_DIR = '/tmp/code-runner/channel-spool';
+
+export interface SpoolEntry {
+  /** The rendered mailbox text — the channel tag's body. */
+  content: string;
+  /** Identifier-keyed attributes for the channel tag (letters/digits/underscores only — other keys are silently dropped by the client). */
+  meta: Record<string, string>;
+}
+
+let seq = 0;
+
+/** Write one delivery to the spool. Returns the file path (tests read it). */
+export function writeSpoolEntry(entry: SpoolEntry, dir: string = CHANNEL_SPOOL_DIR): string {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  seq += 1;
+  const name = `${String(Date.now()).padStart(13, '0')}-${String(seq).padStart(6, '0')}.json`;
+  const file = path.join(dir, name);
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(entry));
+  fs.renameSync(tmp, file);
+  return file;
+}
+
+/** Spool entries in emission order (tmp files excluded). */
+export function listSpoolEntries(dir: string = CHANNEL_SPOOL_DIR): string[] {
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return names
+    .filter((n) => n.endsWith('.json'))
+    .sort()
+    .map((n) => path.join(dir, n));
+}

--- a/container/agent-runner/src/code-runner/claude-args.test.ts
+++ b/container/agent-runner/src/code-runner/claude-args.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The interactive CLI's argv .
+ *
+ * Code mode runs WITHOUT the CLI's local permission prompts. Enforcement is
+ * the gateway's — every request is classified, policy-decided and
+ * credential-injected there — so a second, local y/n adds nothing except a
+ * stall in the one place with no approver: a detached sandbox.
+ */
+import { describe, it, expect } from 'bun:test';
+
+import { claudeArgs, conversationArgs, resolvePermissionMode, DEFAULT_PERMISSION_MODE } from './claude-args.js';
+
+describe('claudeArgs', () => {
+  it("'bypass' skips the CLI prompt — the gateway is the approver", () => {
+    expect(claudeArgs(undefined, 'bypass')).toEqual(['--dangerously-skip-permissions']);
+    expect(claudeArgs('claude-opus-4-6', 'bypass')).toEqual([
+      '--dangerously-skip-permissions',
+      '--model',
+      'claude-opus-4-6',
+    ]);
+  });
+
+  it("'auto' leaves the CLI's own prompting alone", () => {
+    expect(claudeArgs(undefined, 'auto')).toEqual([]);
+    expect(claudeArgs('claude-opus-4-6', 'auto')).toEqual(['--model', 'claude-opus-4-6']);
+  });
+
+  it('defaults to the safe end when the caller says nothing', () => {
+    expect(DEFAULT_PERMISSION_MODE).toBe('auto');
+    expect(claudeArgs()).toEqual([]);
+  });
+
+  it('passes the group model only when set', () => {
+    expect(claudeArgs(null, 'bypass')).toEqual(['--dangerously-skip-permissions']);
+    expect(claudeArgs('', 'bypass')).toEqual(['--dangerously-skip-permissions']);
+  });
+});
+
+describe('conversationArgs', () => {
+  const id = '3f2c9a40-6b1e-5c7d-8e9f-0a1b2c3d4e5f';
+  it('a conversation with a transcript is resumed by id; one without is started under that id', () => {
+    expect(conversationArgs(id, true)).toEqual(['--resume', id]);
+    expect(conversationArgs(id, false)).toEqual(['--session-id', id]);
+  });
+});
+
+describe('resolvePermissionMode', () => {
+  it("'bypass' is the only value that turns prompts off", () => {
+    expect(resolvePermissionMode('bypass')).toBe('bypass');
+  });
+
+  it('anything else reads as auto — a typo must not silently disarm the prompts', () => {
+    for (const raw of ['auto', 'AUTO', 'Bypass', 'dangerous', '', undefined, null, 1, {}]) {
+      expect(resolvePermissionMode(raw)).toBe('auto');
+    }
+  });
+});

--- a/container/agent-runner/src/code-runner/claude-args.ts
+++ b/container/agent-runner/src/code-runner/claude-args.ts
@@ -1,0 +1,28 @@
+/** Claude Code permission posture. Prompt by default; bypass requires an operator choice. */
+export type PermissionMode = 'auto' | 'bypass';
+
+export const DEFAULT_PERMISSION_MODE: PermissionMode = 'auto';
+
+/** Anything unrecognized reads as the safe end rather than throwing at spawn. */
+export function resolvePermissionMode(raw: unknown): PermissionMode {
+  return raw === 'bypass' ? 'bypass' : DEFAULT_PERMISSION_MODE;
+}
+
+export function claudeArgs(model?: string | null, mode: PermissionMode = DEFAULT_PERMISSION_MODE): string[] {
+  const args: string[] = [];
+  if (mode === 'bypass') args.push('--dangerously-skip-permissions');
+  if (model) args.push('--model', model);
+  return args;
+}
+
+/**
+ * The conversation flag for one child life. A reap stops being amnesia: the
+ * CLI's session store rides the group's durable `~/.claude` mount, so a life
+ * whose conversation already has a transcript there resumes it BY ID; the
+ * first life of a conversation starts it under that same id. The caller
+ * (index.ts) resolves the id once per session and asks hasTranscript
+ * (claude-state.ts) before every life, respawns included.
+ */
+export function conversationArgs(conversationId: string, resumable: boolean): string[] {
+  return resumable ? ['--resume', conversationId] : ['--session-id', conversationId];
+}

--- a/container/agent-runner/src/code-runner/claude-state.test.ts
+++ b/container/agent-runner/src/code-runner/claude-state.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Seeding the CLI's first-run state: the two facts an unattended sandbox
+ * needs asserted, everything else preserved, a corrupt file left alone.
+ * Plus the per-session conversation id and the transcript probe over the
+ * CLI's per-project session store.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+
+import {
+  conversationArgsResolver,
+  ensureClaudeState,
+  hasTranscript,
+  mintConversationId,
+  readConversationId,
+  recordConversationId,
+  resolveConversationId,
+} from './claude-state.js';
+
+const WORKSPACE = '/workspace/group';
+let statePath: string;
+
+function read(): Record<string, any> {
+  return JSON.parse(fs.readFileSync(statePath, 'utf8'));
+}
+
+beforeEach(() => {
+  statePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-claude-state-')), '.claude.json');
+});
+
+describe('ensureClaudeState', () => {
+  it('creates the file with onboarding done and the workspace trusted', () => {
+    expect(ensureClaudeState(WORKSPACE, false, statePath)).toBe(true);
+    const state = read();
+    expect(state.hasCompletedOnboarding).toBe(true);
+    expect(state.projects[WORKSPACE].hasTrustDialogAccepted).toBe(true);
+  });
+
+  it('preserves the CLI own keys and other projects', () => {
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({
+        machineID: 'abc123',
+        migrationVersion: 13,
+        projects: { '/somewhere/else': { hasTrustDialogAccepted: true, history: ['x'] } },
+      }),
+    );
+    ensureClaudeState(WORKSPACE, false, statePath);
+    const state = read();
+    expect(state.machineID).toBe('abc123');
+    expect(state.migrationVersion).toBe(13);
+    expect(state.projects['/somewhere/else']).toEqual({ hasTrustDialogAccepted: true, history: ['x'] });
+    expect(state.projects[WORKSPACE].hasTrustDialogAccepted).toBe(true);
+  });
+
+  it('keeps existing per-project fields while asserting trust', () => {
+    fs.writeFileSync(statePath, JSON.stringify({ projects: { [WORKSPACE]: { history: ['prior turn'] } } }));
+    ensureClaudeState(WORKSPACE, false, statePath);
+    expect(read().projects[WORKSPACE]).toEqual({ history: ['prior turn'], hasTrustDialogAccepted: true });
+  });
+
+  it('is idempotent across respawns', () => {
+    ensureClaudeState(WORKSPACE, false, statePath);
+    const first = fs.readFileSync(statePath, 'utf8');
+    ensureClaudeState(WORKSPACE, false, statePath);
+    expect(fs.readFileSync(statePath, 'utf8')).toBe(first);
+  });
+
+  it('records the bypass acceptance only when the deployment chose it', () => {
+    ensureClaudeState(WORKSPACE, false, statePath);
+    expect(read().bypassPermissionsModeAccepted).toBeUndefined();
+    ensureClaudeState(WORKSPACE, true, statePath);
+    expect(read().bypassPermissionsModeAccepted).toBe(true);
+  });
+
+  it('leaves a corrupt file untouched and says so', () => {
+    fs.writeFileSync(statePath, '{ not json');
+    expect(ensureClaudeState(WORKSPACE, false, statePath)).toBe(false);
+    expect(fs.readFileSync(statePath, 'utf8')).toBe('{ not json');
+  });
+});
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('resolveConversationId', () => {
+  let statePath: string;
+
+  beforeEach(() => {
+    statePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-conversation-')), 'code-session.json');
+  });
+
+  it('derives one id per session (uuid v5), records it, and reads it back on the next boot', () => {
+    const first = resolveConversationId('sess-1', statePath);
+    expect(first).toMatch(UUID);
+    expect(JSON.parse(fs.readFileSync(statePath, 'utf8'))).toEqual({ conversationId: first });
+    expect(resolveConversationId('sess-1', statePath)).toBe(first);
+    // Same session id elsewhere → the same conversation: a lost state file finds it again.
+    const elsewhere = path.join(path.dirname(statePath), 'other.json');
+    expect(resolveConversationId('sess-1', elsewhere)).toBe(first);
+    expect(resolveConversationId('sess-2', elsewhere + '2')).not.toBe(first);
+  });
+
+  it('a saved id wins over the derivation (a fresh conversation minted after a failed resume)', () => {
+    fs.writeFileSync(statePath, JSON.stringify({ conversationId: '11111111-2222-4333-8444-555555555555' }));
+    expect(resolveConversationId('sess-1', statePath)).toBe('11111111-2222-4333-8444-555555555555');
+  });
+
+  it('a corrupt or non-uuid saved id is replaced, and no session id means a random one', () => {
+    fs.writeFileSync(statePath, '{ not json');
+    const id = resolveConversationId('sess-1', statePath);
+    expect(id).toMatch(UUID);
+    fs.writeFileSync(statePath, JSON.stringify({ conversationId: 'latest' }));
+    expect(resolveConversationId('sess-1', statePath)).toBe(id);
+    const random = resolveConversationId(null, path.join(path.dirname(statePath), 'anon.json'));
+    expect(random).toMatch(/^[0-9a-f-]{36}$/);
+    expect(random).not.toBe(id);
+  });
+
+  it('mintConversationId replaces the saved id with a new one', () => {
+    const first = resolveConversationId('sess-1', statePath);
+    const minted = mintConversationId(statePath);
+    expect(minted).not.toBe(first);
+    expect(resolveConversationId('sess-1', statePath)).toBe(minted);
+  });
+});
+
+describe('recordConversationId', () => {
+  let statePath: string;
+  const live = '0f0e0d0c-0b0a-4908-8706-050403020100';
+
+  beforeEach(() => {
+    statePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-conversation-')), 'code-session.json');
+  });
+
+  it("puts the CLI's live conversation on record, replacing the minted one", () => {
+    const minted = resolveConversationId('sess-1', statePath);
+    expect(recordConversationId(live, statePath)).toBe(true);
+    expect(readConversationId(statePath)).toBe(live);
+    expect(readConversationId(statePath)).not.toBe(minted);
+    // Unchanged: no rewrite.
+    expect(recordConversationId(live.toUpperCase(), statePath)).toBe(false);
+  });
+
+  it('ignores anything that is not a uuid', () => {
+    resolveConversationId('sess-1', statePath);
+    const before = readConversationId(statePath);
+    expect(recordConversationId('latest', statePath)).toBe(false);
+    expect(recordConversationId(undefined, statePath)).toBe(false);
+    expect(recordConversationId({ id: live }, statePath)).toBe(false);
+    expect(readConversationId(statePath)).toBe(before);
+  });
+});
+
+describe('conversationArgsResolver', () => {
+  let home: string;
+  let statePath: string;
+  const lines: string[] = [];
+
+  function transcript(id: string): void {
+    const projectDir = path.join(home, '.claude', 'projects', '-workspace-group');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, `${id}.jsonl`), '{}\n');
+  }
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-claude-home-'));
+    statePath = path.join(home, 'code-session.json');
+    lines.length = 0;
+  });
+
+  it('starts the minted conversation, resumes it once its transcript exists', () => {
+    const args = conversationArgsResolver({
+      sessionId: 'sess-1',
+      workspaceDir: WORKSPACE,
+      statePath,
+      home,
+      log: (l) => lines.push(l),
+    });
+    const id = readConversationId(statePath)!;
+    expect(args({ life: 1, previousLifeHealthy: null })).toEqual(['--session-id', id]);
+    transcript(id);
+    expect(args({ life: 2, previousLifeHealthy: true })).toEqual(['--resume', id]);
+    expect(lines).toEqual([
+      `[code-runner] life 1: starting conversation ${id}`,
+      `[code-runner] life 2: resuming conversation ${id}`,
+    ]);
+  });
+
+  it('after /clear the hook records the new id, and the next life resumes THAT conversation', () => {
+    const args = conversationArgsResolver({ sessionId: 'sess-1', workspaceDir: WORKSPACE, statePath, home });
+    const minted = readConversationId(statePath)!;
+    args({ life: 1, previousLifeHealthy: null });
+    transcript(minted);
+    // The operator clears: the CLI opens a new conversation and its SessionStart hook reports it.
+    const cleared = '0f0e0d0c-0b0a-4908-8706-050403020100';
+    recordConversationId(cleared, statePath);
+    transcript(cleared);
+    expect(args({ life: 2, previousLifeHealthy: true })).toEqual(['--resume', cleared]);
+    // A recorded id with no transcript yet is started under that id, not resumed.
+    const fresh = '11111111-2222-4333-8444-555555555555';
+    recordConversationId(fresh, statePath);
+    expect(args({ life: 3, previousLifeHealthy: true })).toEqual(['--session-id', fresh]);
+  });
+
+  it('a resumed life that dies early is abandoned for a fresh conversation, once', () => {
+    const args = conversationArgsResolver({ sessionId: 'sess-1', workspaceDir: WORKSPACE, statePath, home });
+    const id = readConversationId(statePath)!;
+    transcript(id);
+    expect(args({ life: 1, previousLifeHealthy: null })).toEqual(['--resume', id]);
+    const second = args({ life: 2, previousLifeHealthy: false });
+    expect(second[0]).toBe('--session-id');
+    expect(second[1]).not.toBe(id);
+    expect(readConversationId(statePath)).toBe(second[1]);
+    // The fresh conversation dying early too is not a reason to mint again.
+    expect(args({ life: 3, previousLifeHealthy: false })).toEqual(['--session-id', second[1]]);
+  });
+});
+
+describe('hasTranscript', () => {
+  let home: string;
+  const id = '3f2c9a40-6b1e-5c7d-8e9f-0a1b2c3d4e5f';
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-claude-home-'));
+  });
+
+  it('a fresh workspace has nothing to resume — no store, no dir, no false start', () => {
+    expect(hasTranscript(WORKSPACE, id, home)).toBe(false);
+    // The project dir existing but EMPTY is still a fresh workspace.
+    fs.mkdirSync(path.join(home, '.claude', 'projects', '-workspace-group'), { recursive: true });
+    expect(hasTranscript(WORKSPACE, id, home)).toBe(false);
+  });
+
+  it("this conversation's transcript in the munged project dir means it is resumable", () => {
+    const projectDir = path.join(home, '.claude', 'projects', '-workspace-group');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, `${id}.jsonl`), '{}\n');
+    expect(hasTranscript(WORKSPACE, id, home)).toBe(true);
+  });
+
+  it("another session's transcript in the same project dir is not this conversation", () => {
+    const projectDir = path.join(home, '.claude', 'projects', '-workspace-group');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, 'a1b2c3d4-0000-4000-8000-000000000000.jsonl'), '{}\n');
+    expect(hasTranscript(WORKSPACE, id, home)).toBe(false);
+  });
+
+  it("another project's transcript is not this workspace's conversation", () => {
+    const other = path.join(home, '.claude', 'projects', '-somewhere-else');
+    fs.mkdirSync(other, { recursive: true });
+    fs.writeFileSync(path.join(other, `${id}.jsonl`), '{}\n');
+    expect(hasTranscript(WORKSPACE, id, home)).toBe(false);
+  });
+});

--- a/container/agent-runner/src/code-runner/claude-state.ts
+++ b/container/agent-runner/src/code-runner/claude-state.ts
@@ -1,0 +1,233 @@
+/**
+ * Seed Claude Code's first-run state for the Host-provided workspace.
+ * The container's home is disposable, while the workspace is durable. Without
+ * this state, a fresh container can stop at a trust prompt before processing
+ * messages. Preserve unrelated settings and the Host's permission policy.
+ */
+import { createHash, randomUUID } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import { conversationArgs } from './claude-args.js';
+import type { LifeContext } from './tmux-session.js';
+
+export function claudeStatePath(): string {
+  return path.join(process.env.HOME || '/home/node', '.claude.json');
+}
+
+/** Where this session's conversation id lives: the session dir is mounted
+ * read-write at /workspace and outlives every container life, like the
+ * turn stamp beside it. */
+export const CONVERSATION_STATE_PATH = '/workspace/code-session.json';
+
+/** Fixed namespace for deriving a conversation id from a session id (uuid v5). */
+const CONVERSATION_NAMESPACE = '6f0d1a7e-2c4b-4e8a-9b3d-5a1c7e9f2b40';
+
+function uuidV5(namespace: string, name: string): string {
+  const bytes = createHash('sha1')
+    .update(Buffer.concat([Buffer.from(namespace.replace(/-/g, ''), 'hex'), Buffer.from(name, 'utf8')]))
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** The conversation id on record for this session, or null when there is none (or the file is unreadable). */
+export function readConversationId(statePath: string = CONVERSATION_STATE_PATH): string | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf8')) as { conversationId?: unknown };
+    return typeof parsed.conversationId === 'string' && UUID_RE.test(parsed.conversationId)
+      ? parsed.conversationId.toLowerCase()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeConversationId(statePath: string, conversationId: string): void {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  const tmp = `${statePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify({ conversationId }, null, 2));
+  fs.renameSync(tmp, statePath);
+}
+
+/**
+ * The CLI conversation this session owns: one id per session, minted once
+ * and kept in the session dir. Several sessions share a group's `~/.claude`
+ * store and the same cwd, so the CLI's own "most recent conversation for
+ * this directory" is not this session's; an explicit id is.
+ *
+ * Derived from the session id (uuid v5, so a lost state file finds the same
+ * conversation again) when the host provided one; random otherwise. A file
+ * already there wins — it may hold a fresh id minted after a resume the CLI
+ * could not load (mintConversationId). Never throws: a state dir that
+ * cannot be written costs the persistence, not the boot.
+ */
+export function resolveConversationId(
+  sessionId: string | null | undefined,
+  statePath: string = CONVERSATION_STATE_PATH,
+): string {
+  const saved = readConversationId(statePath);
+  if (saved) return saved;
+  const id = sessionId ? uuidV5(CONVERSATION_NAMESPACE, sessionId) : randomUUID();
+  try {
+    writeConversationId(statePath, id);
+  } catch (error) {
+    console.error(`[code-runner] could not record the conversation id at ${statePath}:`, error);
+  }
+  return id;
+}
+
+/**
+ * The CLI told us which conversation is live (its SessionStart hook carries
+ * the native session id): put it on record so the next life resumes THAT
+ * one. `/clear` inside the session starts a new conversation under a new
+ * id while the file would still name the old one; recording the hook's id
+ * is what keeps a crash respawn or a post-retirement boot on the
+ * conversation the operator actually sees. Anything that is not a uuid is
+ * ignored; an unchanged id is not rewritten. Never throws.
+ */
+export function recordConversationId(sessionId: unknown, statePath: string = CONVERSATION_STATE_PATH): boolean {
+  if (typeof sessionId !== 'string' || !UUID_RE.test(sessionId)) return false;
+  const id = sessionId.toLowerCase();
+  if (readConversationId(statePath) === id) return false;
+  try {
+    writeConversationId(statePath, id);
+    return true;
+  } catch (error) {
+    console.error(`[code-runner] could not record the conversation id at ${statePath}:`, error);
+    return false;
+  }
+}
+
+/** A new conversation for this session, replacing the saved one: the fresh start after a resume the CLI could not load. */
+export function mintConversationId(statePath: string = CONVERSATION_STATE_PATH): string {
+  const id = randomUUID();
+  try {
+    writeConversationId(statePath, id);
+  } catch (error) {
+    console.error(`[code-runner] could not record the conversation id at ${statePath}:`, error);
+  }
+  return id;
+}
+
+/**
+ * Whether the CLI holds a transcript for `conversationId` in `workspaceDir`.
+ *
+ * The CLI keeps per-project transcripts under
+ * `~/.claude/projects/<munged cwd>/<conversation id>.jsonl`, where the munge
+ * replaces every non-alphanumeric character with '-' — the runner's fixed
+ * cwd `/workspace/group` becomes `-workspace-group`. `~/.claude` is the
+ * group's durable provider-state mount, so the store outlives the
+ * container, which is what makes a post-reap `--resume` land. Absence and
+ * unreadability both answer false: the fresh-start end, never a stall.
+ */
+export function hasTranscript(
+  workspaceDir: string,
+  conversationId: string,
+  home: string = process.env.HOME || '/home/node',
+): boolean {
+  const munged = workspaceDir.replace(/[^A-Za-z0-9]/g, '-');
+  try {
+    return fs.statSync(path.join(home, '.claude', 'projects', munged, `${conversationId}.jsonl`)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+type ProjectState = Record<string, unknown> & { hasTrustDialogAccepted?: boolean };
+type ClaudeState = Record<string, unknown> & {
+  hasCompletedOnboarding?: boolean;
+  bypassPermissionsModeAccepted?: boolean;
+  projects?: Record<string, ProjectState>;
+};
+
+/**
+ * True when the state was written. A corrupt file is left ALONE and reported:
+ * overwriting would eat whatever produced it, and the CLI recreates its own.
+ */
+export function ensureClaudeState(
+  workspaceDir: string,
+  /**
+   * True when the deployment chose the 'bypass' posture. The CLI asks the
+   * operator to accept that mode once; configuring it IS that acceptance,
+   * and the sandbox has no one to ask. Left false, the key is never written
+   * — an 'auto' deployment keeps the dialog it expects.
+   */
+  acceptBypass = false,
+  statePath: string = claudeStatePath(),
+): boolean {
+  let state: ClaudeState = {};
+  if (fs.existsSync(statePath)) {
+    try {
+      state = JSON.parse(fs.readFileSync(statePath, 'utf8')) as ClaudeState;
+    } catch (error) {
+      console.error(`[code-runner] ${statePath} is not valid JSON — leaving it alone:`, error);
+      return false;
+    }
+  }
+
+  state.hasCompletedOnboarding = true;
+  if (acceptBypass) state.bypassPermissionsModeAccepted = true;
+  const projects: Record<string, ProjectState> = { ...(state.projects ?? {}) };
+  projects[workspaceDir] = { ...(projects[workspaceDir] ?? {}), hasTrustDialogAccepted: true };
+  state.projects = projects;
+
+  try {
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    const tmp = `${statePath}.tmp-${process.pid}`;
+    fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+    fs.renameSync(tmp, statePath);
+    return true;
+  } catch (error) {
+    console.error('[code-runner] could not seed the CLI state — expect a first-run prompt:', error);
+    return false;
+  }
+}
+
+/** What the per-life argv resolver needs; every path is overridable for tests. */
+export interface ConversationResolverOptions {
+  /** The host's session id, when the mailbox context carried one. */
+  sessionId: string | null | undefined;
+  workspaceDir: string;
+  statePath?: string;
+  home?: string;
+  log?: (line: string) => void;
+}
+
+/**
+ * The conversation flags for each child life of the session, respawns
+ * included. Before every life the id on record is read fresh — the
+ * SessionStart hook may have replaced it after a `/clear` — and the CLI is
+ * asked to resume it when its transcript exists, or to start it under that
+ * id when none does. A resumed life that died before its healthy-run
+ * window is a transcript the CLI cannot load: the session then starts a
+ * fresh conversation under a new id, once per runner boot, both ids logged.
+ */
+export function conversationArgsResolver(options: ConversationResolverOptions): (life: LifeContext) => string[] {
+  const statePath = options.statePath ?? CONVERSATION_STATE_PATH;
+  const home = options.home ?? process.env.HOME ?? '/home/node';
+  const log = options.log ?? ((line: string) => console.log(line));
+  let conversationId = resolveConversationId(options.sessionId, statePath);
+  let lastLifeResumed = false;
+  let startedFresh = false;
+  return ({ life, previousLifeHealthy }) => {
+    conversationId = readConversationId(statePath) ?? conversationId;
+    if (previousLifeHealthy === false && lastLifeResumed && !startedFresh) {
+      startedFresh = true;
+      const abandoned = conversationId;
+      conversationId = mintConversationId(statePath);
+      console.error(
+        `[code-runner] resumed conversation ${abandoned} died before its healthy-run window — starting a fresh conversation ${conversationId}`,
+      );
+    }
+    const resumable = hasTranscript(options.workspaceDir, conversationId, home);
+    lastLifeResumed = resumable;
+    log(`[code-runner] life ${life}: ${resumable ? 'resuming' : 'starting'} conversation ${conversationId}`);
+    return conversationArgs(conversationId, resumable);
+  };
+}

--- a/container/agent-runner/src/code-runner/code-runner.test.ts
+++ b/container/agent-runner/src/code-runner/code-runner.test.ts
@@ -1,0 +1,101 @@
+/** Runner startup and mailbox delivery through the production tmux session. */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { loadConfig } from '../config.js';
+import { registerAgentMailbox, resetAgentMailboxForTesting } from '../mailbox/index.js';
+import { SqliteAgentMailbox } from '../mailbox/sqlite/index.js';
+import { closeSessionDb, initTestSessionDb } from '../mailbox/sqlite/connection.js';
+import type { AgentMailboxFactory } from '../mailbox/types.js';
+import { MailboxDeliveryLoop } from './mailbox.js';
+import { sleep, spawnTmuxClient, startTmuxStack, waitFor } from './term-audit/harness.js';
+import { CMD_SGR, PROBE_SGR_END } from './term-audit/probe.js';
+
+for (const brokenBinary of [false, true]) {
+  test(`startup refuses ${brokenBinary ? 'a failing' : 'a missing'} tmux executable`, async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-runner-boot-'));
+    const config = path.join(dir, 'container.json');
+    fs.writeFileSync(config, JSON.stringify({ agentGroupId: 'tmux-required', codeMode: true }));
+    if (brokenBinary) fs.writeFileSync(path.join(dir, 'tmux'), '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+    try {
+      const child = Bun.spawn([process.execPath, path.join(import.meta.dir, 'index.ts')], {
+        cwd: dir,
+        env: { ...process.env, PATH: dir, NANOCLAW_CONTAINER_JSON: config },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      const [code, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+      expect(code).toBe(1);
+      expect(stderr).toContain('Code mode requires tmux in the agent image');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}
+
+describe.if(Bun.which('tmux') !== null)('mailbox delivery through tmux', () => {
+  let inbound: ReturnType<typeof initTestSessionDb>['inbound'];
+  let composed: AgentMailboxFactory | undefined;
+
+  beforeEach(() => {
+    loadConfig();
+    inbound = initTestSessionDb().inbound;
+    composed = resetAgentMailboxForTesting();
+    registerAgentMailbox(() => new SqliteAgentMailbox());
+  });
+  afterEach(() => {
+    closeSessionDb();
+    resetAgentMailboxForTesting();
+    if (composed) registerAgentMailbox(composed);
+  });
+
+  function seedInbound(id: string, text: string): void {
+    inbound
+      .prepare(
+        `INSERT INTO messages_in (id, kind, timestamp, status, trigger, on_wake, content)
+       VALUES (?, 'chat', ?, 'pending', 1, 0, ?)`,
+      )
+      .run(id, new Date().toISOString(), JSON.stringify({ text, sender: 'operator' }));
+  }
+
+  test('delivers mail to an attached terminal and continues after the client disconnects', async () => {
+    const stack = await startTmuxStack();
+    const client = spawnTmuxClient(stack.socketPath);
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-mailbox-'));
+    const stateFilePath = path.join(dir, 'state.json');
+    const loop = new MailboxDeliveryLoop({
+      session: stack.session,
+      stateFilePath,
+      lastOperatorInputAt: () => stack.evidence.lastClientInputAt,
+      onFatal: () => {},
+    });
+    try {
+      await waitFor(() => stack.evidence.clientCount === 1, 'the attached operator');
+      const idle = () =>
+        fs.writeFileSync(stateFilePath, JSON.stringify({ state: 'idle', at: new Date().toISOString() }));
+      idle();
+      seedInbound('m1', `mail one ${CMD_SGR}`);
+      await loop.tick();
+      await waitFor(() => stack.rx().includes(Buffer.from('mail one')), 'mail at the session process');
+      await waitFor(() => client.output().includes(PROBE_SGR_END), 'mail on the operator terminal');
+
+      // A newer hook stamp acknowledges the first injection before the next one.
+      await sleep(10);
+      idle();
+      client.kill();
+      await client.exited;
+      await waitFor(() => stack.evidence.clientCount === 0, 'the disconnected operator');
+      seedInbound('m2', 'mail two');
+      await loop.tick();
+      await waitFor(() => stack.rx().includes(Buffer.from('mail two')), 'mail after disconnect');
+      expect(stack.session.running).toBe(true);
+    } finally {
+      loop.stop();
+      client.kill();
+      stack.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 20_000);
+});

--- a/container/agent-runner/src/code-runner/heartbeat-lease.test.ts
+++ b/container/agent-runner/src/code-runner/heartbeat-lease.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { heartbeatPath, touchHeartbeat } from './heartbeat-lease.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) fs.rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+function scratch(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-runner-heartbeat-'));
+  dirs.push(dir);
+  return dir;
+}
+
+describe('the heartbeat lease file', () => {
+  test("the path is the chat runner's default, or NANOCLAW_HEARTBEAT_PATH when set", () => {
+    expect(heartbeatPath({})).toBe('/workspace/.heartbeat');
+    expect(heartbeatPath({ NANOCLAW_HEARTBEAT_PATH: '' })).toBe('/workspace/.heartbeat');
+    expect(heartbeatPath({ NANOCLAW_HEARTBEAT_PATH: '  ' })).toBe('/workspace/.heartbeat');
+    expect(heartbeatPath({ NANOCLAW_HEARTBEAT_PATH: '/run/nanoclaw/heartbeat/.heartbeat' })).toBe(
+      '/run/nanoclaw/heartbeat/.heartbeat',
+    );
+  });
+
+  test('absent: created; present: its mtime refreshed to now', () => {
+    const file = path.join(scratch(), '.heartbeat');
+    expect(touchHeartbeat(file, new Date(1_700_000_000_000))).toBe(true);
+    expect(fs.statSync(file).isFile()).toBe(true);
+    expect(fs.statSync(file).mtimeMs).toBe(1_700_000_000_000);
+    expect(touchHeartbeat(file, new Date(1_700_000_005_000))).toBe(true);
+    expect(fs.statSync(file).mtimeMs).toBe(1_700_000_005_000);
+  });
+
+  test('a directory where the file should be — what a guest makes of an unwritten subPath — is reported, never thrown', () => {
+    const dir = path.join(scratch(), '.heartbeat');
+    fs.mkdirSync(dir);
+    expect(touchHeartbeat(dir)).toBe(false);
+    const target = path.join(scratch(), 'missing-parent', '.heartbeat');
+    expect(() => touchHeartbeat(target)).not.toThrow();
+    expect(touchHeartbeat(target)).toBe(false);
+    // And a directory that cannot be a file for the write arm:
+    fs.chmodSync(dir, 0o555);
+    const inside = path.join(dir, 'nested', '.heartbeat');
+    expect(touchHeartbeat(inside)).toBe(false);
+  });
+});

--- a/container/agent-runner/src/code-runner/heartbeat-lease.ts
+++ b/container/agent-runner/src/code-runner/heartbeat-lease.ts
@@ -1,0 +1,27 @@
+/** The filesystem heartbeat used by the OSS Docker Host's idle lease.
+ * Match the chat runner's configurable path. A missing or unwritable mount
+ * must be reported without crashing the coding session. */
+import fs from 'fs';
+
+const DEFAULT_HEARTBEAT_PATH = '/workspace/.heartbeat';
+
+export function heartbeatPath(env: NodeJS.ProcessEnv = process.env): string {
+  return env.NANOCLAW_HEARTBEAT_PATH?.trim() || DEFAULT_HEARTBEAT_PATH;
+}
+
+export function touchHeartbeat(target: string = heartbeatPath(), now: Date = new Date()): boolean {
+  try {
+    if (!fs.statSync(target).isFile()) return false;
+    fs.utimesSync(target, now, now);
+    return true;
+  } catch {
+    // A missing file can be created; an invalid mount still fails below.
+  }
+  try {
+    fs.writeFileSync(target, '');
+    fs.utimesSync(target, now, now);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/container/agent-runner/src/code-runner/index.ts
+++ b/container/agent-runner/src/code-runner/index.ts
@@ -1,0 +1,258 @@
+/**
+ * Code runner — the second runner type .
+ *
+ * Lives beside the chat runner in the same mounted source tree and the same
+ * image; the host selects it at spawn time for code-mode groups. It never
+ * imports chat composition (formatter, destinations addendum, dispatch
+ * wrapping) — decontamination by omission, not by branching .
+ *
+ * Owns the persistent tmux session, mailbox delivery and the heartbeat that
+ * keeps host-sweep liveness honest. The Host mediates terminal attachment
+ * through the tmux client; disconnecting leaves the session running.
+ */
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+
+import { loadConfig } from '../config.js';
+import { AGENT_STATE_PATH, readAgentState, readAttachActivityAt, writeAttachState } from './agent-state.js';
+import { CHANNEL_SPOOL_DIR } from './channel-spool.js';
+import { channelArgs, ensureChannelMcpConfig, resolveChannelMode } from './channel-mode.js';
+import { claudeArgs, resolvePermissionMode } from './claude-args.js';
+import { conversationArgsResolver, ensureClaudeState } from './claude-state.js';
+import { heartbeatPath, touchHeartbeat } from './heartbeat-lease.js';
+import { decideLiveness, resolveAttachIdleTtlMs, resolveIdleTtlMs, retirementNotice } from './liveness.js';
+import { BUSY_STALE_MS, MailboxDeliveryLoop } from './mailbox.js';
+import { ensureMailboxHooks, ensureTerminalDefaults } from './settings-hooks.js';
+import { SESSION_TERM_ENV } from './term-env.js';
+import { TmuxEvidence } from './tmux-evidence.js';
+import { TmuxSession, TMUX_SOCKET_PATH, type LifeContext } from './tmux-session.js';
+// Capability barrel — registers the singular mailbox slot (the chat runner
+// loads the same barrel at src/index.ts; a runner without it dies at boot on
+// 'No agent mailbox registered' in clearStaleProcessingAcks).
+import '../modules/index.js';
+import { getAgentMailbox, readMailboxContext } from '../mailbox/index.js';
+import type { AgentMailbox } from '../mailbox/types.js';
+
+const WORKSPACE_DIR = '/workspace/group';
+
+const config = loadConfig();
+
+console.log(`[code-runner] boot group=${config.agentGroupId || 'unknown'}`);
+
+if (config.codeMode !== true) {
+  console.error('[code-runner] spawned for a group whose config does not set code_mode — refusing (selection bug)');
+  process.exit(1);
+}
+
+let heartbeatWarned = false;
+function beat(): void {
+  if (touchHeartbeat()) return;
+  if (heartbeatWarned) return;
+  heartbeatWarned = true;
+  console.error(`[code-runner] heartbeat not writable at ${heartbeatPath()} — continuing; check the heartbeat mount`);
+}
+
+/**
+ * Exit only after the registered mailbox has flushed. Bounded, because a
+ * store that cannot be reached must not outlive the signal that asked this
+ * process to go — the acks it still holds are recoverable (an unacked claim
+ * is re-delivered), a container that will not die is not.
+ *
+ * An incomplete flush is the one new failure mode this wait introduces, so
+ * both of its shapes SAY so before the exit: on this box the container log
+ * is all anybody gets, and "mail went missing after a restart" is
+ * unanswerable if the last thing the runner did was swallow the reason.
+ */
+function exitAfterMailboxFlush(mailbox: AgentMailbox, code: number): void {
+  const flushed = mailbox.stop().then(
+    () => true,
+    (error) => {
+      console.error('[code-runner] mailbox flush failed on exit — unacked claims will be redelivered:', error);
+      return true; // reported, not survivable: go.
+    },
+  );
+  const deadline = Bun.sleep(2_000).then(() => false);
+  void Promise.race([flushed, deadline]).then((done) => {
+    if (!done) {
+      console.error(
+        '[code-runner] mailbox did not flush within 2s — exiting anyway; unacked claims will be redelivered',
+      );
+    }
+    process.exit(code);
+  });
+}
+
+function sessionEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) env[k] = v;
+  }
+  Object.assign(env, SESSION_TERM_ENV);
+  return env;
+}
+
+async function main(): Promise<void> {
+  const probe = spawnSync('tmux', ['-V'], { stdio: 'ignore' });
+  if (probe.error || probe.status !== 0) {
+    throw new Error('Code mode requires tmux in the agent image; install tmux and rebuild the image.');
+  }
+  const bootAt = Date.now();
+  // Unconditional boot stamp: a heartbeat file that never existed is
+  // invisible to host-sweep's kill ceiling. The lease below only decides
+  // whether to KEEP refreshing it .
+  beat();
+
+  // Open the registered mailbox for THIS session before anything reads it.
+  // The chat runner does the same at src/index.ts and every `ncl` invocation
+  // opens its own — the seam is per-process, and start() is where an
+  // implementation learns which session it serves. The SQLite driver reaches
+  // its files by fixed path and so survived the omission; an implementation
+  // that is not a file cannot, and without this the delivery loop would read
+  // an empty mailbox forever while the first outbox write threw.
+  const agentMailbox = getAgentMailbox();
+  const mailboxContext = await readMailboxContext();
+  await agentMailbox.start(mailboxContext);
+
+  // Register the idle/busy + notify hooks BEFORE the session spawns, so the
+  // interactive CLI reads settings.json with them already in place .
+  ensureMailboxHooks();
+  // …and its first-run state, or every disposable container stops at a folder-trust
+  // dialog no one is attached to answer.
+  const permissionMode = resolvePermissionMode(process.env.NANOCLAW_CODE_PERMISSION_MODE);
+  ensureClaudeState(WORKSPACE_DIR, permissionMode === 'bypass');
+  // Channel transport: the server registration must predate the spawn —
+  // claude reads the --mcp-config file at startup. Container-private, so the
+  // workspace never carries a project MCP file of ours.
+  const channelMode = resolveChannelMode(process.env.NANOCLAW_CODE_CHANNELS);
+  if (channelMode !== 'off') ensureChannelMcpConfig();
+
+  // Seed fullscreen defaults; `/tui` stays the operator's choice.
+  ensureTerminalDefaults();
+
+  // A reap stops being amnesia. The CLI's session store rides the durable
+  // ~/.claude mount, which every session of the group shares under the same
+  // cwd — so the conversation is named, never "the most recent one here":
+  // one id per NanoClaw session (claude-state.ts), started with
+  // `--session-id` on its first life and resumed with `--resume <id>` on
+  // every later one, respawns included. The id on record is read before
+  // each life because the SessionStart hook (mailbox-hook.ts) replaces it
+  // when the operator starts a new conversation with /clear.
+  const freshBootArgs = [...claudeArgs(config.model, permissionMode), ...channelArgs(channelMode)];
+  const conversation = conversationArgsResolver({ sessionId: mailboxContext?.sessionId, workspaceDir: WORKSPACE_DIR });
+  const argsForLife = (life: LifeContext): string[] => [...freshBootArgs, ...conversation(life)];
+  const sessionOptions = {
+    command: 'claude',
+    args: argsForLife,
+    cwd: WORKSPACE_DIR,
+    env: sessionEnv(),
+    // Every child life starts unready: a dead life's idle/busy stamp must
+    // never gate injection into a booting TUI (mail would be acked and
+    // lost). Deleting the state file re-arms the mailbox readiness hold
+    // until THIS life's SessionStart hook fires.
+    onSpawn: () => fs.rmSync(AGENT_STATE_PATH, { force: true }),
+  };
+
+  const session = new TmuxSession(sessionOptions);
+  await session.start();
+  const presence = new TmuxEvidence();
+  presence.start();
+  // Only tmux's live clients supply human presence for approvals and leases.
+  const stampAttach = (count: number) =>
+    writeAttachState(count, undefined, {
+      lastInputAt: presence.lastClientInputAt,
+      lastConnectAt: presence.lastClientConnectAt,
+    });
+
+  let lastSig = '';
+  const presenceTimer = setInterval(() => {
+    const sig = `${presence.clientCount}:${presence.lastClientInputAt}:${presence.lastClientConnectAt}`;
+    if (sig !== lastSig) {
+      lastSig = sig;
+      stampAttach(presence.clientCount);
+    }
+  }, 1_000);
+  // Boot stamp: a fresh life starts detached — hooks reading a file that was
+  // never written (or a torn one) also read detached, the escalating end.
+  stampAttach(presence.clientCount);
+
+  const deliveryLoop = new MailboxDeliveryLoop({
+    session,
+    lastOperatorInputAt: () => presence.lastClientInputAt,
+    ...(channelMode !== 'off' ? { channelSpoolDir: CHANNEL_SPOOL_DIR } : {}),
+  });
+  deliveryLoop.start();
+  console.log(
+    `[code-runner] session up — tmux socket at ${TMUX_SOCKET_PATH}, mailbox loop running (${channelMode !== 'off' ? `channel transport, mode ${channelMode}` : 'typing transport'})`,
+  );
+
+  // The heartbeat is a lease, not a pulse: refresh only while the session is
+  // observably in use, else exit 0 and let the host respawn on demand .
+  const idleTtlMs = resolveIdleTtlMs();
+  const attachIdleTtlMs = resolveAttachIdleTtlMs();
+  let retiring = false;
+  const lease = setInterval(() => {
+    // Freshness heartbeat for the attach stamp: a stamp only ever written on
+    // connect/disconnect goes stale during a long quiet attach, and the
+    // boundary hook treats a stale stamp as detached (ATTACH_STAMP_FRESH_MS).
+    stampAttach(presence.clientCount);
+    const state = readAgentState();
+    const stateAt = state ? Date.parse(state.at) : NaN;
+    const busyUntilAt = state?.busyUntil ? Date.parse(state.busyUntil) : NaN;
+    const now = Date.now();
+    const liveClientAt = presence.attachedClientActivityAt;
+    const decision = decideLiveness({
+      now,
+      bootAt,
+      clientCount: presence.clientCount,
+      agentState:
+        state && Number.isFinite(stateAt)
+          ? { state: state.state, at: stateAt, busyUntil: Number.isFinite(busyUntilAt) ? busyUntilAt : undefined }
+          : undefined,
+      lastClientInputAt: presence.lastClientInputAt,
+      lastClientConnectAt: presence.lastClientConnectAt,
+      lastInjectionAt: deliveryLoop.lastInjectionAt,
+      lastAttachExecAt: readAttachActivityAt(),
+      attachedClientIdleMs: liveClientAt !== undefined ? Math.max(0, now - liveClientAt) : undefined,
+      idleTtlMs,
+      attachIdleTtlMs,
+      busyStaleMs: BUSY_STALE_MS,
+    });
+    if (decision.alive) {
+      beat();
+      return;
+    }
+    if (retiring) return;
+    retiring = true;
+    clearInterval(lease);
+    console.log(`[code-runner] idle lease expired (${decision.reason}) — exiting`);
+    // An operator still attached would otherwise watch the container vanish
+    // under the terminal: mouse reporting left on, no word why. Detach the
+    // clients cleanly first, the reason on their terminal; bounded, and the
+    // exit does not depend on it.
+    const retire =
+      presence.clientCount > 0
+        ? session
+            .detachClients(retirementNotice(liveClientAt !== undefined ? now - liveClientAt : idleTtlMs))
+            .then((gone) => {
+              if (!gone) console.error('[code-runner] attached clients did not detach in time — exiting anyway');
+            })
+        : Promise.resolve();
+    void retire.finally(() => exitAfterMailboxFlush(agentMailbox, 0));
+  }, 30_000);
+
+  const shutdown = (signal: string) => {
+    console.log(`[code-runner] ${signal} — shutting down`);
+    deliveryLoop.stop();
+    clearInterval(presenceTimer);
+    presence.stop();
+    session.dispose();
+    exitAfterMailboxFlush(agentMailbox, 0);
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+}
+
+main().catch((error) => {
+  console.error('[code-runner] fatal:', error);
+  process.exit(1);
+});

--- a/container/agent-runner/src/code-runner/liveness.test.ts
+++ b/container/agent-runner/src/code-runner/liveness.test.ts
@@ -1,0 +1,222 @@
+/**
+ * liveness lease: each leg of decideLiveness (busy, declared tool
+ * window, the v2 connected-client window, idle TTL with attach and exec
+ * evidence as plain activity), the busy-staleness cap, orphan-exec
+ * immunity, boundary conditions, and the env-driven TTLs.
+ */
+import { describe, it, expect } from 'bun:test';
+
+import {
+  DEFAULT_ATTACH_IDLE_TTL_MS,
+  DEFAULT_IDLE_TTL_MS,
+  decideLiveness,
+  resolveAttachIdleTtlMs,
+  resolveIdleTtlMs,
+  retirementNotice,
+  type LivenessInput,
+} from './liveness.js';
+
+const NOW = 10_000_000_000;
+const TTL = 30 * 60_000;
+const ATTACH_TTL = 4 * 60 * 60_000;
+
+/** Everything stale by default — each test turns on exactly the leg it probes. */
+function input(overrides: Partial<LivenessInput> = {}): LivenessInput {
+  return {
+    now: NOW,
+    bootAt: NOW - TTL * 10,
+    clientCount: 0,
+    agentState: undefined,
+    lastClientInputAt: 0,
+    lastClientConnectAt: 0,
+    lastInjectionAt: 0,
+    lastAttachExecAt: 0,
+    idleTtlMs: TTL,
+    attachIdleTtlMs: ATTACH_TTL,
+    busyStaleMs: TTL,
+    ...overrides,
+  };
+}
+
+describe('decideLiveness', () => {
+  it('everything stale — the lease expires', () => {
+    const decision = decideLiveness(input());
+    expect(decision.alive).toBe(false);
+    expect(decision.reason).toContain('idle');
+  });
+
+  it('a bare connected client is NOT a lease: an orphaned exec with stale input expires', () => {
+    // exec-shim orphans survive a dead ssh forever — a socket
+    // alone must never hold the container (the immortality the lease closes). Note
+    // attachedClientIdleMs stays undefined here: an attach-stack client
+    // count is exactly the evidence tmux does NOT vouch for.
+    expect(decideLiveness(input({ clientCount: 1 })).alive).toBe(false);
+  });
+
+  it('a LIVE tmux client inside the attach window holds the lease past the activity TTL', () => {
+    // The acceptance case: attached-but-silent survives past 30 min — every
+    // activity mark is stale, only the live client (idle 1h < 4h) holds.
+    const decision = decideLiveness(input({ clientCount: 1, attachedClientIdleMs: 60 * 60_000 }));
+    expect(decision.alive).toBe(true);
+    expect(decision.reason).toBe(`attached client idle ${60 * 60_000}ms`);
+  });
+
+  it('attach window boundary is strict: a client idle exactly attachIdleTtlMs is not a lease', () => {
+    expect(decideLiveness(input({ clientCount: 1, attachedClientIdleMs: ATTACH_TTL })).alive).toBe(false);
+  });
+
+  it('a vanished client contributes nothing — undefined idle falls through to the activity legs', () => {
+    // The client detached (or its ssh died and tmux dropped it): with the
+    // marks stale the container expires — the connected-client lease never
+    // outlives the connection that earned it.
+    expect(decideLiveness(input({ attachedClientIdleMs: undefined })).alive).toBe(false);
+  });
+
+  it('the connected-client rule sits AFTER busy: a busy turn still answers with the busy reason', () => {
+    const decision = decideLiveness(
+      input({ agentState: { state: 'busy', at: NOW - 1000 }, clientCount: 1, attachedClientIdleMs: 0 }),
+    );
+    expect(decision.alive).toBe(true);
+    expect(decision.reason).toContain('agent busy');
+  });
+
+  it('a recent client CONNECT holds the lease as activity', () => {
+    expect(decideLiveness(input({ clientCount: 1, lastClientConnectAt: NOW - TTL + 1 })).alive).toBe(true);
+  });
+
+  it('a silently-watching client loses the lease at the TTL', () => {
+    expect(
+      decideLiveness(input({ clientCount: 1, lastClientConnectAt: NOW - TTL, lastClientInputAt: NOW - TTL })).alive,
+    ).toBe(false);
+  });
+
+  it('a fresh busy turn holds the lease', () => {
+    expect(decideLiveness(input({ agentState: { state: 'busy', at: NOW - TTL + 1 } })).alive).toBe(true);
+  });
+
+  it('busy staleness cap: a busy stamp exactly busyStaleMs old no longer holds via the busy leg', () => {
+    // At the cap the busy leg is dead AND the stamp is too old for the idle
+    // leg — a wedged turn (Esc, no Stop hook) cannot make the container immortal.
+    expect(decideLiveness(input({ agentState: { state: 'busy', at: NOW - TTL } })).alive).toBe(false);
+  });
+
+  it('a declared tool window extends busy past the staleness cap', () => {
+    // 45-min test suite: stamp is past busyStaleMs but now < busyUntil.
+    const decision = decideLiveness(
+      input({ agentState: { state: 'busy', at: NOW - TTL, busyUntil: NOW + 15 * 60_000 } }),
+    );
+    expect(decision.alive).toBe(true);
+    expect(decision.reason).toContain('declared tool window');
+  });
+
+  it('holds through a simulated permission-prompt window (Notification stamp), then expires at its cap', () => {
+    // The Notification hook fires ONCE when the dialog appears and stamps
+    // busy + busyUntil (mailbox-hook PERMISSION_PROMPT_HOLD_MS); no further
+    // hook fires while the dialog waits. Deep into the wait — past the busy
+    // staleness cap — the declared window is the only thing holding the container.
+    const promptAt = NOW - TTL - 60_000; // stamped 31 min ago, stale for the busy leg
+    const hold = decideLiveness(input({ agentState: { state: 'busy', at: promptAt, busyUntil: NOW + 60_000 } }));
+    expect(hold.alive).toBe(true);
+    expect(hold.reason).toContain('declared tool window');
+    // The cap is the whole hold: one ms past busyUntil the prompt was going
+    // nowhere and the container expires — bounded, never immortality.
+    const past = decideLiveness(
+      input({
+        agentState: { state: 'busy', at: NOW - TTL * 2, busyUntil: NOW - 1 },
+        bootAt: NOW - TTL * 10,
+      }),
+    );
+    expect(past.alive).toBe(false);
+  });
+
+  it('an expired tool window no longer holds the lease', () => {
+    expect(decideLiveness(input({ agentState: { state: 'busy', at: NOW - TTL * 2, busyUntil: NOW - 1 } })).alive).toBe(
+      false,
+    );
+  });
+
+  it('busyUntil on an idle state is ignored (only busy turns own a tool window)', () => {
+    expect(
+      decideLiveness(input({ agentState: { state: 'idle', at: NOW - TTL * 2, busyUntil: NOW + 60_000 } })).alive,
+    ).toBe(false);
+  });
+
+  it('a stale busy stamp still counts as plain activity for the idle leg', () => {
+    // busyStaleMs shorter than idleTtlMs: past the cap, within the TTL.
+    const decision = decideLiveness(input({ busyStaleMs: 60_000, agentState: { state: 'busy', at: NOW - 120_000 } }));
+    expect(decision.alive).toBe(true);
+    expect(decision.reason).toContain('last activity');
+  });
+
+  it('an idle agent stamp within the TTL holds the lease', () => {
+    expect(decideLiveness(input({ agentState: { state: 'idle', at: NOW - TTL + 1 } })).alive).toBe(true);
+  });
+
+  it('a recent boot holds the lease', () => {
+    expect(decideLiveness(input({ bootAt: NOW - TTL + 1 })).alive).toBe(true);
+  });
+
+  it('recent client input holds the lease even after detach', () => {
+    expect(decideLiveness(input({ lastClientInputAt: NOW - TTL + 1 })).alive).toBe(true);
+  });
+
+  it('a recent mailbox injection holds the lease', () => {
+    expect(decideLiveness(input({ lastInjectionAt: NOW - TTL + 1 })).alive).toBe(true);
+  });
+
+  it('a recent attach-routed exec holds the lease as plain activity', () => {
+    // The reaper case, closed: a working day of attach execs with no chat
+    // traffic keeps the container. A raw exec still stamps nothing.
+    expect(decideLiveness(input({ lastAttachExecAt: NOW - TTL + 1 })).alive).toBe(true);
+    expect(decideLiveness(input({ lastAttachExecAt: NOW - TTL })).alive).toBe(false);
+  });
+
+  it('idle boundary is strict: activity exactly idleTtlMs ago is expired', () => {
+    expect(decideLiveness(input({ lastClientInputAt: NOW - TTL })).alive).toBe(false);
+  });
+});
+
+describe('resolveIdleTtlMs', () => {
+  it('defaults to 30 minutes when unset', () => {
+    expect(resolveIdleTtlMs({})).toBe(DEFAULT_IDLE_TTL_MS);
+    expect(DEFAULT_IDLE_TTL_MS).toBe(30 * 60_000);
+  });
+
+  it('honors a valid NANOCLAW_CODE_IDLE_TTL_MS', () => {
+    expect(resolveIdleTtlMs({ NANOCLAW_CODE_IDLE_TTL_MS: '120000' })).toBe(120_000);
+  });
+
+  it('ignores invalid or non-positive values', () => {
+    expect(resolveIdleTtlMs({ NANOCLAW_CODE_IDLE_TTL_MS: 'soon' })).toBe(DEFAULT_IDLE_TTL_MS);
+    expect(resolveIdleTtlMs({ NANOCLAW_CODE_IDLE_TTL_MS: '-5' })).toBe(DEFAULT_IDLE_TTL_MS);
+    expect(resolveIdleTtlMs({ NANOCLAW_CODE_IDLE_TTL_MS: '0' })).toBe(DEFAULT_IDLE_TTL_MS);
+  });
+});
+
+describe('retirementNotice', () => {
+  it('names the idle span coarsely and says reconnecting wakes the session', () => {
+    expect(retirementNotice(4 * 60 * 60_000)).toBe('[nanoclaw] session retired after 4h idle; reconnect to wake it');
+    expect(retirementNotice(4 * 60 * 60_000 + 11 * 60_000)).toBe(
+      '[nanoclaw] session retired after 4.2h idle; reconnect to wake it',
+    );
+    expect(retirementNotice(35 * 60_000)).toBe('[nanoclaw] session retired after 35m idle; reconnect to wake it');
+    expect(retirementNotice(90 * 60_000)).toBe('[nanoclaw] session retired after 1.5h idle; reconnect to wake it');
+  });
+});
+
+describe('resolveAttachIdleTtlMs', () => {
+  it('defaults to a day when unset', () => {
+    expect(resolveAttachIdleTtlMs({})).toBe(DEFAULT_ATTACH_IDLE_TTL_MS);
+    expect(DEFAULT_ATTACH_IDLE_TTL_MS).toBe(24 * 60 * 60_000);
+  });
+
+  it('honors a valid NANOCLAW_CODE_ATTACH_IDLE_TTL_MS', () => {
+    expect(resolveAttachIdleTtlMs({ NANOCLAW_CODE_ATTACH_IDLE_TTL_MS: '7200000' })).toBe(7_200_000);
+  });
+
+  it('ignores invalid or non-positive values', () => {
+    expect(resolveAttachIdleTtlMs({ NANOCLAW_CODE_ATTACH_IDLE_TTL_MS: 'later' })).toBe(DEFAULT_ATTACH_IDLE_TTL_MS);
+    expect(resolveAttachIdleTtlMs({ NANOCLAW_CODE_ATTACH_IDLE_TTL_MS: '-5' })).toBe(DEFAULT_ATTACH_IDLE_TTL_MS);
+    expect(resolveAttachIdleTtlMs({ NANOCLAW_CODE_ATTACH_IDLE_TTL_MS: '0' })).toBe(DEFAULT_ATTACH_IDLE_TTL_MS);
+  });
+});

--- a/container/agent-runner/src/code-runner/liveness.ts
+++ b/container/agent-runner/src/code-runner/liveness.ts
@@ -1,0 +1,135 @@
+/**
+ * liveness lease — the decision half of the code runner's heartbeat.
+ *
+ * The chat runner earns its heartbeat by doing work; the code runner's PTY
+ * is eternally "up", so an unconditional heartbeat would make the container
+ * immortal and host-sweep's 30-min kill ceiling dead code. Instead the
+ * runner holds a lease: the heartbeat is refreshed only while something
+ * observable says the session is in use — a busy agent turn (capped by the
+ * same 30-min staleness ceiling the mailbox applies to 'busy', extended
+ * through a tool call's DECLARED timeout, since no hook fires mid-call), or
+ * any activity within the idle TTL.
+ *
+ * An attach SOCKET is deliberately not a lease: exec-shim orphans
+ * (`docker exec` and the like) survive a dead ssh session indefinitely (the shim
+ * holds the pty; the in-container client never sees EOF), so a bare socket
+ * would reopen the exact immortality the lease exists to close. Under tmux that
+ * objection dissolves — sessions live in a tmux server, tmux knows its REAL
+ * clients and their per-client activity times, and a dead ssh leaves no tmux
+ * client behind — so a live client IS a lease (the agreed rule:
+ * "keep alive on connection; a longer TTL for idle connection"), with its
+ * own, longer idle window for a connected-but-silent operator. A client that
+ * vanishes contributes nothing: no orphan immortality. When tmux evidence
+ * is unavailable, `attachedClientIdleMs` is undefined and a connection cannot
+ * extend the lease.
+ *
+ * Pure so the semantics are testable without a heartbeat file or a
+ * process.exit.
+ */
+
+/** How long a session with nobody attached stays up after its last activity. */
+export const DEFAULT_IDLE_TTL_MS = 30 * 60_000;
+
+/**
+ * How long a session keeps an attached-but-silent client before retiring:
+ * a day, so an operator who leaves a terminal open overnight finds it in
+ * the morning rather than a dropped connection. Retiring detaches the
+ * client cleanly with a notice first (index.ts).
+ */
+export const DEFAULT_ATTACH_IDLE_TTL_MS = 24 * 60 * 60_000;
+
+export interface LivenessInput {
+  now: number;
+  bootAt: number;
+  clientCount: number;
+  /** Parsed hook state, epochs in ms; undefined when absent or unparseable. */
+  agentState: { state: string; at: number; busyUntil?: number } | undefined;
+  lastClientInputAt: number;
+  /** Epoch ms of the most recent attach connect (0 if none). */
+  lastClientConnectAt: number;
+  lastInjectionAt: number;
+  /** Epoch ms of the most recent attach-routed exec's stamp (0 if none). */
+  lastAttachExecAt: number;
+  /**
+   * Minimum idle across LIVE tmux clients, ms — undefined when no client is
+   * attached or tmux evidence is unavailable, which
+   * makes the connected-client rule vanish rather than fail open.
+   */
+  attachedClientIdleMs?: number;
+  idleTtlMs: number;
+  attachIdleTtlMs: number;
+  busyStaleMs: number;
+}
+
+export function decideLiveness(input: LivenessInput): { alive: boolean; reason: string } {
+  const {
+    now,
+    bootAt,
+    clientCount,
+    agentState,
+    lastClientInputAt,
+    lastClientConnectAt,
+    lastInjectionAt,
+    lastAttachExecAt,
+    attachedClientIdleMs,
+    idleTtlMs,
+    attachIdleTtlMs,
+    busyStaleMs,
+  } = input;
+
+  if (agentState?.state === 'busy') {
+    // A wedged 'busy' (Esc fires no Stop hook) must not hold the lease
+    // forever; past the cap its stamp still counts as plain activity below.
+    if (now - agentState.at < busyStaleMs) {
+      return { alive: true, reason: `agent busy for ${now - agentState.at}ms` };
+    }
+    // Inside a tool's declared window silence IS work: a 45-min test suite
+    // fires no hook between PreToolUse and PostToolUse.
+    if (agentState.busyUntil !== undefined && now < agentState.busyUntil) {
+      return { alive: true, reason: `inside declared tool window (${agentState.busyUntil - now}ms left)` };
+    }
+  }
+
+  // A live client with idle inside its own (longer) window holds the lease —
+  // tmux vouches the client exists RIGHT NOW, so this can never outlive the
+  // connection the way a high-water activity mark deliberately does.
+  if (attachedClientIdleMs !== undefined && attachedClientIdleMs < attachIdleTtlMs) {
+    return { alive: true, reason: `attached client idle ${attachedClientIdleMs}ms` };
+  }
+
+  const idleMs =
+    now -
+    Math.max(bootAt, agentState?.at ?? 0, lastClientInputAt, lastClientConnectAt, lastInjectionAt, lastAttachExecAt);
+  if (idleMs < idleTtlMs) {
+    const clients = clientCount > 0 ? `, ${clientCount} attach client(s)` : '';
+    return { alive: true, reason: `last activity ${idleMs}ms ago${clients}` };
+  }
+
+  return { alive: false, reason: `agent not busy, idle ${idleMs}ms ≥ ttl ${idleTtlMs}ms (${clientCount} client(s))` };
+}
+
+/**
+ * The line a client detached by a retiring runner reads on its terminal: how
+ * long it sat idle, coarsely, and that reconnecting wakes the session.
+ */
+export function retirementNotice(idleMs: number): string {
+  return `[nanoclaw] session retired after ${describeIdle(idleMs)} idle; reconnect to wake it`;
+}
+
+function describeIdle(ms: number): string {
+  const minutes = Math.round(Math.max(0, ms) / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.round(ms / 360_000) / 10}h`;
+}
+
+/** NANOCLAW_CODE_IDLE_TTL_MS overrides the default; invalid or non-positive values are ignored. */
+export function resolveIdleTtlMs(env: Record<string, string | undefined> = process.env): number {
+  const parsed = parseInt(env.NANOCLAW_CODE_IDLE_TTL_MS ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_IDLE_TTL_MS;
+}
+
+/** NANOCLAW_CODE_ATTACH_IDLE_TTL_MS overrides the default; invalid or non-positive values are ignored. */
+export function resolveAttachIdleTtlMs(env: Record<string, string | undefined> = process.env): number {
+  const parsed = parseInt(env.NANOCLAW_CODE_ATTACH_IDLE_TTL_MS ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_ATTACH_IDLE_TTL_MS;
+}

--- a/container/agent-runner/src/code-runner/mailbox-channel.test.ts
+++ b/container/agent-runner/src/code-runner/mailbox-channel.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Pins the hand-rolled MCP subset the channel server speaks — this test IS
+ * the wire contract's tripwire (mailbox-channel.ts header): if the client
+ * ever demands more than initialize/initialized/ping/tools, the failure
+ * lands here first.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, expect, it } from 'bun:test';
+
+import { writeSpoolEntry } from './channel-spool.js';
+import { MailboxChannelServer } from './mailbox-channel.js';
+
+interface Sent {
+  id?: number | string;
+  method?: string;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+  params?: Record<string, unknown>;
+}
+
+function server(overrides: Partial<ConstructorParameters<typeof MailboxChannelServer>[0]> = {}) {
+  const sent: Sent[] = [];
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-channel-'));
+  const s = new MailboxChannelServer({
+    spoolDir: dir,
+    pollMs: 60_000, // tests drive emitSpool() by hand
+    send: (msg) => sent.push(msg as Sent),
+    ...overrides,
+  });
+  return { s, sent, dir };
+}
+
+async function init(s: MailboxChannelServer): Promise<void> {
+  await s.handle({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } });
+  await s.handle({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  s.stop(); // kill the interval the initialized handler armed; tests poll by hand
+}
+
+describe('MCP handshake', () => {
+  it('declares the channel capability, tools, and instructions on initialize', async () => {
+    const { s, sent } = server();
+    await s.handle({ jsonrpc: '2.0', id: 7, method: 'initialize', params: { protocolVersion: '2024-11-05' } });
+    const res = sent[0].result as {
+      protocolVersion: string;
+      capabilities: { experimental: Record<string, unknown>; tools: object };
+      instructions: string;
+      serverInfo: { name: string };
+    };
+    expect(sent[0].id).toBe(7);
+    expect(res.protocolVersion).toBe('2024-11-05'); // echo the client's, never fight over versions
+    expect(res.capabilities.experimental['claude/channel']).toEqual({});
+    // Deliberately NOT declared: the permission relay is a later step — before
+    // v2.1.234 even `false` read as declared, so the key must be absent.
+    expect('claude/channel/permission' in res.capabilities.experimental).toBe(false);
+    expect(res.capabilities.tools).toEqual({});
+    expect(res.instructions).toContain('reply');
+    expect(res.serverInfo.name).toBe('nanoclaw-mailbox');
+  });
+
+  it('answers ping, rejects unknown requests, ignores unknown notifications', async () => {
+    const { s, sent } = server();
+    await s.handle({ jsonrpc: '2.0', id: 1, method: 'ping' });
+    expect(sent[0]).toEqual({ id: 1, result: {} });
+    await s.handle({ jsonrpc: '2.0', id: 2, method: 'resources/list' });
+    expect(sent[1].error?.code).toBe(-32601);
+    await s.handle({ jsonrpc: '2.0', method: 'notifications/cancelled' });
+    expect(sent).toHaveLength(2); // notifications never get a response frame
+  });
+});
+
+describe('spool emission', () => {
+  it('emits nothing before the client says initialized', async () => {
+    const { s, sent, dir } = server();
+    writeSpoolEntry({ content: 'early', meta: {} }, dir);
+    await s.emitSpool();
+    expect(sent).toHaveLength(0);
+  });
+
+  it('forwards entries in order as channel notifications and unlinks after the send', async () => {
+    const { s, sent, dir } = server();
+    await init(s);
+    writeSpoolEntry({ content: 'first mail', meta: { ids: 'm1', batch: '1' } }, dir);
+    writeSpoolEntry({ content: 'second mail', meta: { ids: 'm2,m3', batch: '2' } }, dir);
+    await s.emitSpool();
+    const notes = sent.filter((m) => m.method === 'notifications/claude/channel');
+    expect(notes.map((n) => n.params)).toEqual([
+      { content: 'first mail', meta: { ids: 'm1', batch: '1' } },
+      { content: 'second mail', meta: { ids: 'm2,m3', batch: '2' } },
+    ]);
+    expect(fs.readdirSync(dir).filter((n) => n.endsWith('.json'))).toEqual([]);
+  });
+
+  it('leaves an unreadable entry in place and still emits the rest', async () => {
+    const { s, sent, dir } = server();
+    await init(s);
+    fs.writeFileSync(path.join(dir, '0000000000000-000000.json'), 'not json');
+    writeSpoolEntry({ content: 'good', meta: {} }, dir);
+    await s.emitSpool();
+    expect(sent.filter((m) => m.method === 'notifications/claude/channel')).toHaveLength(1);
+    expect(fs.readdirSync(dir)).toContain('0000000000000-000000.json');
+  });
+});
+
+describe('reply tool', () => {
+  it('lists exactly the reply tool with its schema', async () => {
+    const { s, sent } = server();
+    await s.handle({ jsonrpc: '2.0', id: 3, method: 'tools/list' });
+    const tools = (sent[0].result as { tools: Array<{ name: string; inputSchema: { required: string[] } }> }).tools;
+    expect(tools.map((t) => t.name)).toEqual(['reply']);
+    expect(tools[0].inputSchema.required).toEqual(['text']);
+  });
+
+  it('routes reply through the outbox write path, mapping reply_to', async () => {
+    const calls: Record<string, unknown>[] = [];
+    const { s, sent } = server({
+      // The outbox write is a mailbox-seam write now, so the seam is async —
+      // an object store cannot allocate a sequence synchronously.
+      sendOutbox: async (args) => {
+        calls.push(args as Record<string, unknown>);
+        return { ok: true, data: { id: 'out-1' } } as Awaited<
+          ReturnType<NonNullable<ConstructorParameters<typeof MailboxChannelServer>[0]['sendOutbox']>>
+        >;
+      },
+    });
+    await s.handle({
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: { name: 'reply', arguments: { text: 'on it', reply_to: 'm7' } },
+    });
+    expect(calls).toEqual([{ text: 'on it', 'reply-to': 'm7' }]);
+    expect((sent[0].result as { content: Array<{ text: string }> }).content[0].text).toBe('sent');
+  });
+
+  it('surfaces an outbox refusal as a tool error, never a crash', async () => {
+    const { s, sent } = server({
+      sendOutbox: async () =>
+        ({ ok: false, error: { code: 'bad-args', message: 'text required' } }) as Awaited<
+          ReturnType<NonNullable<ConstructorParameters<typeof MailboxChannelServer>[0]['sendOutbox']>>
+        >,
+    });
+    await s.handle({ jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'reply', arguments: {} } });
+    const res = sent[0].result as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('text required');
+    await s.handle({ jsonrpc: '2.0', id: 6, method: 'tools/call', params: { name: 'nope', arguments: {} } });
+    expect(sent[1].error?.code).toBe(-32602);
+  });
+});

--- a/container/agent-runner/src/code-runner/mailbox-channel.ts
+++ b/container/agent-runner/src/code-runner/mailbox-channel.ts
@@ -1,0 +1,250 @@
+/**
+ * nanoclaw-mailbox — the channel server .
+ *
+ * An MCP stdio server claude spawns from the workspace .mcp.json. It declares
+ * the `claude/channel` capability, forwards spool entries from the mailbox
+ * delivery loop as `notifications/claude/channel` events, and exposes one
+ * `reply` tool that writes the group outbox through the exact same code path
+ * as `ncl outbox send`.
+ *
+ * It holds NO delivery authority: claims, acks, retries and the durable
+ * inbound/outbound record contract all stay in the delivery loop
+ * (mailbox.ts) — and the store behind that contract is whatever the
+ * deployment registered, not this server's business. Channels give no
+ * delivery acknowledgment — a notification "sent" is only written to the
+ * transport, and an unloaded/org-blocked channel drops it silently — so the
+ * hook-evidence ack machinery is what makes this transport trustworthy, not
+ * anything here. Sender gating is structural: the only inbound path is the
+ * loop's spool directory (container-private /tmp), never a network listener.
+ *
+ * The protocol is hand-rolled, not the MCP SDK: one JSON-RPC 2.0 message per
+ * line over stdio, the same hand-synced-wire-contract discipline as the
+ * host's ncl socket port. The subset spoken here — initialize, initialized,
+ * ping, tools/list, tools/call, and the one outbound notification — is
+ * pinned by mailbox-channel.test.ts; if the client ever widens its demands,
+ * the test is where that lands. (Contract: code.claude.com/docs/en/
+ * channels-reference.md, research preview — expect change.)
+ */
+import fs from 'fs';
+
+import { outboxSend } from '../cli/mailbox-verbs.js';
+import { getAgentMailbox, readMailboxContext } from '../mailbox/index.js';
+import { CHANNEL_SPOOL_DIR, listSpoolEntries, type SpoolEntry } from './channel-spool.js';
+// Capability barrel — this file is its own PROCESS (claude spawns it from the
+// workspace .mcp.json), so the singular mailbox slot has to be registered
+// here too. Idempotent: an already-loaded barrel is a module-cache hit.
+import '../modules/index.js';
+
+const SERVER_NAME = 'nanoclaw-mailbox';
+
+export const CHANNEL_INSTRUCTIONS =
+  'Messages from your group mailbox arrive as <channel source="nanoclaw-mailbox" kind="mail|task" ...> events — ' +
+  'the same mail `ncl inbox read` shows. Act on them as you would on injected mail. ' +
+  'Reply ONLY when a message calls for a response, using the reply tool (it writes the group outbox, ' +
+  'identical to `ncl outbox send`); pass reply_to from the tag when answering a specific message.';
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id?: number | string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+type Send = (msg: Record<string, unknown>) => void;
+
+export interface ChannelServerOptions {
+  spoolDir?: string;
+  pollMs?: number;
+  send?: Send;
+  /** Test seam over the outbox write — production is the real outboxSend. */
+  sendOutbox?: typeof outboxSend;
+}
+
+export class MailboxChannelServer {
+  private readonly spoolDir: string;
+  private readonly pollMs: number;
+  private readonly send: Send;
+  private readonly sendOutbox: typeof outboxSend;
+  private initialized = false;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private emitting = false;
+
+  constructor(options: ChannelServerOptions = {}) {
+    this.spoolDir = options.spoolDir ?? CHANNEL_SPOOL_DIR;
+    this.pollMs = options.pollMs ?? 300;
+    this.send = options.send ?? ((msg) => process.stdout.write(`${JSON.stringify({ jsonrpc: '2.0', ...msg })}\n`));
+    this.sendOutbox = options.sendOutbox ?? outboxSend;
+  }
+
+  start(input: NodeJS.ReadableStream = process.stdin): void {
+    let buffer = '';
+    input.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      for (;;) {
+        const nl = buffer.indexOf('\n');
+        if (nl < 0) break;
+        const line = buffer.slice(0, nl).trim();
+        buffer = buffer.slice(nl + 1);
+        if (!line) continue;
+        let frame: JsonRpcRequest;
+        try {
+          frame = JSON.parse(line) as JsonRpcRequest;
+        } catch (error) {
+          console.error(`[${SERVER_NAME}] unparseable frame:`, error);
+          continue;
+        }
+        // handle() is async only because the outbox write is (the mailbox
+        // seam's writeMessageOut returns a promise — a sequence over an
+        // object store is not a synchronous allocation). Everything else
+        // still replies before the first await, so frame order is unchanged
+        // for every method but tools/call, whose reply carries its id.
+        void this.handle(frame).catch((error) => console.error(`[${SERVER_NAME}] handler failed:`, error));
+      }
+    });
+    // The client owns this process: EOF on stdin means the session is gone.
+    input.on('end', () => process.exit(0));
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  /** One spool scan — exposed for tests; production runs it on the interval. */
+  async emitSpool(): Promise<void> {
+    if (!this.initialized || this.emitting) return;
+    this.emitting = true;
+    try {
+      for (const file of listSpoolEntries(this.spoolDir)) {
+        let entry: SpoolEntry;
+        try {
+          entry = JSON.parse(fs.readFileSync(file, 'utf8')) as SpoolEntry;
+        } catch {
+          // Torn files cannot exist (tmp+rename) — an unreadable entry is
+          // debris; leave it for a human rather than crash-loop on it.
+          console.error(`[${SERVER_NAME}] unreadable spool entry left in place: ${file}`);
+          continue;
+        }
+        this.send({
+          method: 'notifications/claude/channel',
+          params: { content: entry.content, meta: entry.meta },
+        });
+        // Unlink AFTER the transport write: a crash between the two re-emits
+        // (duplicates-over-loss); the reverse order would lose the delivery.
+        fs.unlinkSync(file);
+      }
+    } finally {
+      this.emitting = false;
+    }
+  }
+
+  /** One protocol frame — public because it IS the pinned surface (tests drive it directly). */
+  async handle(req: JsonRpcRequest): Promise<void> {
+    switch (req.method) {
+      case 'initialize': {
+        this.reply(req, {
+          protocolVersion: (req.params?.protocolVersion as string) ?? '2025-06-18',
+          capabilities: { experimental: { 'claude/channel': {} }, tools: {} },
+          serverInfo: { name: SERVER_NAME, version: '1.0.0' },
+          instructions: CHANNEL_INSTRUCTIONS,
+        });
+        return;
+      }
+      case 'notifications/initialized': {
+        this.initialized = true;
+        this.timer = setInterval(() => void this.emitSpool(), this.pollMs);
+        // fs.watch would race mkdir of the spool dir; the poll is the
+        // contract, the watch would only be latency sugar.
+        return;
+      }
+      case 'ping': {
+        this.reply(req, {});
+        return;
+      }
+      case 'tools/list': {
+        this.reply(req, {
+          tools: [
+            {
+              name: 'reply',
+              description: 'Send a message back over the group mailbox (identical to `ncl outbox send`).',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  text: { type: 'string', description: 'The message to send' },
+                  reply_to: {
+                    type: 'string',
+                    description: 'Optional inbound message id this answers (the reply_to tag attribute)',
+                  },
+                },
+                required: ['text'],
+              },
+            },
+          ],
+        });
+        return;
+      }
+      case 'tools/call': {
+        const name = req.params?.name;
+        if (name !== 'reply') {
+          this.error(req, -32602, `unknown tool: ${String(name)}`);
+          return;
+        }
+        const args = (req.params?.arguments ?? {}) as { text?: string; reply_to?: string };
+        const frame = await this.sendOutbox({
+          text: args.text,
+          ...(args.reply_to ? { 'reply-to': args.reply_to } : {}),
+        });
+        if (frame.ok) {
+          this.reply(req, { content: [{ type: 'text', text: 'sent' }] });
+        } else {
+          this.reply(req, {
+            content: [{ type: 'text', text: `outbox refused: ${frame.error?.message ?? 'unknown error'}` }],
+            isError: true,
+          });
+        }
+        return;
+      }
+      default: {
+        // Notifications (no id) are ignorable by contract; unknown REQUESTS
+        // get a proper method-not-found so the client never hangs on us.
+        if (req.id !== undefined) this.error(req, -32601, `method not found: ${req.method}`);
+      }
+    }
+  }
+
+  private reply(req: JsonRpcRequest, result: Record<string, unknown>): void {
+    this.send({ id: req.id, result });
+  }
+
+  private error(req: JsonRpcRequest, code: number, message: string): void {
+    this.send({ id: req.id, error: { code, message } });
+  }
+}
+
+if (import.meta.main) {
+  // The reply tool writes the group outbox, so this process opens the
+  // registered mailbox for its own session exactly as `ncl` does — the seam
+  // is per-process, and an implementation that is not a file learns WHICH
+  // session it serves only from this context. Fatal on purpose: a channel
+  // server whose reply tool cannot write is worse than one that never came
+  // up, because the agent would believe it had replied.
+  //
+  // Wrapped in an async IIFE so this entrypoint carries no top-level await:
+  // it stays loadable by any bundler or target that forbids one.
+  void (async () => {
+    const mailbox = getAgentMailbox();
+    await mailbox.start(await readMailboxContext());
+    // The spool dir is fixed in production (container-private /tmp); the env
+    // override exists for the local harness, which runs the real server against
+    // a scratch dir outside a container.
+    const spoolDir = process.env.NANOCLAW_CHANNEL_SPOOL?.trim() || CHANNEL_SPOOL_DIR;
+    const server = new MailboxChannelServer({ spoolDir });
+    server.start();
+    console.error(`[${SERVER_NAME}] channel server up, watching ${spoolDir}`);
+  })().catch((err: unknown) => {
+    // "Fatal on purpose" was the intent above and an unhandled rejection is not
+    // reliably fatal — make it so, and say which process died.
+    console.error(`[${SERVER_NAME}] fatal: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/container/agent-runner/src/code-runner/mailbox-hook.test.ts
+++ b/container/agent-runner/src/code-runner/mailbox-hook.test.ts
@@ -1,0 +1,199 @@
+/**
+ * The mailbox hook script, exercised the way claude runs it: a subprocess
+ * with the event payload on stdin. State transitions, the PostToolUse
+ * new-mail notify (with seq high-water dedupe), and the always-exit-0
+ * contract (a broken hook must never block the agent).
+ *
+ * The notify's input is the delivery loop's stamp, not a store: the hook
+ * runs on every tool call and holds no transport knowledge, so the fixture
+ * here is one local file — which is exactly the shape that keeps working
+ * when the registered mailbox is not a pair of SQLite files.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+
+// NEVER import from mailbox-hook.ts here: the script runs main() on import,
+// which reads the (absent) container.json, self-heals, and process.exit(0)s
+// THE TEST RUN — bun then reports success for tests that never executed.
+// Measured live: a canary `expect(1).toBe(2)` appended to this file exited 0.
+import { PERMISSION_PROMPT_HOLD_MS, readAgentState, writeMailNotice } from './agent-state.js';
+import { readConversationId } from './claude-state.js';
+
+const SCRIPT = path.join(import.meta.dir, 'mailbox-hook.ts');
+
+let dir: string;
+let statePath: string;
+let noticePath: string;
+
+function runHook(payload: unknown, envExtra: Record<string, string> = {}): { exitCode: number; stdout: string } {
+  const proc = Bun.spawnSync(['bun', SCRIPT, statePath], {
+    stdin: Buffer.from(typeof payload === 'string' ? payload : JSON.stringify(payload)),
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      NANOCLAW_MAIL_NOTICE: noticePath,
+      NANOCLAW_CONTAINER_JSON: path.join(dir, 'container.json'),
+      ...envExtra,
+    },
+  });
+  return { exitCode: proc.exitCode, stdout: proc.stdout.toString() };
+}
+
+/** What the delivery loop publishes: the sequences of mail still waiting. */
+function stampWaiting(...seqs: number[]): void {
+  writeMailNotice({ seqs }, noticePath);
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-hook-'));
+  statePath = path.join(dir, 'state.json');
+  noticePath = path.join(dir, 'mail-notice.json');
+  fs.writeFileSync(path.join(dir, 'container.json'), JSON.stringify({ codeMode: true }));
+});
+
+describe('state transitions', () => {
+  it('SessionStart and Stop write idle; UserPromptSubmit and PreToolUse write busy', () => {
+    for (const [event, expected] of [
+      ['SessionStart', 'idle'],
+      ['UserPromptSubmit', 'busy'],
+      ['Stop', 'idle'],
+      ['PreToolUse', 'busy'],
+    ] as const) {
+      const res = runHook({ hook_event_name: event });
+      expect(res.exitCode).toBe(0);
+      expect(readAgentState(statePath)?.state).toBe(expected);
+    }
+  });
+
+  it("SessionStart puts the payload's session_id on record as the live conversation; other events and non-uuids do not", () => {
+    const conversationPath = path.join(dir, 'code-session.json');
+    const env = { NANOCLAW_CODE_SESSION: conversationPath };
+    const live = '0f0e0d0c-0b0a-4908-8706-050403020100';
+    expect(runHook({ hook_event_name: 'SessionStart', source: 'clear', session_id: live }, env).exitCode).toBe(0);
+    expect(readConversationId(conversationPath)).toBe(live);
+    expect(readAgentState(statePath)?.state).toBe('idle');
+    runHook({ hook_event_name: 'Stop', session_id: '11111111-2222-4333-8444-555555555555' }, env);
+    expect(readConversationId(conversationPath)).toBe(live);
+    runHook({ hook_event_name: 'SessionStart', session_id: 'not-a-uuid' }, env);
+    expect(readConversationId(conversationPath)).toBe(live);
+  });
+
+  it('malformed stdin and unknown events exit 0 without touching state', () => {
+    expect(runHook('not json').exitCode).toBe(0);
+    expect(runHook({ hook_event_name: 'SomethingNew' }).exitCode).toBe(0);
+    expect(readAgentState(statePath)).toBeNull();
+  });
+
+  it('in a non-code-mode container it self-heals: deregisters its hooks and exits 0', () => {
+    // The group flipped back to chat mode; settings.json still carries our
+    // entries, and the chat runner executes hooks too. First firing removes them.
+    fs.writeFileSync(path.join(dir, 'container.json'), JSON.stringify({})); // codeMode off
+    const configDir = path.join(dir, 'claude-config');
+    fs.mkdirSync(configDir, { recursive: true });
+    const settingsPath = path.join(configDir, 'settings.json');
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          Stop: [
+            { hooks: [{ type: 'command', command: 'bun /app/src/other-hook.ts' }] },
+            { hooks: [{ type: 'command', command: 'bun /app/src/code-runner/mailbox-hook.ts' }] },
+          ],
+          PreToolUse: [{ hooks: [{ type: 'command', command: 'bun /app/src/code-runner/mailbox-hook.ts' }] }],
+        },
+      }),
+    );
+
+    const res = runHook({ hook_event_name: 'Stop' }, { CLAUDE_CONFIG_DIR: configDir });
+    expect(res.exitCode).toBe(0);
+    expect(readAgentState(statePath)).toBeNull(); // no state written in chat mode
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(
+      settings.hooks.Stop.flatMap((e: { hooks: Array<{ command: string }> }) => e.hooks.map((h) => h.command)),
+    ).toEqual(['bun /app/src/other-hook.ts']);
+    expect(settings.hooks.PreToolUse).toBeUndefined(); // emptied event key dropped
+  });
+});
+
+describe('Notification permission-prompt hold', () => {
+  it('permission_prompt stamps busy with a bounded busyUntil — never immortality', () => {
+    const before = Date.now();
+    const res = runHook({ hook_event_name: 'Notification', notification_type: 'permission_prompt' });
+    expect(res.exitCode).toBe(0);
+    const state = readAgentState(statePath)!;
+    expect(state.state).toBe('busy');
+    const busyUntil = Date.parse(state.busyUntil!);
+    expect(busyUntil).toBeGreaterThan(before);
+    // Bounded: exactly one hold's width from the stamp, no more. The CLI
+    // fires this once per dialog, so the cap is the whole story.
+    expect(busyUntil).toBeLessThanOrEqual(Date.now() + PERMISSION_PROMPT_HOLD_MS);
+  });
+
+  it('idle_prompt and unknown types do NOT hold — waiting for input IS the reapable state', () => {
+    for (const type of ['idle_prompt', 'auth_success', undefined]) {
+      const res = runHook({ hook_event_name: 'Notification', notification_type: type });
+      expect(res.exitCode).toBe(0);
+      expect(readAgentState(statePath)).toBeNull();
+    }
+  });
+
+  it('the hold preserves the notify high-water mark', () => {
+    stampWaiting(2);
+    runHook({ hook_event_name: 'PostToolUse' });
+    runHook({ hook_event_name: 'Notification', notification_type: 'permission_prompt' });
+    expect(readAgentState(statePath)?.notifiedSeq).toBe(2);
+  });
+});
+
+describe('PostToolUse busy-notify', () => {
+  it('emits additionalContext once per arrival wave, deduped by seq high-water', () => {
+    stampWaiting(2);
+    const first = runHook({ hook_event_name: 'PostToolUse' });
+    expect(first.exitCode).toBe(0);
+    expect(first.stdout).toContain('additionalContext');
+    expect(first.stdout).toContain('1 new message');
+    expect(first.stdout).toContain('ncl inbox read');
+    expect(readAgentState(statePath)?.notifiedSeq).toBe(2);
+
+    // Same mail, next tool call: silence.
+    const second = runHook({ hook_event_name: 'PostToolUse' });
+    expect(second.stdout).toBe('');
+
+    // New arrival above the high-water mark: notify again.
+    stampWaiting(2, 4);
+    const third = runHook({ hook_event_name: 'PostToolUse' });
+    expect(third.stdout).toContain('1 new message');
+    expect(readAgentState(statePath)?.notifiedSeq).toBe(4);
+  });
+
+  it('stays silent once the loop reports the mail claimed, and when there is no stamp at all', () => {
+    // The loop publishes only unclaimed mail: a claimed/acked message simply
+    // leaves the stamp, and the hook has nothing to say.
+    stampWaiting(2);
+    expect(runHook({ hook_event_name: 'PostToolUse' }).stdout).toContain('1 new message');
+    stampWaiting();
+    expect(runHook({ hook_event_name: 'PostToolUse' }).stdout).toBe('');
+
+    // No stamp at all (a loop that has not ticked yet, or a torn write):
+    // fail closed — silence, exit 0, and the loop still injects at turn end.
+    fs.rmSync(noticePath);
+    const res = runHook({ hook_event_name: 'PostToolUse' });
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toBe('');
+
+    fs.writeFileSync(noticePath, 'not json');
+    expect(runHook({ hook_event_name: 'PostToolUse' }).stdout).toBe('');
+  });
+
+  it('busy/idle transitions preserve the notify high-water mark', () => {
+    stampWaiting(2);
+    runHook({ hook_event_name: 'PostToolUse' });
+    runHook({ hook_event_name: 'Stop' });
+    expect(readAgentState(statePath)?.state).toBe('idle');
+    expect(readAgentState(statePath)?.notifiedSeq).toBe(2);
+  });
+});

--- a/container/agent-runner/src/code-runner/mailbox-hook.ts
+++ b/container/agent-runner/src/code-runner/mailbox-hook.ts
@@ -1,0 +1,187 @@
+/**
+ * Mailbox hook — the claude-code command hook for code-mode sessions
+ * .
+ *
+ * One script, four events (settings.json routes them all here):
+ *   SessionStart      → ready + idle (the TUI is up; injection may begin);
+ *                       the payload's session_id — the conversation the CLI
+ *                       is actually in, a new one after /clear — goes on
+ *                       record so the next child life resumes it
+ *   UserPromptSubmit  → busy (a turn started)
+ *   PreToolUse        → busy (belt — mid-turn confirmation)
+ *   Stop              → idle (turn over; the delivery loop injects within a tick)
+ *   PostToolUse       → busy-path notify: if NEW inbound mail is pending,
+ *                       return additionalContext so the working agent learns
+ *                       mid-turn ("a hook riding on a tool response").
+ *                       Deduped via a seq high-water mark in the state file.
+ *   Notification      → permission-prompt hold: a waiting dialog fires no
+ *                       other hook, so stamp busy with a bounded busyUntil
+ *                       or the container expires mid-prompt (a lease gap).
+ *
+ * Contract (mirrors memory/hook.ts): payload on stdin, result on stdout,
+ * ALWAYS exit 0 — a broken hook must never block the agent's real work.
+ */
+import fs from 'fs';
+
+import {
+  AGENT_STATE_PATH,
+  MAIL_NOTICE_PATH,
+  PERMISSION_PROMPT_HOLD_MS,
+  readAgentState,
+  readMailNotice,
+  writeAgentState,
+} from './agent-state.js';
+import { CONVERSATION_STATE_PATH, recordConversationId } from './claude-state.js';
+import { removeMailboxHooks } from './settings-hooks.js';
+import { TURN_STATE_PATH, writeTurnState } from './turn-stamp.js';
+
+// Env overrides are a test seam — production always runs at the real paths.
+const CONTAINER_JSON_PATH = process.env.NANOCLAW_CONTAINER_JSON || '/workspace/agent/container.json';
+const MAIL_NOTICE = process.env.NANOCLAW_MAIL_NOTICE || MAIL_NOTICE_PATH;
+const TURN_STATE = process.env.NANOCLAW_TURN_STATE || TURN_STATE_PATH;
+const CONVERSATION_STATE = process.env.NANOCLAW_CODE_SESSION || CONVERSATION_STATE_PATH;
+
+/**
+ * The host-visible turn stamp (turn-stamp.ts) rides the same three events
+ * that move the agent state between idle and busy. Best-effort: the
+ * workspace mount is the host's to provide, and a stamp that cannot be
+ * written must never cost the agent its real state.
+ */
+function stampTurn(state: 'idle' | 'busy'): void {
+  try {
+    writeTurnState(state, TURN_STATE);
+  } catch {
+    // no workspace mount (or read-only): the mirror simply sees nothing
+  }
+}
+
+/**
+ * The hook entries live in per-group settings.json, which SURVIVES a flip
+ * back to chat mode — and the chat runner executes settings hooks too. So
+ * the hook self-gates: in a non-code-mode container it deregisters itself
+ * (settings self-heal; chat runner stays untouched) and exits.
+ */
+function inCodeMode(): boolean {
+  try {
+    const config = JSON.parse(fs.readFileSync(CONTAINER_JSON_PATH, 'utf8')) as { codeMode?: boolean };
+    return config.codeMode === true;
+  } catch {
+    return false;
+  }
+}
+
+interface HookPayload {
+  hook_event_name?: string;
+  /** Every hook payload names the CLI's live conversation (a uuid). */
+  session_id?: unknown;
+  tool_name?: string;
+  tool_input?: { timeout?: unknown };
+  /** Notification events only (payload verified at CLI 2.1.197): which
+   *  notification fired — 'permission_prompt' is the one that owns a hold. */
+  notification_type?: string;
+}
+
+/** Ceiling on a declared tool window — a bogus timeout must not mint immortality. */
+const MAX_DECLARED_TOOL_MS = 4 * 3600_000;
+
+/**
+ * Pending mail the agent has not been shown, above the notify high-water
+ * mark — read from the delivery loop's stamp (agent-state.ts
+ * writeMailNotice), never from the mailbox itself.
+ *
+ * The hook holds NO transport knowledge. It fires on every tool call, and
+ * since the mailbox seam the transport may be an object store,
+ * where opening a mailbox per tool call is a network listing; the delivery
+ * loop is already the one process with a live mailbox and already polls
+ * every second, so it publishes and this reads. A missing, torn or empty
+ * stamp reads as nothing waiting — fail closed: no notify, no crash, and
+ * the loop still injects at turn end.
+ */
+function newPendingMail(sinceSeq: number): { count: number; maxSeq: number } {
+  const notice = readMailNotice(MAIL_NOTICE);
+  const fresh = (notice?.seqs ?? []).filter((seq) => seq > sinceSeq);
+  return { count: fresh.length, maxSeq: fresh.reduce((max, seq) => Math.max(max, seq), sinceSeq) };
+}
+
+function main(): void {
+  if (!inCodeMode()) {
+    try {
+      removeMailboxHooks();
+    } catch {
+      // self-healing is best-effort; never block the (chat) agent
+    }
+    process.exit(0);
+  }
+
+  let payload: HookPayload = {};
+  try {
+    payload = JSON.parse(fs.readFileSync(0, 'utf-8')) as HookPayload;
+  } catch {
+    process.exit(0); // malformed input: do nothing, never block
+  }
+
+  const statePath = process.argv[2] || AGENT_STATE_PATH;
+
+  switch (payload.hook_event_name) {
+    case 'SessionStart':
+      recordConversationId(payload.session_id, CONVERSATION_STATE);
+      writeAgentState({ state: 'idle' }, statePath);
+      stampTurn('idle');
+      break;
+    case 'Stop':
+      writeAgentState({ state: 'idle' }, statePath);
+      stampTurn('idle');
+      break;
+    case 'UserPromptSubmit':
+      writeAgentState({ state: 'busy' }, statePath);
+      stampTurn('busy');
+      break;
+    case 'PreToolUse': {
+      // A declared Bash timeout extends the busy lease through the call —
+      // no hook fires DURING a tool, so 45 silent minutes of test suite
+      // would otherwise expire the lease mid-run (mirrors host-sweep's
+      // kill-ceiling extension on the chat side).
+      const timeout = payload.tool_name === 'Bash' ? payload.tool_input?.timeout : undefined;
+      const busyUntil =
+        typeof timeout === 'number' && Number.isFinite(timeout) && timeout > 0
+          ? new Date(Date.now() + Math.min(timeout, MAX_DECLARED_TOOL_MS)).toISOString()
+          : undefined;
+      writeAgentState({ state: 'busy', busyUntil }, statePath);
+      break;
+    }
+    case 'Notification': {
+      // Only the permission dialog owns a hold. 'idle_prompt' (claude waiting
+      // for input at its main prompt) is exactly the reapable idle state and
+      // must not extend the lease; unknown types stay no-ops for the same
+      // reason a malformed payload does.
+      if (payload.notification_type === 'permission_prompt') {
+        writeAgentState(
+          { state: 'busy', busyUntil: new Date(Date.now() + PERMISSION_PROMPT_HOLD_MS).toISOString() },
+          statePath,
+        );
+      }
+      break;
+    }
+    case 'PostToolUse': {
+      const seen = readAgentState(statePath)?.notifiedSeq ?? 0;
+      const mail = newPendingMail(seen);
+      if (mail.count > 0) {
+        writeAgentState({ state: 'busy', notifiedSeq: mail.maxSeq }, statePath);
+        process.stdout.write(
+          JSON.stringify({
+            hookSpecificOutput: {
+              hookEventName: 'PostToolUse',
+              additionalContext: `[nanoclaw] ${mail.count} new message(s) arrived while you work. They will be injected when you finish, or read them now: ncl inbox read`,
+            },
+          }),
+        );
+      }
+      break;
+    }
+    default:
+      break; // unknown event: no-op
+  }
+  process.exit(0);
+}
+
+main();

--- a/container/agent-runner/src/code-runner/mailbox.test.ts
+++ b/container/agent-runner/src/code-runner/mailbox.test.ts
@@ -1,0 +1,924 @@
+/**
+ * Mailbox delivery, acknowledgment, and crash recovery against real SQLite
+ * session databases. Register the SQLite fixture explicitly so these SQL
+ * assertions do not depend on the runtime's selected mailbox implementation.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { loadConfig } from '../config.js';
+import { registerAgentMailbox, resetAgentMailboxForTesting } from '../mailbox/index.js';
+import { SqliteAgentMailbox } from '../mailbox/sqlite/index.js';
+import { initTestSessionDb, closeSessionDb } from '../mailbox/sqlite/connection.js';
+import type { AgentMailboxFactory } from '../mailbox/types.js';
+import type { MessageInRow } from '../db/index.js';
+import { formatLocalTime, TIMEZONE } from '../timezone.js';
+import { READY_FALLBACK_MS, readMailNotice } from './agent-state.js';
+import {
+  ACK_WINDOW_MS,
+  BUSY_STALE_MS,
+  COMPOSE_HOLD_MS,
+  HOLD_RELEASE_MS,
+  MailboxDeliveryLoop,
+  MAX_INJECT_ATTEMPTS,
+  NUDGE_WINDOW_MS,
+  renderMailbox,
+  type MailboxSession,
+} from './mailbox.js';
+
+loadConfig(); // defaults — getPendingMessages reads maxMessagesPerPrompt
+
+class FakeSession implements MailboxSession {
+  written: string[] = [];
+  running = true;
+  lastSpawnAt = 0;
+  write(data: string) {
+    this.written.push(data);
+  }
+  get text() {
+    return this.written.join('');
+  }
+}
+
+let inbound: ReturnType<typeof initTestSessionDb>['inbound'];
+let outbound: ReturnType<typeof initTestSessionDb>['outbound'];
+let session: FakeSession;
+let statePath: string;
+let noticePath: string;
+let now: number;
+let composed: AgentMailboxFactory | undefined;
+
+/** State stamps must ride the FAKE clock — production compares hook wall-clock stamps to Date.now(). */
+function stampState(state: 'idle' | 'busy', atMs: number = now): void {
+  fs.writeFileSync(statePath, JSON.stringify({ state, at: new Date(atMs).toISOString() }));
+}
+
+function loop(overrides: Partial<ConstructorParameters<typeof MailboxDeliveryLoop>[0]> = {}) {
+  return new MailboxDeliveryLoop({
+    session,
+    stateFilePath: statePath,
+    mailNoticePath: noticePath,
+    now: () => now,
+    onFatal: () => {},
+    ...overrides,
+  });
+}
+
+function seedInbound(
+  id: string,
+  opts: {
+    text?: string;
+    sender?: string;
+    kind?: string;
+    trigger?: number;
+    onWake?: number;
+    seq?: number;
+    content?: string;
+  } = {},
+): void {
+  inbound
+    .prepare(
+      `INSERT INTO messages_in (id, seq, kind, timestamp, status, trigger, on_wake, content)
+       VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)`,
+    )
+    .run(
+      id,
+      opts.seq ?? null,
+      opts.kind ?? 'chat',
+      new Date().toISOString(),
+      opts.trigger ?? 1,
+      opts.onWake ?? 0,
+      opts.content ?? JSON.stringify({ text: opts.text ?? `text of ${id}`, sender: opts.sender ?? 'alice' }),
+    );
+}
+
+function ackRows(): Array<{ message_id: string; status: string }> {
+  return outbound.prepare('SELECT message_id, status FROM processing_ack').all() as Array<{
+    message_id: string;
+    status: string;
+  }>;
+}
+
+beforeEach(() => {
+  const dbs = initTestSessionDb();
+  inbound = dbs.inbound;
+  outbound = dbs.outbound;
+  session = new FakeSession();
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-mailbox-'));
+  statePath = path.join(stateDir, 'state.json');
+  noticePath = path.join(stateDir, 'mail-notice.json');
+  now = 1_000_000_000;
+  // Capture per test, not once at import: another suite may hold the slot
+  // when this file loads, and a swap must always put back what it took.
+  composed = resetAgentMailboxForTesting();
+  registerAgentMailbox(() => new SqliteAgentMailbox());
+});
+
+afterEach(() => {
+  closeSessionDb();
+  resetAgentMailboxForTesting();
+  if (composed) registerAgentMailbox(composed);
+});
+
+describe('idle injection', () => {
+  it('types pending mail into the PTY as a bracketed paste and acks completed on the busy transition', async () => {
+    stampState('idle');
+    seedInbound('m1', { text: 'ship the driver', sender: 'alice' });
+    const l = loop();
+    await l.tick();
+    expect(session.text).toContain('\x1b[200~');
+    expect(session.text).toContain('ship the driver');
+    expect(session.text).toContain('alice');
+    expect(session.text).toEndWith('\x1b[201~\r');
+    // The write alone earns only the claim — completion needs the TUI's
+    // hook evidence that the CR actually submitted.
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'processing' }]);
+
+    stampState('busy', now + 50); // UserPromptSubmit fired post-injection
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+
+    // Next tick: nothing left, nothing typed again.
+    session.written = [];
+    stampState('idle', now + 100);
+    await l.tick();
+    expect(session.text).toBe('');
+  });
+
+  it('never injects while the hook state says busy, delivers after Stop flips it', async () => {
+    stampState('busy');
+    seedInbound('m1');
+    const l = loop();
+    await l.tick();
+    expect(session.text).toBe('');
+    expect(ackRows()).toEqual([]);
+
+    stampState('idle');
+    await l.tick();
+    expect(session.text).toContain('text of m1');
+    stampState('busy', now + 50);
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+  });
+
+  it('skips injection while the PTY is down (respawning) and recovers after', async () => {
+    stampState('idle');
+    seedInbound('m1');
+    session.running = false;
+    const l = loop();
+    await l.tick();
+    expect(ackRows()).toEqual([]);
+    session.running = true;
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'processing' }]);
+    stampState('busy', now + 50);
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+  });
+});
+
+describe('contracts honored', () => {
+  it('leaves a trigger=0-only batch pending (accumulate) and delivers it alongside a trigger=1 row', async () => {
+    stampState('idle');
+    seedInbound('ctx', { trigger: 0, text: 'context only' });
+    const l = loop();
+    await l.tick();
+    expect(session.text).toBe('');
+    expect(ackRows()).toEqual([]);
+
+    seedInbound('wake', { trigger: 1, text: 'now engage' });
+    await l.tick();
+    expect(session.text).toContain('context only');
+    expect(session.text).toContain('now engage');
+    stampState('busy', now + 50);
+    await l.tick();
+    expect(
+      ackRows()
+        .map((r) => r.message_id)
+        .sort(),
+    ).toEqual(['ctx', 'wake']);
+    expect(ackRows().every((r) => r.status === 'completed')).toBe(true);
+  });
+
+  it('never types kind=system rows (transport envelopes)', async () => {
+    stampState('idle');
+    seedInbound('sys', { kind: 'system', text: 'cli_response payload' });
+    const l = loop();
+    await l.tick();
+    expect(session.text).toBe('');
+    expect(ackRows()).toEqual([]);
+  });
+
+  it('delivers on_wake rows on the first poll only', async () => {
+    stampState('idle');
+    seedInbound('wake-note', { onWake: 1, text: 'you were restarted' });
+    const l = loop();
+    await l.tick();
+    expect(session.text).toContain('you were restarted');
+    stampState('busy', now + 50); // submit evidence — completes the delivery
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'wake-note', status: 'completed' }]);
+
+    // A second loop instance (fresh "container") with a new on_wake row NOT
+    // on its first poll: seed after the first tick. Fresh idle stamp so the
+    // busy gate is not what hides the row — on_wake retirement must be.
+    stampState('idle', now + 100);
+    const l2 = loop();
+    await l2.tick(); // first poll, nothing pending
+    seedInbound('wake-late', { onWake: 1, text: 'stale restart note' });
+    await l2.tick();
+    expect(session.text).not.toContain('stale restart note');
+  });
+
+  it("start() clears a crashed predecessor's processing claims", async () => {
+    outbound
+      .prepare("INSERT INTO processing_ack (message_id, status, status_changed) VALUES ('ghost', 'processing', ?)")
+      .run(new Date().toISOString());
+    const l = loop();
+    l.start();
+    l.stop();
+    expect(ackRows()).toEqual([]);
+  });
+});
+
+describe('readiness', () => {
+  it('waits for the first hook signal, then fails open after the fallback window', async () => {
+    seedInbound('m1');
+    const l = loop();
+    await l.tick(); // no state file, within window — hold
+    expect(session.text).toBe('');
+
+    now += READY_FALLBACK_MS + 1;
+    await l.tick(); // hooks presumed broken — fail open
+    expect(session.text).toContain('text of m1');
+  });
+
+  it("a dead life's stale idle stamp never gates a respawned claude — the hold re-arms per life", async () => {
+    // Life 1 ended idle; its stamp survives (the confirmed
+    // mail-loss repro). Life 2 spawns later than the stamp.
+    stampState('idle');
+    seedInbound('m1', { text: 'urgent: prod is down' });
+    now += 5_000;
+    session.lastSpawnAt = now; // respawn NOW — stamp predates it
+    const l = loop();
+    await l.tick();
+    expect(session.text).toBe(''); // held: booting TUI, not typed at
+    expect(ackRows()).toEqual([]); // and crucially NOT acked
+
+    // This life's SessionStart fires → stamp is fresh → delivery.
+    now += 1_000;
+    stampState('idle');
+    await l.tick();
+    expect(session.text).toContain('urgent: prod is down');
+    stampState('busy', now + 50); // the submit's own hook evidence
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+  });
+
+  it('the fail-open window measures from the current life, not container boot', async () => {
+    seedInbound('m1');
+    now += READY_FALLBACK_MS * 2; // container is old...
+    session.lastSpawnAt = now - 1_000; // ...but this claude is 1s old
+    const l = loop();
+    await l.tick();
+    expect(session.text).toBe(''); // young life: still held
+    now += READY_FALLBACK_MS;
+    await l.tick(); // hooks presumed broken for THIS life — fail open
+    expect(session.text).toContain('text of m1');
+  });
+});
+
+describe('stale-busy ceiling', () => {
+  it('busy blocks delivery until the 30-minute staleness ceiling, then treats as idle', async () => {
+    stampState('busy');
+    seedInbound('m1');
+    const l = loop();
+    now += BUSY_STALE_MS - 60_000;
+    await l.tick();
+    expect(session.text).toBe(''); // fresh-enough busy: honored
+
+    now += 61_000; // past the ceiling — wedged turn (Esc fires no Stop hook)
+    await l.tick();
+    expect(session.text).toContain('text of m1');
+  });
+});
+
+describe('operator compose hold', () => {
+  it('holds injection while an attached human typed recently', async () => {
+    stampState('idle');
+    seedInbound('m1');
+    let typedAt = now - 1_000;
+    const l = loop({ lastOperatorInputAt: () => typedAt });
+    await l.tick();
+    expect(session.text).toBe(''); // human mid-composition — never submit over them
+
+    now += COMPOSE_HOLD_MS;
+    await l.tick();
+    expect(session.text).toContain('text of m1');
+  });
+});
+
+describe('first-poll retention', () => {
+  it('a skipped trigger=0-only batch does not burn the on_wake window', async () => {
+    stampState('idle');
+    const l = loop();
+    seedInbound('ctx', { trigger: 0 });
+    await l.tick(); // trigger=0-only: skipped, firstPoll must survive the skip
+    expect(session.text).toBe('');
+
+    seedInbound('wake-note', { onWake: 1, trigger: 1, text: 'late restart note' });
+    await l.tick(); // still first-poll semantics: the on_wake row is visible and delivered
+    expect(session.text).toContain('late restart note');
+    expect(session.text).toContain('text of ctx'); // rider delivered too
+  });
+});
+
+describe('trigger starvation rescue', () => {
+  it('an older trigger=1 row crowded out by 10 newer trigger=0 rows still delivers', async () => {
+    stampState('idle');
+    seedInbound('mention', { trigger: 1, seq: 2, text: 'old mention' });
+    for (let i = 0; i < 10; i++) seedInbound(`ctx-${i}`, { trigger: 0, seq: 4 + i * 2 });
+    await loop().tick();
+    expect(session.text).toContain('old mention'); // rescued into the batch
+  });
+});
+
+describe('escape-sequence hardening', () => {
+  it('a message carrying the bracketed-paste-end sequence cannot break out of the paste', async () => {
+    stampState('idle');
+    seedInbound('evil', { text: 'innocent\x1b[201~\rmalicious-keystrokes\x1b[200~more' });
+    await loop().tick();
+    const injected = session.text;
+    // Exactly one paste wrapper — ours — survives; embedded ESC is gone.
+    expect(injected.split('\x1b[201~')).toHaveLength(2);
+    expect(injected.split('\x1b[200~')).toHaveLength(2);
+    expect(injected).toContain('malicious-keystrokes'); // as inert text
+    expect(injected.indexOf('\x1b[201~')).toBeGreaterThan(injected.indexOf('malicious-keystrokes'));
+    // The only CR is our final submit keystroke, outside the paste.
+    expect(injected.match(/\r/g)).toHaveLength(1);
+    expect(injected.endsWith('\x1b[201~\r')).toBe(true);
+  });
+});
+
+describe('renderMailbox', () => {
+  function row(overrides: Partial<MessageInRow> & { content: string }): MessageInRow {
+    return {
+      id: 'big',
+      seq: 2,
+      kind: 'chat',
+      timestamp: new Date().toISOString(),
+      status: 'pending',
+      process_after: null,
+      recurrence: null,
+      tries: 0,
+      trigger: 1,
+      platform_id: null,
+      channel_type: null,
+      thread_id: null,
+      ...overrides,
+    };
+  }
+
+  it('truncates long texts into previews pointing at ncl inbox read --id', async () => {
+    const long = 'x'.repeat(900);
+    const rendered = renderMailbox([row({ content: JSON.stringify({ text: long, sender: 'g' }) })], 700);
+    expect(rendered).toContain('truncated — full text: ncl inbox read --id big');
+    expect(rendered).not.toContain('x'.repeat(701));
+  });
+
+  it('renders every attachment after the text — name, type and the staged path — and with no text at all', () => {
+    const attachments = [
+      { type: 'image', name: 'screen.png', localPath: 'inbox/m1/screen.png' },
+      { type: 'file', name: 'notes.txt', url: 'https://example.invalid/notes.txt' },
+    ];
+    const captioned = renderMailbox(
+      [row({ id: 'm1', content: JSON.stringify({ text: 'Review this screenshot', sender: 'g', attachments }) })],
+      700,
+    );
+    expect(captioned).toBe(
+      captioned.split('\n')[0] +
+        '\nReview this screenshot' +
+        '\n[image: screen.png — saved to /workspace/inbox/m1/screen.png]' +
+        '\n[file: notes.txt (https://example.invalid/notes.txt)]',
+    );
+    const bare = renderMailbox(
+      [row({ id: 'm2', content: JSON.stringify({ text: '', sender: 'g', attachments: [attachments[0]] }) })],
+      700,
+    );
+    expect(bare.split('\n')).toHaveLength(2);
+    expect(bare).toEndWith('[image: screen.png — saved to /workspace/inbox/m1/screen.png]');
+    // The preview budget applies to the text alone; the attachment lines survive a truncated caption.
+    const long = renderMailbox(
+      [
+        row({
+          id: 'm3',
+          content: JSON.stringify({ text: 'x'.repeat(800), sender: 'g', attachments: [attachments[0]] }),
+        }),
+      ],
+      700,
+    );
+    expect(long).toContain('truncated — full text: ncl inbox read --id m3');
+    expect(long).toEndWith('[image: screen.png — saved to /workspace/inbox/m1/screen.png]');
+  });
+
+  it('renders a prompt-only task row task-shaped, timed by process_after', async () => {
+    const processAfter = '2026-08-16T09:30:00.000Z';
+    const rendered = renderMailbox(
+      [
+        row({
+          id: 't1',
+          kind: 'task',
+          process_after: processAfter,
+          content: JSON.stringify({ prompt: 'check the deploy', script: 'echo hi', originSessionId: 'sess-1' }),
+        }),
+      ],
+      700,
+    );
+    expect(rendered).toContain(`[nanoclaw task · ${formatLocalTime(processAfter, TIMEZONE)}]`);
+    expect(rendered).toContain('Instructions: check the deploy');
+    // Task-shaped, never the raw JSON blob under an 'unknown' mail header.
+    expect(rendered).not.toContain('unknown');
+    expect(rendered).not.toContain('originSessionId');
+    expect(rendered).not.toContain('Script output:');
+  });
+
+  it("surfaces a task's stored scriptOutput before the instructions", async () => {
+    const rendered = renderMailbox(
+      [
+        row({
+          id: 't2',
+          kind: 'task',
+          content: JSON.stringify({ prompt: 'report on it', scriptOutput: { ok: true, count: 3 } }),
+        }),
+      ],
+      700,
+    );
+    expect(rendered).toContain(`Script output: ${JSON.stringify({ ok: true, count: 3 })}`);
+    expect(rendered.indexOf('Script output:')).toBeLessThan(rendered.indexOf('Instructions: report on it'));
+  });
+
+  it('strips the legacy persisted task contract from prompts', async () => {
+    const rendered = renderMailbox(
+      [
+        row({
+          id: 't3',
+          kind: 'task',
+          content: JSON.stringify({ prompt: 'water the plants\n\n[Task delivery contract: legacy generated suffix]' }),
+        }),
+      ],
+      700,
+    );
+    expect(rendered).toContain('Instructions: water the plants');
+    expect(rendered).not.toContain('Task delivery contract');
+  });
+
+  it('truncates long task bodies into previews like mail', async () => {
+    const rendered = renderMailbox(
+      [row({ id: 't4', kind: 'task', content: JSON.stringify({ prompt: 'y'.repeat(900) }) })],
+      700,
+    );
+    expect(rendered).toContain('truncated — full text: ncl inbox read --id t4');
+    expect(rendered).not.toContain('y'.repeat(701));
+  });
+});
+
+describe('task delivery', () => {
+  it('injects a kind=task row task-shaped, not as raw JSON', async () => {
+    stampState('idle');
+    seedInbound('t1', {
+      kind: 'task',
+      content: JSON.stringify({ prompt: 'run the nightly checks', script: '', originSessionId: 'sess-9' }),
+    });
+    const l = loop();
+    await l.tick();
+    expect(session.text).toContain('[nanoclaw task · ');
+    expect(session.text).toContain('Instructions: run the nightly checks');
+    expect(session.text).not.toContain('originSessionId');
+    stampState('busy', now + 50);
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 't1', status: 'completed' }]);
+  });
+});
+
+describe('lastInjectionAt', () => {
+  it('is 0 before any delivery and stamps the injection time after (liveness input)', async () => {
+    stampState('idle');
+    const l = loop();
+    expect(l.lastInjectionAt).toBe(0);
+    await l.tick(); // empty tick — no injection, no stamp
+    expect(l.lastInjectionAt).toBe(0);
+
+    seedInbound('m1');
+    now += 5_000;
+    await l.tick();
+    expect(l.lastInjectionAt).toBe(now);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The inject-ack state machine (characterized in testing): completed is
+// earned by the TUI's own hook evidence, never assumed on the write.
+
+describe('inject-ack state machine', () => {
+  /** The bracketed-paste injections among the raw PTY writes. */
+  function pastes(): string[] {
+    return session.written.filter((w) => w.startsWith('\x1b[200~'));
+  }
+  /** The bare-CR re-nudges among the raw PTY writes. */
+  function nudges(): string[] {
+    return session.written.filter((w) => w === '\r');
+  }
+
+  it("acks on a busy stamp strictly newer than the injection — the gating stamp's tie never acks", async () => {
+    stampState('idle'); // at == the injection's own millisecond (fake clock)
+    seedInbound('m1');
+    const l = loop();
+    await l.tick(); // inject
+    await l.tick(); // same stamp, same millisecond — the tie must NOT auto-ack
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'processing' }]);
+
+    stampState('busy', now + 1); // strictly newer — the submit's evidence
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+  });
+
+  it('accepts a same-life idle stamp newer than the injection (whole turn inside the poll gap) — no duplicate', async () => {
+    stampState('idle');
+    seedInbound('m1');
+    const l = loop();
+    await l.tick(); // inject
+    stampState('idle', now + 500); // Stop hook: the turn ran and finished between polls
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+    expect(pastes()).toHaveLength(1); // treated as a miss it would have re-delivered
+  });
+
+  it('re-nudges with exactly one bare CR when no transition lands inside the ack window', async () => {
+    stampState('idle');
+    seedInbound('m1');
+    const l = loop();
+    await l.tick(); // inject
+    now += ACK_WINDOW_MS;
+    await l.tick();
+    expect(nudges()).toHaveLength(1);
+    expect(session.written).toHaveLength(2); // the paste, then the bare CR — nothing else
+    await l.tick(); // inside the nudge window: no second nudge, no re-claim
+    expect(nudges()).toHaveLength(1);
+  });
+
+  it('releases the claim after the nudge window, re-injects next tick, and the on_wake row survives', async () => {
+    stampState('idle');
+    seedInbound('wk', { onWake: 1, trigger: 1, text: 'restart mail' });
+    const l = loop();
+    await l.tick(); // inject (first poll — the only poll that can see on_wake)
+    expect(ackRows()).toEqual([{ message_id: 'wk', status: 'processing' }]);
+
+    now += ACK_WINDOW_MS;
+    await l.tick(); // nudge
+    now += NUDGE_WINDOW_MS;
+    await l.tick(); // still nothing — claim released for retry
+    expect(ackRows()).toEqual([]);
+
+    await l.tick(); // next tick re-claims: firstPoll stayed armed, on_wake row still visible
+    expect(pastes()).toHaveLength(2);
+    expect(session.text.split('restart mail')).toHaveLength(3);
+
+    stampState('busy', now + 50);
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'wk', status: 'completed' }]);
+  });
+
+  it('fail-open delivery (broken hooks) keeps ack-on-write — no wait, no nudge, no retry loop', async () => {
+    seedInbound('m1');
+    const l = loop();
+    now += READY_FALLBACK_MS + 1;
+    await l.tick(); // no state file ever — fail open
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+    now += ACK_WINDOW_MS + NUDGE_WINDOW_MS;
+    await l.tick();
+    await l.tick();
+    expect(session.written).toHaveLength(1); // the paste — never a nudge
+  });
+
+  it('stale-busy-ceiling delivery keeps ack-on-write — its hooks stopped reporting', async () => {
+    stampState('busy');
+    seedInbound('m1');
+    const l = loop();
+    now += BUSY_STALE_MS + 1;
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+    expect(session.written).toHaveLength(1);
+  });
+
+  it('a respawn mid-wait releases the claim — the injection died with the old life, never ack', async () => {
+    stampState('idle');
+    seedInbound('m1');
+    const l = loop();
+    await l.tick(); // inject into life 1
+    session.lastSpawnAt = now + 5_000; // life 1 died; life 2 spawns
+    now += 5_000;
+    await l.tick();
+    expect(ackRows()).toEqual([]); // released, not acked — life 2 never saw the paste
+
+    // Life 2's own SessionStart→idle gates the retry as any fresh life.
+    now += 1_000;
+    stampState('idle');
+    await l.tick();
+    expect(pastes()).toHaveLength(2);
+    stampState('busy', now + 50);
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+  });
+
+  it('holds the re-nudge while an operator is mid-composition, nudges once the hold clears', async () => {
+    stampState('idle');
+    seedInbound('m1');
+    let typedAt = 0;
+    const l = loop({ lastOperatorInputAt: () => typedAt });
+    await l.tick(); // inject
+    typedAt = now + 1_000; // operator starts typing during the ack wait
+    now += ACK_WINDOW_MS + 1_500;
+    await l.tick();
+    expect(nudges()).toHaveLength(0); // a nudge now would submit their half-typed prompt
+
+    now = typedAt + COMPOSE_HOLD_MS;
+    await l.tick();
+    expect(nudges()).toHaveLength(1); // hold cleared — the deferred nudge lands
+  });
+
+  it('a compose hold can never starve the claim past the host SLA — released un-nudged at the ceiling', async () => {
+    stampState('idle');
+    seedInbound('m1');
+    let typedAt = 0;
+    const l = loop({ lastOperatorInputAt: () => typedAt });
+    await l.tick(); // inject
+    const injectedAt = now;
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'processing' }]);
+
+    // The operator types continuously with gaps under COMPOSE_HOLD_MS: the
+    // nudge can never fire, and before HOLD_RELEASE_MS existed nothing else
+    // could either — the 'processing' claim froze until the host's 60s
+    // claim-stuck kill landed on the live attach.
+    while (now - injectedAt < HOLD_RELEASE_MS) {
+      typedAt = now;
+      now += COMPOSE_HOLD_MS / 2;
+      await l.tick();
+    }
+    expect(nudges()).toHaveLength(0); // never submitted over their composition
+    expect(ackRows()).toEqual([]); // released at the ceiling — half the 60s SLA
+
+    // Still typing: nothing is re-claimed over them (claim age stays 0)...
+    typedAt = now;
+    await l.tick();
+    expect(ackRows()).toEqual([]);
+    expect(pastes()).toHaveLength(1);
+
+    // ...until they pause — the normal retry path re-claims, and the TUI's
+    // own evidence completes it.
+    now += COMPOSE_HOLD_MS;
+    await l.tick();
+    expect(pastes()).toHaveLength(2);
+    stampState('busy', now + 50);
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+  });
+
+  it("the attempt cap is per MESSAGE ID — new mail riding a re-claim never resets a message's count", async () => {
+    // Binding verdict #4's distinguishing scenario: a per-BATCH key would
+    // reset the counter the moment m2 changes the batch's composition, and
+    // m1 would be re-claimed forever.
+    stampState('idle');
+    seedInbound('m1');
+    const l = loop();
+    for (let attempt = 1; attempt < MAX_INJECT_ATTEMPTS; attempt++) {
+      await l.tick(); // (re-)claim + inject m1 alone
+      now += ACK_WINDOW_MS;
+      await l.tick(); // nudge
+      now += NUDGE_WINDOW_MS;
+      await l.tick(); // attempt spent — claim released
+    }
+    expect(pastes()).toHaveLength(MAX_INJECT_ATTEMPTS - 1);
+    expect(ackRows()).toEqual([]);
+
+    seedInbound('m2', { text: 'rider mail' });
+    await l.tick(); // m1's final attempt — with m2 riding along
+    const last = pastes()[MAX_INJECT_ATTEMPTS - 1];
+    expect(pastes()).toHaveLength(MAX_INJECT_ATTEMPTS);
+    expect(last).toContain('text of m1');
+    expect(last).toContain('rider mail');
+
+    now += ACK_WINDOW_MS;
+    await l.tick(); // nudge
+    now += NUDGE_WINDOW_MS;
+    await l.tick(); // m1 hit the per-id cap — the changed batch must NOT reset it
+    expect(ackRows().sort((a, b) => a.message_id.localeCompare(b.message_id))).toEqual([
+      { message_id: 'm1', status: 'processing' },
+      { message_id: 'm2', status: 'processing' },
+    ]);
+    const writes = session.written.length;
+    await l.tick();
+    await l.tick();
+    expect(session.written).toHaveLength(writes); // escalated: claiming stopped for good
+  });
+
+  it("stops re-claiming at the per-id attempt cap and leaves the claim to the host's claim-stuck SLA", async () => {
+    stampState('idle');
+    seedInbound('m1');
+    const l = loop();
+    for (let attempt = 1; attempt <= MAX_INJECT_ATTEMPTS; attempt++) {
+      await l.tick(); // (re-)claim + inject
+      expect(pastes()).toHaveLength(attempt);
+      now += ACK_WINDOW_MS;
+      await l.tick(); // nudge
+      now += NUDGE_WINDOW_MS;
+      await l.tick(); // attempt spent: release — or, at the cap, escalate
+    }
+    // Escalated: the LAST claim stays 'processing' unrefreshed so the host's
+    // 60s claim-stuck kill recycles the container (tries/backoff/MAX_TRIES).
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'processing' }]);
+    const writes = session.written.length;
+    await l.tick();
+    await l.tick();
+    expect(session.written).toHaveLength(writes); // claiming stopped for good
+  });
+});
+
+describe('channel transport ', () => {
+  function spoolDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-mailbox-spool-'));
+  }
+  function spoolFiles(dir: string): string[] {
+    return fs
+      .readdirSync(dir)
+      .filter((n) => n.endsWith('.json'))
+      .sort();
+  }
+
+  it('spools instead of typing; the ack discipline is unchanged', async () => {
+    const dir = spoolDir();
+    stampState('idle');
+    seedInbound('m1', { text: 'ship the driver', sender: 'alice' });
+    const l = loop({ channelSpoolDir: dir });
+    await l.tick();
+
+    // Nothing touches the terminal — the channel owns injection mechanics.
+    expect(session.text).toBe('');
+    const files = spoolFiles(dir);
+    expect(files).toHaveLength(1);
+    const entry = JSON.parse(fs.readFileSync(path.join(dir, files[0]), 'utf8'));
+    expect(entry.content).toContain('ship the driver');
+    expect(entry.meta).toEqual({ ids: 'm1', batch: '1' });
+    // The spool write earns only the claim; completion still needs hook evidence.
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'processing' }]);
+
+    stampState('busy', now + 50);
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+  });
+
+  it('the nudge is a no-op write but the windows still run: no evidence releases and re-spools', async () => {
+    const dir = spoolDir();
+    stampState('idle');
+    seedInbound('m1');
+    const l = loop({ channelSpoolDir: dir });
+    await l.tick();
+    expect(spoolFiles(dir)).toHaveLength(1);
+
+    // Ack window expires with no evidence → the "nudge" stamps without any
+    // terminal write (there is no composer on this transport).
+    now += ACK_WINDOW_MS + 1;
+    await l.tick();
+    expect(session.text).toBe('');
+    expect(spoolFiles(dir)).toHaveLength(1); // nudge never re-spools
+
+    // Nudge window expires too → the claim is released, exactly as on the
+    // typing transport. (What the RETRY looks like is the availability
+    // fallback's subject — silence on a channel means the events are going
+    // nowhere, so the next attempt types instead of re-spooling.)
+    now += NUDGE_WINDOW_MS + 1;
+    await l.tick();
+    expect(ackRows()).toEqual([]);
+  });
+});
+
+describe('channel availability fallback (verified live: 2.1.238 answers "Channels are not currently available" while the server emits into the void)', () => {
+  it('an unacked channel delivery downgrades the session to typing, purges the spool, and redelivers', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-mailbox-spool-'));
+    stampState('idle');
+    seedInbound('m1', { text: 'still gets through' });
+    const l = loop({ channelSpoolDir: dir });
+
+    await l.tick(); // spooled, nothing typed
+    expect(session.text).toBe('');
+    expect(l.channelFellBack).toBe(false);
+
+    // No hook evidence ever arrives — the client dropped the event silently.
+    now += ACK_WINDOW_MS + 1;
+    await l.tick(); // "nudge" (no-op on this transport)
+    now += NUDGE_WINDOW_MS + 1;
+    await l.tick(); // release + downgrade
+
+    expect(l.channelFellBack).toBe(true);
+    expect(ackRows()).toEqual([]);
+    // The spool is purged: no entry left for a server that will never read it.
+    expect(fs.readdirSync(dir).filter((n) => n.endsWith('.json'))).toEqual([]);
+
+    // The redelivery is TYPED — mail reaches the agent despite channels being
+    // unavailable, which is the whole point of the durable contract.
+    await l.tick();
+    expect(session.text).toContain('\x1b[200~');
+    expect(session.text).toContain('still gets through');
+    stampState('busy', now + 50);
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+  });
+
+  it('stays on channels when deliveries ack — one failure is what downgrades, not configuration', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-mailbox-spool-'));
+    stampState('idle');
+    seedInbound('m1');
+    const l = loop({ channelSpoolDir: dir });
+    await l.tick();
+    stampState('busy', now + 50);
+    await l.tick();
+    expect(l.channelFellBack).toBe(false);
+
+    seedInbound('m2');
+    stampState('idle', now + 100);
+    now += 200;
+    await l.tick();
+    expect(session.text).toBe(''); // still spooling, never typing
+  });
+});
+
+describe("mail notice (the busy-path notify's input)", () => {
+  it('publishes the waiting sequences on every tick — especially the busy ones the hook exists for', async () => {
+    // Busy is exactly when deliver() returns before it would ever look at
+    // the mailbox, and exactly when the PostToolUse hook needs an answer.
+    stampState('busy');
+    seedInbound('m1', { seq: 2 });
+    seedInbound('m2', { seq: 4 });
+    const l = loop();
+    await l.tick();
+    expect(session.text).toBe(''); // nothing injected — the turn is untouched
+    expect(readMailNotice(noticePath)?.seqs).toEqual([2, 4]);
+  });
+
+  it('publishes only what the hook may announce: no system envelopes, no context-only rows, no claimed mail', async () => {
+    stampState('busy');
+    seedInbound('sys', { kind: 'system', seq: 2 });
+    seedInbound('ctx', { trigger: 0, seq: 4 });
+    seedInbound('mail', { seq: 6 });
+    const l = loop();
+    await l.tick();
+    expect(readMailNotice(noticePath)?.seqs).toEqual([6]);
+
+    // Once the loop claims it, it is no longer news — and the stamp is
+    // published AFTER delivery, so the claiming tick already says so.
+    stampState('idle');
+    await l.tick();
+    expect(session.text).toContain('text of mail');
+    expect(readMailNotice(noticePath)?.seqs).toEqual([]);
+  });
+
+  it('delivers even when the notice write throws — the notify is a courtesy, delivery is the point', async () => {
+    // The stamp is a /tmp write and /tmp can be full, read-only, or (here)
+    // shadowed by a file where the dir must be: mkdirSync raises ENOTDIR.
+    // Before, this ran first inside tick()'s try and took the whole tick
+    // with it, so a broken notify silently stopped mail.
+    const blocker = path.join(path.dirname(noticePath), 'blocker');
+    fs.writeFileSync(blocker, 'not a directory');
+    const l = loop({ mailNoticePath: path.join(blocker, 'mail-notice.json') });
+
+    stampState('idle');
+    seedInbound('m1', { text: 'ship it anyway', seq: 2 });
+    await l.tick();
+    expect(session.text).toContain('ship it anyway');
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'processing' }]);
+
+    // And the ack half of the contract still completes on the next tick.
+    stampState('busy', now + 50);
+    await l.tick();
+    expect(ackRows()).toEqual([{ message_id: 'm1', status: 'completed' }]);
+  });
+
+  it('stamps the notice even when the tick itself fails', async () => {
+    // The other half of the isolation: a delivery that throws must not cost
+    // the hook its answer either.
+    stampState('busy');
+    seedInbound('m1', { seq: 2 });
+    const exploding: MailboxSession = {
+      write: () => {},
+      lastSpawnAt: 0,
+      get running(): boolean {
+        throw new Error('session probe blew up');
+      },
+    };
+    const l = loop({ session: exploding });
+    await l.tick(); // swallowed by tick()'s catch
+    expect(readMailNotice(noticePath)?.seqs).toEqual([2]);
+  });
+});

--- a/container/agent-runner/src/code-runner/mailbox.ts
+++ b/container/agent-runner/src/code-runner/mailbox.ts
@@ -1,0 +1,625 @@
+/**
+ * Mailbox delivery loop  — the code runner's inbound side.
+ *
+ * Watches the registered mailbox (`getAgentMailbox()` through the runner's
+ * db barrel — SQLite files by default, any other store the seam registers;
+ * this loop never learns which) and, when the interactive session is idle,
+ * TYPES pending messages into the PTY — the attached human literally sees
+ * the mail arrive. Busy turns are never interrupted: the PostToolUse hook
+ * notifies mid-turn, the Stop hook flips the state file to idle, and the
+ * next tick here delivers.
+ *
+ * Ack discipline is the chat runner's, reused 1:1 : claim with a
+ * 'processing' ack, ack 'completed' — never writing the inbound side.
+ * An unacked row keeps countDueMessages > 0 and the host re-wakes containers
+ * forever; a 'processing' claim older than ~60s gets the container killed.
+ * clearStaleProcessingAcks() at boot is the crash-recovery half of that
+ * contract; the mailbox interface's releaseProcessingClaims is the retry half.
+ *
+ * The COMPLETED ack is earned, not assumed (characterized in
+ * testing): typing paste+CR into a TUI that is not input-settled leaves
+ * the text in the composer unsubmitted, so acking on the write silently
+ * loses the submit. Instead the loop holds the claim as a cross-tick
+ * pending-ack and completes only on the hook-stamp evidence that the TUI
+ * actually took the input: a state stamp (busy = UserPromptSubmit, idle = a
+ * whole turn ran inside the poll gap) strictly newer than the injection, in
+ * the same child life. No transition within ACK_WINDOW_MS → one bare CR
+ * re-nudge; still nothing after NUDGE_WINDOW_MS → release the claim (delete
+ * the 'processing' row) so the next tick re-claims and re-injects. An
+ * operator compose hold defers the nudge but can never starve the claim:
+ * past HOLD_RELEASE_MS the claim is released un-nudged — releasing needs no
+ * PTY write, so it is safe mid-composition — keeping the claim's age far
+ * under the host's 60s claim-stuck SLA (which would otherwise kill the
+ * container out from under the attached operator). A message
+ * that fails MAX_INJECT_ATTEMPTS injections stops being re-claimed — its
+ * last 'processing' row is deliberately left to age past the host's
+ * claim-stuck SLA, whose kill + backoff + MAX_TRIES ceiling is the existing
+ * poison-message bound (a fresh boot is the contract's answer to a wedged
+ * TUI).
+ *
+ * Deliberately NOT here (chat composition): XML message wrapping,
+ * <message to> dispatch, auto-replies, re-wrap nudges. Replies are the
+ * agent's own explicit act via `ncl outbox send`.
+ */
+import fs from 'fs';
+
+import {
+  clearStaleProcessingAcks,
+  getPendingMessages,
+  markCompleted,
+  markProcessing,
+  releaseProcessingClaims,
+  type MessageInRow,
+} from '../db/index.js';
+import { markScriptSkipped } from '../db/messages-in.js';
+import { applyPreTaskScripts } from '../scheduling/task-script.js';
+import { stripLegacyTaskContract } from '../formatter.js';
+import { formatLocalTime, TIMEZONE } from '../timezone.js';
+import { describeAttachments, parseAttachments } from './attachments.js';
+import {
+  AGENT_STATE_PATH,
+  MAIL_NOTICE_PATH,
+  READY_FALLBACK_MS,
+  readAgentState,
+  writeMailNotice,
+} from './agent-state.js';
+import { listSpoolEntries, writeSpoolEntry } from './channel-spool.js';
+
+/** Implementation choice, not a locked decision: injected messages longer than this become previews. */
+const DEFAULT_PREVIEW_CHARS = 700;
+
+const DEFAULT_POLL_MS = 1_000;
+
+/** Mirrors poll-loop's corruption escape hatch: a poisoned store never recovers in-process. */
+const CORRUPTION_EXIT_THRESHOLD = 10;
+
+/**
+ * A 'busy' with no transition this long is a wedge (a turn interrupted with
+ * Esc fires no Stop hook), not a working turn: PreToolUse refreshes the
+ * stamp on every tool call, so legitimate long turns stay fresh. Mirrors
+ * the host's 30-min absolute ceiling — deliberately NOT shorter, because a
+ * permission-prompt wait fires no hooks either and must stay undisturbed.
+ */
+export const BUSY_STALE_MS = 30 * 60_000;
+
+/** Hold injection while an attached human typed recently — never submit someone's half-composed prompt. */
+export const COMPOSE_HOLD_MS = 10_000;
+
+/**
+ * How long after an injection to wait for the hook-stamp evidence of a
+ * submit before re-nudging with a bare CR. Testing saw the unsettled window at
+ * ~3s post-spawn; its ~19s outlier (unsettled long after turn-end with a
+ * live attach client) is deliberately under-covered. NOTE the true cost of
+ * under-coverage is DUPLICATE delivery, not merely a spent retry: each
+ * release re-pastes into the still-unsettled composer, so the eventual
+ * settle submits the accumulated copies at once — and a settle landing
+ * after the attempt-cap escalation leaves already-delivered mail
+ * 'processing' for the host recycle to redeliver whole in the fresh boot.
+ * A sanctioned duplicates-over-loss trade; tune from live observation,
+ * not by widening these windows toward the 60s SLA.
+ */
+export const ACK_WINDOW_MS = 3_000;
+
+/** How long after the CR re-nudge to wait before releasing the claim for retry. */
+export const NUDGE_WINDOW_MS = 3_000;
+
+/**
+ * Hard ceiling on a pending-ack that the operator compose hold keeps
+ * un-nudged. Without it, an attached operator typing with gaps under
+ * COMPOSE_HOLD_MS would defer the nudge forever, freeze the 'processing'
+ * claim past the host's claim-stuck SLA (CLAIM_STUCK_MS=60s), and the kill
+ * would land on the live attach — the exact interruption the hold exists
+ * to prevent. Releasing a claim needs no PTY write, so it runs safely
+ * mid-composition; half the SLA leaves the release + re-claim cycle ample
+ * headroom.
+ */
+export const HOLD_RELEASE_MS = 30_000;
+
+/**
+ * In-process injection ceiling PER MESSAGE ID (not per batch — batch
+ * composition changes when new mail rides along on a re-claim, and a
+ * shifting key would reset the counter). When any id in a batch hits the
+ * cap, the loop stops re-claiming and leaves the last 'processing' row
+ * unrefreshed: the host's claim-stuck SLA (~60s kill + tries/backoff/
+ * MAX_TRIES) recycles the container — the existing poison-message ceiling.
+ */
+export const MAX_INJECT_ATTEMPTS = 3;
+
+export interface MailboxSession {
+  write(data: string): void;
+  readonly running: boolean;
+  /** Spawn time of the current child life — readiness is per life, not per container. */
+  readonly lastSpawnAt: number;
+}
+
+export interface MailboxOptions {
+  session: MailboxSession;
+  stateFilePath?: string;
+  pollMs?: number;
+  previewChars?: number;
+  /** Epoch ms of the last operator keystroke reported by tmux, 0 if none. */
+  lastOperatorInputAt?: () => number;
+  now?: () => number;
+  /** Test seam: replaces process.exit on repeated corruption. */
+  onFatal?: (code: number) => void;
+  /**
+   * Channel transport : when set, deliveries
+   * are spooled for the nanoclaw-mailbox channel server instead of typed
+   * into the terminal, and the bare-CR re-nudge becomes a no-op (there is no
+   * composer to nudge). EVERYTHING else — claims, hook-evidence acks, the
+   * windows, compose holds, attempt caps — runs identically: the state
+   * machine is transport-independent by design, and channels give no
+   * delivery signal of their own (silent drop when unloaded/org-blocked),
+   * so the contract here is still what makes delivery trustworthy.
+   */
+  channelSpoolDir?: string;
+  /** Where the busy-notify stamp lands for the PostToolUse hook to read. */
+  mailNoticePath?: string;
+}
+
+/** A delivered-but-unacked injection, carried across ticks (never an in-tick sleep). */
+interface PendingAck {
+  ids: string[];
+  /** now() at the moment of the paste+CR write — the ack must postdate this strictly. */
+  injectedAt: number;
+  /** session.lastSpawnAt at injection: a respawn mid-wait means the injection died with the old life. */
+  lifeSpawnAt: number;
+  /** now() when the bare-CR re-nudge was written; null until then. */
+  nudgedAt: number | null;
+  /** This delivery went out over the channel transport (no composer to nudge). */
+  viaChannel: boolean;
+}
+
+interface ParsedContent {
+  text?: string;
+  sender?: string;
+  author?: { fullName?: string; userName?: string };
+  prompt?: string;
+  scriptOutput?: unknown;
+  attachments?: unknown;
+}
+
+function parseContent(raw: string): ParsedContent {
+  try {
+    const parsed = JSON.parse(raw) as ParsedContent;
+    return typeof parsed === 'object' && parsed !== null ? parsed : { text: raw };
+  } catch {
+    return { text: raw };
+  }
+}
+
+function isCorruptionError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /malformed|corrupt/i.test(msg);
+}
+
+/**
+ * Inbound mail is attacker-controlled input being TYPED INTO A TERMINAL.
+ * A message containing the literal bracketed-paste-end sequence would
+ * escape the paste wrapper and deliver raw keystrokes (including Enter) to
+ * the TUI. Strip every C0 control except newline and tab (CR becomes LF),
+ * plus ESC and DEL — mail is text, not key sequences.
+ */
+export function sanitizeForTerminal(s: string): string {
+  return s.replace(/\r\n?/g, '\n').replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '');
+}
+
+export function renderMailbox(messages: MessageInRow[], previewChars: number): string {
+  const blocks = messages.map((msg) => {
+    const content = parseContent(msg.content);
+    let header: string;
+    let text: string;
+    if (msg.kind === 'task') {
+      // Deliberate minimal duplicate of the chat runner's formatTaskMessage:
+      // that function is module-private and stays that way (never amend
+      // chat-runner code to enable reuse here). scriptOutput arrives from the
+      // delivery-time pre-task script run, exactly as on the chat side.
+      header = `[nanoclaw task · ${formatLocalTime(msg.process_after ?? msg.timestamp, TIMEZONE)}]`;
+      text =
+        (content.scriptOutput ? `Script output: ${JSON.stringify(content.scriptOutput)}\n` : '') +
+        `Instructions: ${stripLegacyTaskContract(content.prompt ?? '')}`;
+    } else {
+      const sender = content.sender || content.author?.fullName || content.author?.userName || 'unknown';
+      header = `[nanoclaw mail · ${sender} · ${formatLocalTime(msg.timestamp, TIMEZONE)}]`;
+      text = content.text ?? msg.content;
+    }
+    const body =
+      text.length > previewChars
+        ? `${text.slice(0, previewChars)}\n… [truncated — full text: ncl inbox read --id ${msg.id}]`
+        : text;
+    // Attachments follow the text, outside the preview budget: a file the
+    // host staged is part of the message whether or not there was a caption.
+    const attachments = describeAttachments(parseAttachments(content));
+    return [header, ...(body ? [body] : []), ...attachments].join('\n');
+  });
+  return blocks.join('\n\n');
+}
+
+export class MailboxDeliveryLoop {
+  private readonly opts: Required<Omit<MailboxOptions, 'session' | 'channelSpoolDir'>> & {
+    session: MailboxSession;
+    channelSpoolDir?: string;
+  };
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private firstPoll = true;
+  private readonly bootAt: number;
+  private fallbackLoggedForLife = -1;
+  private staleBusyLogged = false;
+  private corruptionStreak = 0;
+  private injectionAt = 0;
+  private delivering = false;
+  private pendingAck: PendingAck | null = null;
+  /** In-process injection attempts per MESSAGE ID (see MAX_INJECT_ATTEMPTS). */
+  private readonly attempts = new Map<string, number>();
+  /** Set when a message hit the attempt cap — the loop stops claiming and waits for the host's kill. */
+  private escalated = false;
+  /**
+   * Set when a channel-transport delivery went unacked: channels are
+   * unavailable in this session (org policy, client version, or an
+   * unregistered plugin all present identically — the client drops events
+   * with no error to the server, VERIFIED live on 2.1.238: "Channels are not
+   * currently available" while our server emitted happily into the void).
+   * Availability is therefore not knowable at config time, so the fallback
+   * is dynamic: downgrade this session to the typing transport permanently
+   * and let the released claim redeliver. One wasted ack window, no lost
+   * mail, no churn — the decision note's "channels where available,
+   * send-keys where not" resolved at runtime instead of by configuration.
+   */
+  private channelDowngraded = false;
+
+  constructor(options: MailboxOptions) {
+    this.opts = {
+      stateFilePath: AGENT_STATE_PATH,
+      mailNoticePath: MAIL_NOTICE_PATH,
+      pollMs: DEFAULT_POLL_MS,
+      previewChars: DEFAULT_PREVIEW_CHARS,
+      lastOperatorInputAt: () => 0,
+      now: () => Date.now(),
+      onFatal: (code) => process.exit(code),
+      ...options,
+    };
+    this.bootAt = this.opts.now();
+  }
+
+  /** Epoch ms of the last injection (0 before the first) — a liveness input. */
+  get lastInjectionAt(): number {
+    return this.injectionAt;
+  }
+
+  /** Channel transport configured AND not yet proven unavailable. */
+  private get channelTransportLive(): boolean {
+    return this.opts.channelSpoolDir !== undefined && !this.channelDowngraded;
+  }
+
+  /** True once a channel delivery went unacked and the loop fell back to typing. */
+  get channelFellBack(): boolean {
+    return this.channelDowngraded;
+  }
+
+  /** Drop spool entries the channel server never emitted, so a downgrade
+   * cannot leave a duplicate waiting for a server that will never read it. */
+  private purgeSpool(): void {
+    const dir = this.opts.channelSpoolDir;
+    if (!dir) return;
+    for (const file of listSpoolEntries(dir)) {
+      try {
+        fs.unlinkSync(file);
+      } catch {
+        // already emitted; nothing to purge
+      }
+    }
+  }
+
+  start(): void {
+    // Crash-recovery contract: a dead predecessor's 'processing' claims
+    // would otherwise hide those messages from us forever.
+    clearStaleProcessingAcks();
+    this.timer = setInterval(() => this.tick(), this.opts.pollMs);
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  /**
+   * One poll — exposed for tests (await it); production runs it on the
+   * interval. Re-entrancy-guarded: a pre-task script can hold a delivery
+   * across many interval fires, and an overlapping deliver would double-claim
+   * the same batch.
+   */
+  async tick(): Promise<void> {
+    if (this.delivering) return;
+    this.delivering = true;
+    try {
+      await this.deliver();
+      this.corruptionStreak = 0;
+    } catch (error) {
+      if (isCorruptionError(error)) {
+        this.corruptionStreak++;
+        if (this.corruptionStreak >= CORRUPTION_EXIT_THRESHOLD) {
+          console.error('[code-runner] repeated SQLite corruption — exiting for a fresh mount');
+          this.opts.onFatal(75);
+        }
+      }
+      console.error('[code-runner] mailbox tick failed:', error);
+    } finally {
+      // AFTER delivery, and outside its failure path on purpose — see
+      // publishMailNotice. Delivery is the point; the notify is a courtesy.
+      this.publishMailNotice();
+      this.delivering = false;
+    }
+  }
+
+  /**
+   * Stamp what is waiting, for the PostToolUse hook's mid-turn notify.
+   *
+   * The hook is a claude subprocess that fires on EVERY tool call, so it
+   * must not open the mailbox itself: with SQLite files that was two cheap
+   * local reads, but the seam's transport can be an object store, where a
+   * per-tool-call mailbox open is a full listing over the network. So the
+   * process that already holds a live mailbox and already polls every
+   * second publishes the answer instead, and the hook reads one local file
+   * — the same hook↔runner file vocabulary the idle/busy state already
+   * uses, in the other direction. Sole writer here; hooks only ever read.
+   *
+   * Runs on EVERY tick, past every readiness gate, because the notify exists
+   * precisely for the busy turns deliver() returns early from. The filter is
+   * the hook's own: due, wake-eligible, non-system mail nobody has claimed.
+   * Sequences (not a count) so the hook keeps its high-water dedupe; rows
+   * with no sequence are unaddressable by that mark and skipped, exactly as
+   * the hook's `seq > ?` predicate skipped them.
+   *
+   * A NOTIFY MUST NEVER COST A DELIVERY. Two rules keep that true, and both
+   * are load-bearing:
+   *
+   * - It runs in tick()'s `finally`, AFTER deliver(). The stamp is one
+   *   `/tmp` write, and /tmp can be full, read-only or mode-broken; ahead of
+   *   deliver() an ENOSPC would abort the tick before a single message
+   *   moved. Behind it, the same failure costs one mid-turn nudge and
+   *   nothing else. It also makes the stamp truthful: mail deliver() just
+   *   claimed is no longer news, so the agent is not told about the mail it
+   *   was handed a millisecond ago.
+   * - It swallows its own errors. `finally` re-throws, and the mailbox read
+   *   here can fail too — so nothing from this method leaves it. The
+   *   corruption ladder stays deliver()'s, which is the read that matters.
+   */
+  private publishMailNotice(): void {
+    try {
+      const seqs = getPendingMessages(false)
+        .filter((m) => m.kind !== 'system' && m.trigger === 1 && typeof m.seq === 'number')
+        .map((m) => m.seq as number);
+      writeMailNotice({ seqs }, this.opts.mailNoticePath);
+    } catch (error) {
+      console.error('[code-runner] mail notice not stamped — the mid-turn notify is skipped, delivery is not:', error);
+    }
+  }
+
+  /**
+   * Resolve an outstanding pending-ack. MUST run before the readiness gates:
+   * after a successful injection the state file reads 'busy' — which IS the
+   * ack signal — and the busy early-return would skip the code that records
+   * it; the compose-hold return would likewise block ack processing whenever
+   * an attached operator types during the wait.
+   *
+   * Returns true when the pending-ack resolved to a completed ack and
+   * deliver() may fall through to normal gating; false when deliver() must
+   * stop here this tick (still waiting, nudged, released, or escalated —
+   * a released claim is re-claimed on the NEXT tick, never this one).
+   */
+  private resolvePendingAck(): boolean {
+    const pending = this.pendingAck!;
+    const now = this.opts.now();
+
+    // Respawn mid-wait: the injection died with the old life — release the
+    // claim for retry, never ack on a life that cannot have submitted it.
+    if (this.opts.session.lastSpawnAt !== pending.lifeSpawnAt) {
+      releaseProcessingClaims(pending.ids);
+      this.pendingAck = null;
+      console.error('[code-runner] claude respawned before the injection acked — claim released for retry');
+      return false;
+    }
+
+    // The ack: a hook stamp STRICTLY newer than the injection, same life.
+    // 'busy' is UserPromptSubmit — the CR submitted; 'idle' is a Stop from a
+    // turn that started AND finished inside the polling gap — treating it as
+    // a miss would re-deliver already-processed mail. Strictly newer, not
+    // >=: the PRE-injection gating idle stamp can share the injection's
+    // millisecond (deterministic under the fake clock) and must never ack.
+    const state = readAgentState(this.opts.stateFilePath);
+    if (state !== null && Date.parse(state.at) > pending.injectedAt) {
+      markCompleted(pending.ids);
+      for (const id of pending.ids) this.attempts.delete(id);
+      this.pendingAck = null;
+      this.firstPoll = false; // delivery proven — safe to retire the on_wake window
+      return true;
+    }
+
+    // No evidence yet. First give the TUI ACK_WINDOW_MS, then one bare-CR
+    // re-nudge (the failure shape: paste landed in the composer, the CR
+    // didn't submit — a second CR submits it).
+    if (pending.nudgedAt === null) {
+      if (now - pending.injectedAt < ACK_WINDOW_MS) return false;
+      // Never submit over a human mid-keystroke: an attached operator's
+      // composer text would ride our '\r'. Extend the wait, don't nudge —
+      // but never past HOLD_RELEASE_MS: a compose hold must not starve this
+      // state machine into the host's 60s claim-stuck kill. Releasing needs
+      // no PTY write, so it runs even mid-composition; deliver()'s own
+      // compose hold then defers the re-claim until the operator pauses.
+      // Deliberately NO cap check here — escalation leaves a claim to die,
+      // which must never happen because a human was typing (the cap still
+      // binds on the next post-nudge failure).
+      const lastTyped = this.opts.lastOperatorInputAt();
+      if (lastTyped > 0 && now - lastTyped < COMPOSE_HOLD_MS) {
+        if (now - pending.injectedAt < HOLD_RELEASE_MS) return false;
+        releaseProcessingClaims(pending.ids);
+        this.pendingAck = null;
+        // firstPoll stays armed: on_wake rows must survive to the re-fetch.
+        console.error(
+          '[code-runner] operator compose hold outlasted the ack wait — claim released, un-nudged, before the claim-stuck SLA',
+        );
+        return false;
+      }
+      // The CR re-nudge is paste mechanics — on the channel transport it is
+      // a no-op, but it still STAMPS: the state machine's windows and caps
+      // run identically on both transports (the same suite covers them once),
+      // and the channel's "nudge" grace is simply more time for the queued
+      // notification's turn to start.
+      if (!pending.viaChannel) this.opts.session.write('\r');
+      pending.nudgedAt = now;
+      return false;
+    }
+
+    if (now - pending.nudgedAt < NUDGE_WINDOW_MS) return false;
+
+    // Nudge failed too — this attempt is spent. At the per-id cap: stop
+    // re-claiming and leave the 'processing' rows to age into the host's
+    // claim-stuck SLA (kill + tries/backoff/MAX_TRIES) — the existing
+    // poison-message ceiling; a fresh boot heals a wedged TUI.
+    if (pending.ids.some((id) => (this.attempts.get(id) ?? 0) >= MAX_INJECT_ATTEMPTS)) {
+      this.escalated = true;
+      this.pendingAck = null;
+      console.error(
+        `[code-runner] injection unacked after ${MAX_INJECT_ATTEMPTS} attempts — leaving claim for the host's claim-stuck recycle`,
+      );
+      return false;
+    }
+    // A channel delivery that never acked means the events are going
+    // nowhere — the client acknowledges nothing, so this silence IS the
+    // availability signal. Downgrade permanently and let the release below
+    // redeliver by typing.
+    if (pending.viaChannel && !this.channelDowngraded) {
+      this.channelDowngraded = true;
+      this.purgeSpool();
+      console.error(
+        '[code-runner] channel delivery went unacked — channels are unavailable in this session ' +
+          '(org policy, client version, or unregistered plugin); falling back to the typing transport for good',
+      );
+    }
+    releaseProcessingClaims(pending.ids);
+    this.pendingAck = null;
+    // firstPoll stays armed: on_wake rows must survive to the re-fetch.
+    console.error('[code-runner] injection never acked (no hook transition) — claim released, next tick retries');
+    return false;
+  }
+
+  private async deliver(): Promise<void> {
+    if (this.escalated) return;
+
+    // Pending-ack resolution runs BEFORE every gate, the running gate
+    // included — see resolvePendingAck: a claim whose session died must be
+    // released for retry even while the session is down, or it sits at
+    // 'processing' until the host's claim-stuck sweep recycles the container.
+    // While one is outstanding, nothing new is claimed.
+    if (this.pendingAck !== null && !this.resolvePendingAck()) return;
+    if (!this.opts.session.running) return;
+
+    // Readiness is PER CHILD LIFE: the code runner deletes the state file on
+    // every claude spawn (respawns included), so a fresh life holds until
+    // its own SessionStart hook fires. A state stamp predating the current
+    // spawn is a dead life's leftover — same as no state at all.
+    const lifeStart = Math.max(this.bootAt, this.opts.session.lastSpawnAt);
+    let state = readAgentState(this.opts.stateFilePath);
+    if (state !== null && Date.parse(state.at) < lifeStart) state = null;
+
+    // The two degraded paths where the busy signal can never come keep
+    // ack-on-write semantics: fail-open means hooks are broken (an ack wait
+    // would turn "mail moves with jank" into "mail never completes"), and a
+    // stale-busy delivery is typed over a wedged turn whose hooks stopped
+    // reporting.
+    let ackOnWrite = false;
+
+    if (state === null) {
+      // No hook has fired in THIS life. Early: wait. Long after: hooks are
+      // broken (e.g. corrupt settings.json) — fail open so mail still moves.
+      if (this.opts.now() - lifeStart < READY_FALLBACK_MS) return;
+      if (this.fallbackLoggedForLife !== lifeStart) {
+        this.fallbackLoggedForLife = lifeStart;
+        console.error('[code-runner] no hook state after 60s — assuming idle (are the mailbox hooks registered?)');
+      }
+      ackOnWrite = true;
+    } else if (state.state === 'busy') {
+      // An interrupted turn (Esc) fires no Stop hook — give 'busy' the same
+      // staleness ceiling the host gives claims, or mail wedges forever.
+      if (this.opts.now() - Date.parse(state.at) < BUSY_STALE_MS) return;
+      if (!this.staleBusyLogged) {
+        this.staleBusyLogged = true;
+        console.error('[code-runner] busy state stale past 30min — treating as idle');
+      }
+      ackOnWrite = true;
+    } else {
+      this.staleBusyLogged = false;
+    }
+
+    // Never submit over a human mid-keystroke: an attached operator's
+    // composer text would ride our '\r'.
+    const lastTyped = this.opts.lastOperatorInputAt();
+    if (lastTyped > 0 && this.opts.now() - lastTyped < COMPOSE_HOLD_MS) return;
+
+    const isFirstPoll = this.firstPoll;
+    const batch = getPendingMessages(isFirstPoll).filter((m) => m.kind !== 'system');
+    if (batch.length === 0) {
+      // Nothing pending at all — safe to retire the on_wake window.
+      this.firstPoll = false;
+      return;
+    }
+
+    // Accumulate contract: trigger=0 rows are context-only; they ride along
+    // with the next trigger=1 arrival, never engage the agent on their own.
+    // Keep firstPoll armed — the skipped batch may hold on_wake rows that
+    // only an isFirstPoll fetch can see again.
+    if (!batch.some((m) => m.trigger === 1)) return;
+
+    const ids = batch.map((m) => m.id);
+    markProcessing(ids);
+    // Pre-task scripts gate and enrich task rows exactly as on the chat side
+    // (task-script.ts is shared scheduling code, imported 1:1). A gated or
+    // broken script acks as a script-skip — the row must not wake the agent,
+    // and the host's consecutive-failure backoff keeps counting.
+    const { keep, skipped } = await applyPreTaskScripts(batch);
+    if (skipped.length > 0) {
+      markScriptSkipped(skipped);
+      console.error(`[code-runner] pre-task script skipped ${skipped.length} task(s)`);
+    }
+    if (keep.length === 0) {
+      this.firstPoll = false;
+      return;
+    }
+    const keepIds = keep.map((m) => m.id);
+    const rendered = sanitizeForTerminal(renderMailbox(keep, this.opts.previewChars));
+    if (this.channelTransportLive) {
+      // Channel transport: one spool entry per delivery batch — the channel
+      // server forwards it as one notification, the client queues it while
+      // busy and delivers it as one turn, and the batch's ids ack together
+      // on that turn's hook evidence exactly as a typed batch would.
+      writeSpoolEntry(
+        { content: rendered, meta: { ids: keepIds.join(','), batch: String(keep.length) } },
+        this.opts.channelSpoolDir,
+      );
+    } else {
+      this.opts.session.write(`\x1b[200~${rendered}\x1b[201~\r`);
+    }
+    this.injectionAt = this.opts.now();
+
+    if (ackOnWrite) {
+      // Degraded paths only (broken hooks / stale busy): no transition can
+      // ever arrive, so complete on the write exactly as before the
+      // pending-ack machinery — never retry-loop these.
+      markCompleted(keepIds);
+      this.firstPoll = false;
+      return;
+    }
+
+    // The completed ack is earned by the busy transition, not assumed on the
+    // write. firstPoll stays armed until the ack lands — a failed
+    // delivery's on_wake rows must survive to a re-fetch.
+    for (const id of keepIds) this.attempts.set(id, (this.attempts.get(id) ?? 0) + 1);
+    this.pendingAck = {
+      ids: keepIds,
+      injectedAt: this.injectionAt,
+      lifeSpawnAt: this.opts.session.lastSpawnAt,
+      nudgedAt: null,
+      viaChannel: this.channelTransportLive,
+    };
+  }
+}

--- a/container/agent-runner/src/code-runner/settings-hooks.test.ts
+++ b/container/agent-runner/src/code-runner/settings-hooks.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Settings reconcile for the mailbox hooks: keyed by our command string,
+ * idempotent, preserves foreign entries, refuses to clobber a corrupt file
+ * (which claude already treats as hook-less — overwriting would also eat
+ * whatever the operator was editing).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+
+import {
+  ensureTerminalDefaults,
+  ensureMailboxHooks,
+  removeMailboxHooks,
+  BOUNDARY_HOOK_COMMAND,
+  BOUNDARY_HOOK_TIMEOUT_S,
+  MAILBOX_HOOK_COMMAND,
+} from './settings-hooks.js';
+
+let settingsPath: string;
+
+function read(): { hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>> } & Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+}
+
+beforeEach(() => {
+  settingsPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-settings-')), 'settings.json');
+});
+
+describe('ensureMailboxHooks', () => {
+  it('creates the file with all six events wired to the hook script', () => {
+    expect(ensureMailboxHooks(settingsPath)).toBe(true);
+    const settings = read();
+    // Notification is the permission-prompt hold : the one event
+    // that fires while a dialog waits, so dropping it re-opens the
+    // container-expires-mid-prompt gap.
+    for (const event of ['SessionStart', 'UserPromptSubmit', 'PostToolUse', 'Stop', 'Notification']) {
+      const commands = settings.hooks[event].flatMap((e) => e.hooks.map((h) => h.command));
+      expect(commands).toEqual([MAILBOX_HOOK_COMMAND]);
+    }
+    // PreToolUse alone also carries the boundary confirm as its own entry.
+    const preToolUse = settings.hooks.PreToolUse.flatMap((e) => e.hooks.map((h) => h.command));
+    expect(preToolUse).toEqual([MAILBOX_HOOK_COMMAND, BOUNDARY_HOOK_COMMAND]);
+  });
+
+  it('the boundary entry gets the long timeout; the mailbox entries keep timeout 10', () => {
+    ensureMailboxHooks(settingsPath);
+    const settings = read() as unknown as {
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; timeout?: number }> }>>;
+    };
+    for (const [event, entries] of Object.entries(settings.hooks)) {
+      for (const entry of entries) {
+        for (const hook of entry.hooks) {
+          if (hook.command === BOUNDARY_HOOK_COMMAND) {
+            // The confirm must outwait a human approver; the ladder is
+            // host-deny (~590s) < hook self-deny (600s) < this kill (660s).
+            expect(event).toBe('PreToolUse');
+            expect(hook.timeout).toBe(BOUNDARY_HOOK_TIMEOUT_S);
+            expect(entry.matcher).toBe('Bash|Edit|Write');
+          } else {
+            expect(hook.timeout).toBe(10);
+          }
+        }
+      }
+    }
+  });
+
+  it('is idempotent and preserves foreign hooks and unrelated settings', () => {
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        autoMemoryEnabled: false,
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: 'bun /app/src/other-hook.ts' }] }],
+          PreCompact: [{ hooks: [{ type: 'command', command: 'bun /app/src/compact-instructions.ts' }] }],
+        },
+      }),
+    );
+    ensureMailboxHooks(settingsPath);
+    ensureMailboxHooks(settingsPath); // twice — no duplicates
+    const settings = read();
+    expect(settings.autoMemoryEnabled).toBe(false);
+    const stopCommands = settings.hooks.Stop.flatMap((e) => e.hooks.map((h) => h.command));
+    expect(stopCommands).toEqual(['bun /app/src/other-hook.ts', MAILBOX_HOOK_COMMAND]);
+    expect(settings.hooks.PreCompact.flatMap((e) => e.hooks.map((h) => h.command))).toEqual([
+      'bun /app/src/compact-instructions.ts',
+    ]);
+    expect(settings.hooks.PostToolUse.flatMap((e) => e.hooks.map((h) => h.command))).toEqual([MAILBOX_HOOK_COMMAND]);
+  });
+
+  it('leaves a corrupt settings.json untouched and reports failure', () => {
+    fs.writeFileSync(settingsPath, '{ not json');
+    expect(ensureMailboxHooks(settingsPath)).toBe(false);
+    expect(fs.readFileSync(settingsPath, 'utf8')).toBe('{ not json');
+  });
+});
+
+it('preserves operator settings it does not own and adds none of its own', () => {
+  fs.writeFileSync(settingsPath, JSON.stringify({ model: 'operator-choice' }));
+  ensureMailboxHooks(settingsPath);
+  expect(read().model).toBe('operator-choice');
+  fs.writeFileSync(settingsPath, '{}');
+  ensureMailboxHooks(settingsPath);
+  expect(read().model).toBeUndefined();
+});
+
+describe('removeMailboxHooks', () => {
+  it('is the exact inverse: strips ours everywhere, keeps foreign entries, drops emptied events', () => {
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        autoMemoryEnabled: false,
+        hooks: { Stop: [{ hooks: [{ type: 'command', command: 'bun /app/src/other-hook.ts' }] }] },
+      }),
+    );
+    ensureMailboxHooks(settingsPath);
+    expect(removeMailboxHooks(settingsPath)).toBe(true);
+    const settings = read();
+    expect(settings.autoMemoryEnabled).toBe(false);
+    expect(settings.hooks.Stop.flatMap((e) => e.hooks.map((h) => h.command))).toEqual(['bun /app/src/other-hook.ts']);
+    for (const event of ['SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse', 'Notification']) {
+      expect(settings.hooks[event]).toBeUndefined();
+    }
+  });
+
+  it('no-ops on a missing file and refuses a corrupt one', () => {
+    expect(removeMailboxHooks(settingsPath)).toBe(true); // nothing there
+    fs.writeFileSync(settingsPath, '{ not json');
+    expect(removeMailboxHooks(settingsPath)).toBe(false);
+    expect(fs.readFileSync(settingsPath, 'utf8')).toBe('{ not json');
+  });
+});
+
+describe('ensureTerminalDefaults', () => {
+  it('seeds the fullscreen renderer when the operator has expressed no preference', () => {
+    expect(ensureTerminalDefaults(settingsPath)).toBe(true);
+    expect(read().tui).toBe('fullscreen');
+  });
+
+  it('never overrides an operator choice — /tui wins, and the choice is durable', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ tui: 'plain', hooks: { Stop: [] } }));
+    expect(ensureTerminalDefaults(settingsPath)).toBe(false);
+    const after = read();
+    expect(after.tui).toBe('plain');
+    expect(after.hooks).toEqual({ Stop: [] });
+  });
+
+  it('preserves the hooks the mailbox registered', () => {
+    ensureMailboxHooks(settingsPath);
+    ensureTerminalDefaults(settingsPath);
+    const after = read();
+    expect(after.tui).toBe('fullscreen');
+    expect(Object.keys(after.hooks ?? {}).length).toBeGreaterThan(0);
+  });
+});

--- a/container/agent-runner/src/code-runner/settings-hooks.ts
+++ b/container/agent-runner/src/code-runner/settings-hooks.ts
@@ -1,0 +1,162 @@
+/**
+ * Ensure the mailbox hooks are registered in the group's settings.json
+ * ("per-group settings.json is the hook home").
+ *
+ * Runs at code-runner boot, before the interactive session spawns — the
+ * same in-container pattern as the chat runner's writeMemorySessionHook,
+ * with migrate-claude-memory-settings' discipline: keyed reconcile (only
+ * entries whose command is OURS are touched; everything else in the file
+ * is preserved) and an atomic tmp+rename write, because a half-written
+ * settings.json silently disables EVERY hook with no error anywhere.
+ *
+ * Host-ownership of this file is a later step — today it lives in
+ * the RW ~/.claude mount like the rest of provider state.
+ */
+import fs from 'fs';
+import path from 'path';
+
+export const MAILBOX_HOOK_COMMAND = 'bun /app/src/code-runner/mailbox-hook.ts';
+
+/** The detached-boundary confirm — its OWN entry (below), never folded
+ *  into the mailbox entries: those keep timeout:10, this one must outwait a
+ *  human approver. */
+export const BOUNDARY_HOOK_COMMAND = 'bun /app/src/code-runner/boundary-hook.ts';
+
+/**
+ * The CLI kills a hook at its settings timeout (seconds). The boundary
+ * ladder: host expiry denies at ~590s, the hook's own poll ceiling denies at
+ * 600s (boundary.ts), and this is the last-resort kill for a wedged hook —
+ * each rung under the next so the decision is always an explicit deny, never
+ * a kill the CLI interprets on its own.
+ */
+export const BOUNDARY_HOOK_TIMEOUT_S = 660;
+
+/** PreToolUse matcher: only the tools the boundaries can name — a
+ *  subprocess per unrelated tool call would be pure spawn tax. */
+const BOUNDARY_HOOK_MATCHER = 'Bash|Edit|Write';
+
+// 'Notification' closes the lease gap "a permission-prompt wait
+// fires no hooks and the container expires mid-prompt": at the pinned CLI (2.1.197)
+// a visible permission dialog fires the Notification hook with
+// notification_type "permission_prompt" once the operator has been inactive
+// ~6s, and the handler stamps a bounded busy hold (mailbox-hook.ts).
+const HOOK_EVENTS = ['SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse', 'Stop', 'Notification'] as const;
+
+interface HookEntry {
+  matcher?: string;
+  hooks: Array<{ type: string; command: string; timeout?: number }>;
+}
+
+/** The keyed-reconcile key: an entry is OURS iff its command is one of these. */
+function isOurCommand(command: string): boolean {
+  return command === MAILBOX_HOOK_COMMAND || command === BOUNDARY_HOOK_COMMAND;
+}
+
+type SettingsShape = { hooks?: Record<string, HookEntry[]> } & Record<string, unknown>;
+
+export function claudeSettingsPath(): string {
+  const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(process.env.HOME || '/home/node', '.claude');
+  return path.join(configDir, 'settings.json');
+}
+
+/** True when settings were written; false when left alone (corrupt file). */
+export function ensureMailboxHooks(settingsPath: string = claudeSettingsPath()): boolean {
+  let settings: SettingsShape = {};
+  if (fs.existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as SettingsShape;
+    } catch (error) {
+      // A corrupt file already means "no hooks anywhere"; overwriting would
+      // also destroy whatever the operator was editing. Louder is better.
+      console.error(`[code-runner] ${settingsPath} is not valid JSON — mailbox hooks NOT registered:`, error);
+      return false;
+    }
+  }
+
+  const hooks: Record<string, HookEntry[]> = { ...(settings.hooks ?? {}) };
+  for (const event of HOOK_EVENTS) {
+    const existing = (hooks[event] ?? []).filter((entry) => !entry.hooks?.some((h) => isOurCommand(h.command)));
+    existing.push({ hooks: [{ type: 'command', command: MAILBOX_HOOK_COMMAND, timeout: 10 }] });
+    if (event === 'PreToolUse') {
+      existing.push({
+        matcher: BOUNDARY_HOOK_MATCHER,
+        hooks: [{ type: 'command', command: BOUNDARY_HOOK_COMMAND, timeout: BOUNDARY_HOOK_TIMEOUT_S }],
+      });
+    }
+    hooks[event] = existing;
+  }
+  settings.hooks = hooks;
+
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+  writeAtomic(settingsPath, settings);
+  return true;
+}
+
+/**
+ * Seed the fullscreen renderer as the sandbox default (verified with the supported CLI).
+ *
+ * The CLI ships two renderers. The default plain-scrolling one enables
+ * neither the alternate screen nor mouse tracking, so under tmux — where the
+ * operator's clicks and wheel reach a real terminal — clicking to position
+ * the cursor does nothing and scrolling fights the pane. Fullscreen turns
+ * both on (verified: it emits ?1049h/?1000h/?1006h where the default emits
+ * none of them). A durable sandbox terminal wants that.
+ *
+ * SEEDED, NOT FORCED: written only when the key is absent, so `/tui` remains
+ * the operator's to change and the choice survives in group state. (The
+ * CLAUDE_CODE_NO_FLICKER env var would win every boot instead — the wrong
+ * shape for a preference.)
+ *
+ */
+export function ensureTerminalDefaults(settingsPath: string = claudeSettingsPath()): boolean {
+  let settings: SettingsShape = {};
+  if (fs.existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as SettingsShape;
+    } catch (error) {
+      console.error(`[code-runner] ${settingsPath} is not valid JSON — terminal defaults NOT seeded:`, error);
+      return false;
+    }
+  }
+  if (settings.tui !== undefined) return false; // the operator has chosen; leave it
+  settings.tui = 'fullscreen';
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+  writeAtomic(settingsPath, settings);
+  return true;
+}
+
+/**
+ * The exact inverse — strip our hook entries, preserve everything foreign.
+ * Called by the hook script itself when it finds it is running in a
+ * non-code-mode container (a group flipped back to chat mode): the entries
+ * are persistent per-group state, the chat runner must stay untouched
+ * , so the hooks self-heal the settings on their first firing.
+ */
+export function removeMailboxHooks(settingsPath: string = claudeSettingsPath()): boolean {
+  if (!fs.existsSync(settingsPath)) return true;
+  let settings: SettingsShape;
+  try {
+    settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as SettingsShape;
+  } catch {
+    return false; // corrupt: not ours to rewrite
+  }
+  if (!settings.hooks) return true;
+
+  const hooks: Record<string, HookEntry[]> = {};
+  let changed = false;
+  for (const [event, entries] of Object.entries(settings.hooks)) {
+    const kept = entries.filter((entry) => !entry.hooks?.some((h) => isOurCommand(h.command)));
+    if (kept.length !== entries.length) changed = true;
+    if (kept.length > 0) hooks[event] = kept;
+  }
+  if (!changed) return true;
+  settings.hooks = hooks;
+  writeAtomic(settingsPath, settings);
+  return true;
+}
+
+function writeAtomic(settingsPath: string, settings: SettingsShape): void {
+  const tmp = `${settingsPath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n');
+  fs.renameSync(tmp, settingsPath);
+}

--- a/container/agent-runner/src/code-runner/term-audit/harness.ts
+++ b/container/agent-runner/src/code-runner/term-audit/harness.ts
@@ -1,0 +1,155 @@
+/** Shared harness for the tmux terminal audit and integration tests. */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { TmuxEvidence } from '../tmux-evidence.js';
+import { TmuxSession } from '../tmux-session.js';
+import { SESSION_TERM_ENV } from '../term-env.js';
+import { PROBE_BOOT } from './probe.js';
+
+export const PROBE_PATH = path.join(import.meta.dir, 'probe.ts');
+
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export async function waitFor(cond: () => boolean, what: string, ms = 8_000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await sleep(10);
+  }
+}
+
+export function auditSessionEnv(extra: Record<string, string> = {}): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) env[k] = v;
+  }
+  // Container reality: the runner has no terminal parent, so only what the
+  // runner itself forces exists. A developer shell's COLORTERM leaking in
+  // would fake the env verdict.
+  delete env.COLORTERM;
+  Object.assign(env, SESSION_TERM_ENV, extra);
+  return env;
+}
+
+/** Reassemble the byte stream the probe received from its `[rx <hex>]` echoes. */
+export function rxBytes(output: string): Buffer {
+  const hex: string[] = [];
+  for (const m of output.matchAll(/\[rx ([0-9a-f]*)\]/g)) hex.push(m[1]);
+  return Buffer.from(hex.join(''), 'hex');
+}
+
+export interface TmuxStack {
+  session: TmuxSession;
+  evidence: TmuxEvidence;
+  socketPath: string;
+  log(): string;
+  rx(): Buffer;
+  /** Literal text through the pane's stdin server-side (no client needed). */
+  type(text: string): Promise<void>;
+  tmux(args: string[]): Promise<{ exitCode: number; stdout: string }>;
+  close(): void;
+}
+
+export async function startTmuxStack(): Promise<TmuxStack> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-term-audit-tmux-'));
+  const socketPath = path.join(dir, 'tmux.sock');
+  const logPath = path.join(dir, 'probe.log');
+  const session = new TmuxSession({
+    command: process.execPath,
+    args: [PROBE_PATH],
+    cwd: dir,
+    env: auditSessionEnv({ PROBE_LOG: logPath }),
+    socketPath,
+    confPath: path.join(dir, 'tmux.conf'),
+    pollMs: 200,
+  });
+  await session.start();
+  const evidence = new TmuxEvidence({ socketPath, pollMs: 200 });
+  evidence.start();
+
+  const log = () => {
+    try {
+      return fs.readFileSync(logPath, 'utf8');
+    } catch {
+      return '';
+    }
+  };
+  const tmux = async (args: string[]) => {
+    const proc = Bun.spawn(['tmux', '-S', socketPath, ...args], { stdout: 'pipe', stderr: 'pipe' });
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    return { exitCode, stdout };
+  };
+  try {
+    await waitFor(() => log().includes(PROBE_BOOT), 'the probe boot line in the log');
+  } catch (error) {
+    evidence.stop();
+    session.dispose();
+    throw error;
+  }
+  return {
+    session,
+    evidence,
+    socketPath,
+    log,
+    rx: () => rxBytes(log()),
+    type: async (text) => {
+      await tmux(['send-keys', '-t', 'agent', '-l', text]);
+    },
+    tmux,
+    close() {
+      evidence.stop();
+      session.dispose();
+    },
+  };
+}
+
+export interface TmuxTtyClient {
+  write(data: Buffer | string): void;
+  resize(cols: number, rows: number): void;
+  output(): string;
+  exited: Promise<number>;
+  kill(): void;
+}
+
+/** Real tmux client under a test terminal. The explicit SIGWINCH substitutes
+ * for delivery by the operator terminal's controlling-terminal machinery. */
+export function spawnTmuxClient(socketPath: string, opts: { cols?: number; rows?: number } = {}): TmuxTtyClient {
+  const out: Buffer[] = [];
+  const terminal = new Bun.Terminal({
+    cols: opts.cols ?? 100,
+    rows: opts.rows ?? 40,
+    name: 'xterm-256color',
+    data(_t, chunk) {
+      out.push(Buffer.from(chunk));
+    },
+  });
+  // Mirrors the production attach argv (cli/attach-resolve.ts): the exec
+  // transport forwards neither TERM nor the locale, so the client restores
+  // the color floor and forces UTF-8 itself.
+  const proc = Bun.spawn(
+    ['env', 'TERM=xterm-256color', 'tmux', '-u', '-S', socketPath, 'attach-session', '-t', 'agent'],
+    {
+      terminal,
+      env: { ...process.env, TERM: 'xterm-256color' },
+      onExit() {
+        if (!terminal.closed) terminal.close();
+      },
+    },
+  );
+  return {
+    write: (data) => void terminal.write(data),
+    resize: (cols, rows) => {
+      terminal.resize(cols, rows);
+      try {
+        proc.kill('SIGWINCH');
+      } catch {
+        // client already exited
+      }
+    },
+    output: () => Buffer.concat(out).toString('latin1'),
+    exited: proc.exited,
+    kill: () => proc.kill(),
+  };
+}

--- a/container/agent-runner/src/code-runner/term-audit/matrix.ts
+++ b/container/agent-runner/src/code-runner/term-audit/matrix.ts
@@ -1,0 +1,54 @@
+/** Verdicts and reporting for the terminal audit. */
+export type Verdict = 'PASS' | 'FAIL' | 'MANUAL';
+
+export interface Row {
+  name: string;
+  verdict: Verdict;
+  detail: string;
+}
+
+export class Matrix {
+  readonly rows: Row[] = [];
+  readonly notes: string[] = [];
+  private readonly startedAt = Date.now();
+
+  constructor(private readonly title: string) {}
+
+  row(name: string, verdict: Verdict, detail: string): void {
+    this.rows.push({ name, verdict, detail });
+    console.log(`  … ${name}: ${verdict}`);
+  }
+
+  /** One matrix row per attempt: a thrown timeout is that row's FAIL, not the run's. */
+  async attempt(name: string, fn: () => Promise<[Verdict, string]> | [Verdict, string]): Promise<void> {
+    try {
+      const [verdict, detail] = await fn();
+      this.row(name, verdict, detail);
+    } catch (error) {
+      this.row(name, 'FAIL', (error as Error).message);
+    }
+  }
+
+  note(...lines: string[]): void {
+    this.notes.push(...lines);
+  }
+
+  print(): void {
+    const width = Math.max(...this.rows.map((r) => r.name.length)) + 2;
+    console.log(`\n== ${this.title} (${new Date().toISOString()}, ${Math.round(Date.now() - this.startedAt)}ms) ==`);
+    for (const r of this.rows) {
+      console.log(`${r.name.padEnd(width)}${r.verdict.padEnd(8)}${r.detail}`);
+    }
+    console.log('\nnotes:');
+    for (const n of this.notes) console.log(`  - ${n}`);
+    const fails = this.rows.filter((r) => r.verdict === 'FAIL').length;
+    const manual = this.rows.filter((r) => r.verdict === 'MANUAL').length;
+    console.log(
+      `\n${this.rows.length} rows: ${this.rows.length - fails - manual} PASS, ${fails} FAIL, ${manual} MANUAL`,
+    );
+  }
+}
+
+export function fmt(ms: number): string {
+  return `${Math.round(ms)}ms`;
+}

--- a/container/agent-runner/src/code-runner/term-audit/probe.ts
+++ b/container/agent-runner/src/code-runner/term-audit/probe.ts
@@ -1,0 +1,130 @@
+/**
+ * Terminal audit probe — the disposable child the term-audit harness runs
+ * inside the real tmux session in place of the interactive agent CLI.
+ *
+ * Everything it does is evidence for one matrix row:
+ *  - boot line: TERM/COLORTERM/geometry as the child actually sees them;
+ *  - raw-mode hex echo of every stdin chunk (`[rx <hex>]`) — byte-exact key
+ *    passthrough and paste-integrity evidence, reassembled by the harness;
+ *  - SIGWINCH trap printing `stty size` (kernel truth) plus process.stdout
+ *    geometry — resize-propagation evidence;
+ *  - command tokens in the input stream trigger output patterns (truecolor /
+ *    256-color SGR, bracketed-paste DECSET toggles, a bulk emit for the
+ *    scrollback row, a geometry report).
+ *
+ * Guarded with import.meta.main so the harness can import the pattern
+ * constants without running the probe.
+ */
+import fs from 'fs';
+
+export const PROBE_BOOT = 'PROBE_BOOT';
+export const PROBE_WINCH = 'PROBE_WINCH';
+export const PROBE_SIZE = 'PROBE_SIZE';
+export const PROBE_SGR_BEGIN = 'PROBE_SGR_BEGIN';
+export const PROBE_SGR_END = 'PROBE_SGR_END';
+export const PROBE_BULK_DONE = 'PROBE_BULK_DONE';
+export const PROBE_PASTE_ON = 'PROBE_PASTE_ON';
+export const PROBE_PASTE_OFF = 'PROBE_PASTE_OFF';
+
+/** Truecolor (24-bit) SGR test pattern — must retain its color values at the client. */
+export const SGR_TRUECOLOR = '\x1b[38;2;10;20;30m\x1b[48;2;200;100;50mTRUECOLOR\x1b[0m';
+/** 256-color SGR test pattern — must retain its color values at the client. */
+export const SGR_256 = '\x1b[38;5;196m\x1b[48;5;24mCOLOR256\x1b[0m';
+/** DECSET/DECRST 2004 — what a TUI emits to toggle bracketed-paste mode. */
+export const PASTE_ON_SEQ = '\x1b[?2004h';
+export const PASTE_OFF_SEQ = '\x1b[?2004l';
+/** Size of the deterministic bulk emit for the replay-ring row. */
+export const BULK_BYTES = 300_000;
+
+/** Command tokens the probe recognizes anywhere in its input stream. */
+export const CMD_SGR = '@sgr@';
+export const CMD_PASTE_ON = '@paste-on@';
+export const CMD_PASTE_OFF = '@paste-off@';
+export const CMD_BULK = '@bulk@';
+export const CMD_SIZE = '@size@';
+
+export function bulkPattern(bytes: number = BULK_BYTES): string {
+  const parts: string[] = [];
+  let total = 0;
+  for (let i = 0; total < bytes; i++) {
+    const line = `bulk-${String(i).padStart(6, '0')} ${'x'.repeat(56)}\n`;
+    parts.push(line);
+    total += line.length;
+  }
+  return parts.join('');
+}
+
+function main(): void {
+  // Mirror every report to a side-channel file when the harness asks
+  // (PROBE_LOG): under tmux the client-visible stream is a RENDERING — the
+  // redraw may split any text line with cursor motion — so byte-exact rows
+  // need an oracle that never rode the screen.
+  const logPath = process.env.PROBE_LOG;
+  const out = (s: string) => {
+    process.stdout.write(s);
+    if (logPath) {
+      try {
+        fs.appendFileSync(logPath, s);
+      } catch {
+        // the audit's problem, not the probe's
+      }
+    }
+  };
+  const cols = () => process.stdout.columns ?? 0;
+  const rows = () => process.stdout.rows ?? 0;
+
+  /** The kernel's view of the pty geometry ("rows cols"), read via stdin. */
+  function sttySize(): string {
+    try {
+      const res = Bun.spawnSync(['stty', 'size'], { stdin: 'inherit', stdout: 'pipe', stderr: 'pipe' });
+      const text = res.stdout.toString().trim();
+      return text || 'unavailable';
+    } catch {
+      return 'unavailable';
+    }
+  }
+
+  out(
+    `${PROBE_BOOT} term=${process.env.TERM ?? 'unset'} colorterm=${process.env.COLORTERM ?? 'unset'} ` +
+      `lang=${process.env.LC_CTYPE ?? process.env.LC_ALL ?? process.env.LANG ?? 'unset'} size=${cols()}x${rows()}\n`,
+  );
+
+  process.on('SIGWINCH', () => {
+    out(`${PROBE_WINCH} stty=[${sttySize()}] size=${cols()}x${rows()}\n`);
+  });
+
+  const commands: Array<[string, () => void]> = [
+    [CMD_SGR, () => out(`${PROBE_SGR_BEGIN}${SGR_TRUECOLOR}${SGR_256}${PROBE_SGR_END}\n`)],
+    [CMD_PASTE_ON, () => out(`${PASTE_ON_SEQ}${PROBE_PASTE_ON}\n`)],
+    [CMD_PASTE_OFF, () => out(`${PASTE_OFF_SEQ}${PROBE_PASTE_OFF}\n`)],
+    [CMD_BULK, () => out(`${bulkPattern()}${PROBE_BULK_DONE}\n`)],
+    // stty is the kernel's live winsize; process.stdout geometry is bun's
+    // boot-time snapshot (a term-audit finding: it never refreshes) — report
+    // both so the matrix can tell the kernel hop from the notify hop.
+    [CMD_SIZE, () => out(`${PROBE_SIZE} stty=[${sttySize()}] size=${cols()}x${rows()}\n`)],
+  ];
+
+  // Command tokens may split across input chunks — scan a rolling window.
+  let window = '';
+  const maxToken = Math.max(...commands.map(([t]) => t.length));
+
+  if (process.stdin.isTTY) process.stdin.setRawMode(true);
+  process.stdin.on('data', (chunk: Buffer) => {
+    out(`[rx ${chunk.toString('hex')}]\n`);
+    window += chunk.toString('latin1');
+    for (;;) {
+      let earliest: { at: number; token: string; run: () => void } | null = null;
+      for (const [token, run] of commands) {
+        const at = window.indexOf(token);
+        if (at !== -1 && (earliest === null || at < earliest.at)) earliest = { at, token, run };
+      }
+      if (earliest === null) break;
+      earliest.run();
+      window = window.slice(earliest.at + earliest.token.length);
+    }
+    if (window.length > maxToken) window = window.slice(window.length - maxToken);
+  });
+  process.stdin.resume();
+}
+
+if (import.meta.main) main();

--- a/container/agent-runner/src/code-runner/term-audit/run.ts
+++ b/container/agent-runner/src/code-runner/term-audit/run.ts
@@ -1,0 +1,470 @@
+/**
+ * Audit the production tmux session and client using a terminal probe.
+ * Run: bun src/code-runner/term-audit/run.ts
+ * Input assertions read the probe log; output assertions read the terminal.
+ */
+import net from 'net';
+
+import { sleep, waitFor, startTmuxStack, spawnTmuxClient, type TmuxStack, type TmuxTtyClient } from './harness.js';
+import { fmt, Matrix } from './matrix.js';
+import {
+  CMD_BULK,
+  CMD_PASTE_ON,
+  CMD_SGR,
+  CMD_SIZE,
+  PROBE_BULK_DONE,
+  PROBE_PASTE_ON,
+  PROBE_SGR_END,
+  PROBE_WINCH,
+  SGR_256,
+  SGR_TRUECOLOR,
+} from './probe.js';
+
+const matrix = new Matrix('term-audit matrix — tmux');
+
+/** Client bookkeeping: rows attach and drop clients in sequence, and the
+ * evidence poll observes with a lag — every transition waits for the count
+ * to SETTLE at the expected value or the next row reasons over a stale one
+ * (the first audit run failed four rows on exactly that race). */
+let liveClients = 0;
+
+async function attachClient(stack: TmuxStack, opts: { cols?: number; rows?: number } = {}): Promise<TmuxTtyClient> {
+  await waitFor(() => stack.evidence.clientCount === liveClients, 'client counts to settle before attach');
+  const client = spawnTmuxClient(stack.socketPath, opts);
+  liveClients++;
+  await waitFor(() => stack.evidence.clientCount === liveClients, 'the tmux client to register');
+  // Let the initial redraw land before rows start reasoning about output.
+  await sleep(300);
+  return client;
+}
+
+/** Kill (or confirm an already-exited) client and wait for tmux to drop it. */
+async function dropClient(stack: TmuxStack, client: TmuxTtyClient): Promise<void> {
+  client.kill();
+  liveClients--;
+  await waitFor(() => stack.evidence.clientCount === liveClients, 'the client to drop', 10_000);
+}
+
+// ---------------------------------------------------------------------------
+
+async function checkEnv(stack: TmuxStack): Promise<void> {
+  const boot = stack.log().match(/PROBE_BOOT term=(\S+) colorterm=(\S+)/);
+  const locale = stack.log().match(/PROBE_BOOT .*lang=(\S+)/);
+  matrix.row(
+    'env-locale',
+    locale?.[1]?.toLowerCase().includes('utf-8') ? 'PASS' : 'FAIL',
+    `pane LANG=${locale?.[1] ?? 'unset'} — tmux decides UTF-8 from the locale, and a raw PTY never needed one`,
+  );
+  matrix.row(
+    'env-term',
+    boot?.[1] === 'xterm-256color' ? 'PASS' : 'FAIL',
+    `pane TERM=${boot?.[1] ?? 'unreadable'} (tmux default-terminal, tmux-session.ts conf)`,
+  );
+  matrix.row(
+    'env-colorterm',
+    boot?.[2] === 'truecolor' ? 'PASS' : 'FAIL',
+    boot?.[2] === 'truecolor'
+      ? 'COLORTERM=truecolor inherited through the tmux server env'
+      : `COLORTERM=${boot?.[2] ?? 'unset'} in the pane`,
+  );
+}
+
+async function checkBytePath(stack: TmuxStack): Promise<void> {
+  const client = await attachClient(stack);
+  try {
+    // The row the first live prototype attach earned: a raw PTY passes bytes
+    // through, but tmux parses and re-renders them, so a missing locale
+    // silently downgrades BOTH server and client to non-UTF-8 and every
+    // filled block / box-drawing glyph lands as wrong-width junk. Assert the
+    // negotiated mode, not the intent.
+    await matrix.attempt('utf8-mode', async () => {
+      const clients = await stack.tmux(['list-clients', '-F', '#{client_utf8} #{client_termname}']);
+      const rows = clients.stdout.trim().split('\n').filter(Boolean);
+      const allUtf8 = rows.length > 0 && rows.every((r) => r.startsWith('1 '));
+      const all256 = rows.every((r) => r.includes('256color'));
+      return [
+        allUtf8 && all256 ? 'PASS' : 'FAIL',
+        `client(s): ${rows.join(' | ') || 'none'} — utf8 must be 1 (else filled shapes garble) and termname 256color (else no truecolor to the operator)`,
+      ];
+    });
+
+    // Copy must reach the OPERATOR's clipboard, not a container-private
+    // buffer: tmux's default set-clipboard=external leaves mouse selection
+    // stranded in the container (measured on a prototype — "highlighting to copy"
+    // silently did nothing). The proof is the OSC 52 escape appearing in the
+    // client's own byte stream, since that is what rides the exec transport
+    // and ssh home.
+    await matrix.attempt('copy-to-operator-clipboard', async () => {
+      const before = client.output().length;
+      await stack.tmux(['copy-mode', '-t', 'agent']);
+      await stack.tmux(['send-keys', '-X', '-t', 'agent', 'begin-selection']);
+      for (let i = 0; i < 5; i++) await stack.tmux(['send-keys', '-X', '-t', 'agent', 'cursor-right']);
+      await stack.tmux(['send-keys', '-X', '-t', 'agent', 'copy-selection-and-cancel']);
+      const deadline = Date.now() + 3_000;
+      while (Date.now() < deadline && !client.output().slice(before).includes('\x1b]52;')) await sleep(50);
+      const seen = client.output().slice(before).includes('\x1b]52;');
+      const setting = (await stack.tmux(['show', '-gv', 'set-clipboard'])).stdout.trim();
+      return seen
+        ? [
+            'PASS',
+            `tmux emitted OSC 52 to the client (set-clipboard=${setting}) — selection lands in the operator's clipboard`,
+          ]
+        : [
+            'FAIL',
+            `no OSC 52 in the client stream (set-clipboard=${setting}) — copy stays in the container's tmux buffer`,
+          ];
+    });
+
+    await matrix.attempt('input-latency', async () => {
+      const keys = ['q', 'w', 'e', 'r', 't'];
+      const timings: number[] = [];
+      for (const key of keys) {
+        const before = stack.rx().length;
+        const t0 = performance.now();
+        client.write(key);
+        await waitFor(() => stack.rx().length > before, `echo of '${key}'`);
+        timings.push(performance.now() - t0);
+      }
+      timings.sort((a, b) => a - b);
+      const median = timings[Math.floor(timings.length / 2)];
+      return [
+        median <= 100 ? 'PASS' : 'FAIL',
+        `median ${fmt(median)} over ${keys.length} keys (min ${fmt(timings[0])}, max ${fmt(timings[timings.length - 1])}; local bound 100ms)`,
+      ];
+    });
+
+    await matrix.attempt('sgr-bytes', async () => {
+      const before = client.output().length;
+      client.write(CMD_SGR);
+      await waitFor(() => stack.log().includes(PROBE_SGR_END), 'the SGR pattern at the probe');
+      await sleep(300); // let the render reach the client
+      const seen = client.output().slice(before);
+      if (seen.includes(SGR_TRUECOLOR) && seen.includes(SGR_256)) {
+        return ['PASS', 'truecolor + 256-color SGR byte-exact at the operator terminal'];
+      }
+      // tmux re-encodes SGR from its own screen model; the row's subject is
+      // color FIDELITY at the operator, so exact params anywhere count —
+      // and a miss on the exact sequence with params intact is re-encoding,
+      // not loss.
+      const truecolorParams = seen.includes('38;2;10;20;30') && seen.includes('48;2;200;100;50');
+      const c256Params = seen.includes('38;5;196') && seen.includes('48;5;24');
+      return truecolorParams && c256Params
+        ? ['PASS', 'SGR re-encoded by tmux with 24-bit and 256-color parameters intact (RGB terminal-override active)']
+        : ['FAIL', `color parameters lost in tmux transit (truecolor=${truecolorParams} 256=${c256Params})`];
+    });
+
+    await matrix.attempt('key-passthrough', async () => {
+      const keyBytes = Buffer.from([
+        0x1b,
+        0x5b,
+        0x41, // up
+        0x1b,
+        0x5b,
+        0x42, // down
+        0x1b,
+        0x5b,
+        0x43, // right
+        0x1b,
+        0x5b,
+        0x44, // left
+        0x01,
+        0x05,
+        0x17,
+        0x03, // ctrl-a ctrl-e ctrl-w ctrl-c (no 0x02 — that is tmux's prefix, reserved by design)
+        0x1b,
+        0x62, // alt-b (ESC-prefix)
+      ]);
+      const before = stack.rx().length;
+      client.write(keyBytes);
+      await waitFor(() => stack.rx().subarray(before).includes(keyBytes), 'the key bytes at the probe');
+      return [
+        'PASS',
+        'arrows, ctrl chords, alt/ESC-prefix byte-exact at the child (0x02 is the reserved prefix instead of 0x1d)',
+      ];
+    });
+
+    await matrix.attempt('bracketed-paste-intact', async () => {
+      // Production-faithful: the TUI (claude) enables bracketed paste, so the
+      // pane requests it and tmux re-wraps operator pastes with the markers.
+      const before = stack.rx().length;
+      client.write(CMD_PASTE_ON);
+      await waitFor(() => stack.log().includes(PROBE_PASTE_ON), 'the pane to enable bracketed paste');
+      await sleep(200);
+      const paste = Buffer.from('\x1b[200~paste-payload-integrity\x1b[201~', 'latin1');
+      client.write(paste);
+      await waitFor(
+        () => stack.rx().subarray(before).toString('latin1').includes('paste-payload-integrity'),
+        'the paste payload at the probe',
+      );
+      const got = stack.rx().subarray(before).toString('latin1');
+      const markers = got.includes('\x1b[200~') && got.includes('\x1b[201~');
+      return markers
+        ? ['PASS', 'markers + payload intact at the child (pane in paste mode; tmux re-wraps)']
+        : ['FAIL', 'payload arrived but the paste markers were stripped despite the pane requesting 2004'];
+    });
+
+    await matrix.attempt('multi-client', async () => {
+      const second = await attachClient(stack);
+      try {
+        const beforeRx = stack.rx().length;
+        const beforeOut = client.output().length;
+        second.write('z');
+        await waitFor(() => stack.rx().subarray(beforeRx).includes(Buffer.from('z')), "second client's keystroke");
+        await waitFor(() => client.output().length > beforeOut, "the first client's view to advance");
+        return ['PASS', 'two attachers: both see the stream, both can type (tmux native)'];
+      } finally {
+        await dropClient(stack, second);
+      }
+    });
+
+    await matrix.attempt('multi-client-resize', async () => {
+      // tmux's documented policy is window-size latest: the most recently
+      // active client's geometry wins — same "last wins" family as the
+      // attach server's last-resize-wins. The status line takes one row, so
+      // a client at RxC gives the pane (R-1)xC.
+      const second = await attachClient(stack, { cols: 81, rows: 21 });
+      let dropped = false;
+      try {
+        const q1 = stack.log().length;
+        await stack.type(CMD_SIZE);
+        await waitFor(() => stack.log().slice(q1).includes('stty=['), 'the kernel winsize report');
+        const afterSecond = stack
+          .log()
+          .slice(q1)
+          .match(/stty=\[[^\]]*\]/)?.[0];
+        await dropClient(stack, second);
+        dropped = true;
+        client.resize(101, 31);
+        await sleep(400);
+        const q2 = stack.log().length;
+        await stack.type(CMD_SIZE);
+        await waitFor(() => stack.log().slice(q2).includes('stty=['), 'the kernel winsize report');
+        const afterResize = stack
+          .log()
+          .slice(q2)
+          .match(/stty=\[[^\]]*\]/)?.[0];
+        return afterSecond === 'stty=[21 81]' && afterResize === 'stty=[31 101]'
+          ? [
+              'PASS',
+              `latest-active client wins (${afterSecond} → ${afterResize}; window-size latest; pane = the client's FULL geometry — no status bar steals a row)`,
+            ]
+          : ['FAIL', `geometry did not follow the latest client (${afterSecond ?? '?'} → ${afterResize ?? '?'})`];
+      } finally {
+        if (!dropped) await dropClient(stack, second);
+      }
+    });
+
+    await matrix.attempt('detach-key-reserved', async () => {
+      const throwaway = await attachClient(stack);
+      // 0x1d is an ordinary byte now — prove it passes through first.
+      const before = stack.rx().length;
+      throwaway.write(Buffer.from([0x1d]));
+      await waitFor(
+        () =>
+          stack
+            .rx()
+            .subarray(before)
+            .includes(Buffer.from([0x1d])),
+        '0x1d at the probe',
+      );
+      // The reserved chord is the prefix: C-b d detaches; C-b never reaches the TUI.
+      throwaway.write(Buffer.from([0x02, 0x64]));
+      const code = await Promise.race([throwaway.exited, sleep(5_000).then(() => -1)]);
+      liveClients--;
+      if (code === -1) throwaway.kill();
+      await waitFor(() => stack.evidence.clientCount === liveClients, 'the detached client to drop', 10_000);
+      return [
+        code === 0 ? 'PASS' : 'FAIL',
+        `C-b d detaches (exit ${code}); 0x1d passes through to the TUI — the reserved key moved to tmux's prefix, by design`,
+      ];
+    });
+  } finally {
+    await dropClient(stack, client);
+  }
+}
+
+async function checkPasteDetachByte(stack: TmuxStack): Promise<void> {
+  await matrix.attempt('paste-with-0x1d', async () => {
+    const client = await attachClient(stack);
+    try {
+      const before = stack.rx().length;
+      const full = Buffer.from('\x1b[200~ab\x1dcd\x1b[201~', 'latin1');
+      client.write(full.subarray(0, 3));
+      await sleep(30);
+      client.write(full.subarray(3));
+      await waitFor(
+        () => stack.rx().subarray(before).toString('latin1').includes('ab\x1dcd'),
+        'the full paste (0x1d included) at the probe',
+      );
+      return ['PASS', 'a paste containing 0x1d arrives intact — no reserved byte inside the stream anymore'];
+    } finally {
+      await dropClient(stack, client);
+    }
+  });
+}
+
+async function checkReplay(stack: TmuxStack): Promise<void> {
+  await matrix.attempt('replay-scrollback', async () => {
+    const writer = await attachClient(stack);
+    writer.write(CMD_BULK);
+    await waitFor(() => stack.log().includes(PROBE_BULK_DONE), 'the bulk emit', 20_000);
+    await dropClient(stack, writer);
+
+    const fresh = await attachClient(stack);
+    try {
+      await waitFor(() => fresh.output().includes(PROBE_BULK_DONE), 'the redrawn screen tail', 10_000);
+      // Depth: the pane's history (capture-pane over the whole scrollback)
+      // must still hold the START of the bulk emit — tmux's history-limit is
+      // the ring buffer's successor.
+      const captured = await stack.tmux(['capture-pane', '-p', '-t', 'agent', '-S', '-']);
+      const depth = captured.stdout.includes('bulk-000000');
+      return depth
+        ? [
+            'PASS',
+            'fresh attach redraws the live screen; full bulk history present in tmux scrollback (capture-pane from line 0)',
+          ]
+        : [
+            'FAIL',
+            'the scrollback lost the head of the bulk emit (history-limit too small for the ring the attach stack kept)',
+          ];
+    } finally {
+      await dropClient(stack, fresh);
+    }
+  });
+  matrix.row(
+    'replay-visual-mismatch',
+    'MANUAL',
+    'tmux redraws every attach from its own screen model at the client geometry — the mismatch class the ring replay had should be structurally gone; confirm by eye once live',
+  );
+}
+
+async function checkTtyResize(stack: TmuxStack): Promise<void> {
+  const tty = await attachClient(stack, { cols: 91, rows: 33 });
+  try {
+    await matrix.attempt('resize-connect', async () => {
+      await sleep(300);
+      const q = stack.log().length;
+      await stack.type(CMD_SIZE);
+      await waitFor(() => stack.log().slice(q).includes('stty=['), 'the kernel winsize report', 10_000);
+      const got = stack
+        .log()
+        .slice(q)
+        .match(/stty=\[[^\]]*\]/)?.[0];
+      // status off: the pane is the client's full geometry, no row lost.
+      return got === 'stty=[33 91]'
+        ? ['PASS', 'client geometry landed in the pane pty on attach (stty=[33 91] — the full 91x33, no status bar)']
+        : ['FAIL', `connect-time size did not land: ${got ?? 'no stty report'}`];
+    });
+
+    let liveLanded = false;
+    let logAtResize = 0;
+    await matrix.attempt('resize-live', async () => {
+      logAtResize = stack.log().length;
+      tty.resize(121, 41);
+      let last = 'no stty report';
+      for (let i = 0; i < 5; i++) {
+        await sleep(300);
+        const q = stack.log().length;
+        await stack.type(CMD_SIZE);
+        await waitFor(() => stack.log().slice(q).includes('stty=['), 'the kernel winsize report', 10_000);
+        last =
+          stack
+            .log()
+            .slice(q)
+            .match(/stty=\[[^\]]*\]/)?.[0] ?? last;
+        if (last === 'stty=[41 121]') {
+          liveLanded = true;
+          return ['PASS', 'live resize landed in the pane pty (stty=[41 121] — the full client geometry)'];
+        }
+      }
+      return ['FAIL', `live resize never landed (kernel still ${last})`];
+    });
+
+    await matrix.attempt('resize-child-notify', () => {
+      if (!liveLanded) return ['FAIL', 'not reached — the live-resize leg failed first'];
+      const winched = stack.log().slice(logAtResize).includes(PROBE_WINCH);
+      return winched
+        ? ['PASS', 'the child was notified natively (pane pty is a real controlling terminal — SIGWINCH → PROBE_WINCH)']
+        : ['FAIL', 'pane winsize changed but the child never heard SIGWINCH'];
+    });
+  } finally {
+    tty.write(Buffer.from([0x02, 0x64])); // C-b d — detach cleanly
+    await Promise.race([tty.exited, sleep(2_000)]);
+    await dropClient(stack, tty); // kill is a no-op on an exited client
+  }
+}
+
+const DISCONNECT_BOUND_MS = 15_000;
+
+async function checkDisconnect(stack: TmuxStack): Promise<void> {
+  await matrix.attempt('disconnect-epipe-mode', async () => {
+    const client = await attachClient(stack);
+    const t0 = Date.now();
+    client.kill(); // the exec transport died; the in-container tmux client dies with its tty
+    liveClients--;
+    await waitFor(() => stack.evidence.clientCount === liveClients, 'the disconnect', 30_000);
+    const ms = Date.now() - t0;
+    return [
+      ms <= DISCONNECT_BOUND_MS ? 'PASS' : 'FAIL',
+      `client death → tmux dropped it in ${fmt(ms)} (server-native; evidence poll 200ms; bound ${fmt(DISCONNECT_BOUND_MS)})`,
+    ];
+  });
+
+  matrix.row(
+    'disconnect-buffered-mode',
+    'MANUAL',
+    'a wedged-but-open exec stream blocks the in-container tmux client on its tty writes; tmux buffers per-client server-side and the idle lease stays the designed backstop — not reproducible under the auto-draining Bun.Terminal wrapper; verify over a remote exec transport',
+  );
+
+  await matrix.attempt('orphan-socket-sweep', async () => {
+    const sock = await new Promise<net.Socket>((resolve, reject) => {
+      const s = net.createConnection(stack.socketPath);
+      s.on('data', () => {});
+      s.once('connect', () => resolve(s));
+      s.once('error', reject);
+    });
+    try {
+      await sleep(2_000);
+      return stack.evidence.clientCount === 0
+        ? [
+            'PASS',
+            'a silent client-shaped socket never becomes a tmux client — no sweep needed, the protocol handshake is the gate',
+          ]
+        : ['FAIL', 'a silent socket registered as a client'];
+    } finally {
+      sock.destroy();
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log('term-audit: auditing the tmux terminal…');
+  const stack = await startTmuxStack();
+  try {
+    await checkEnv(stack);
+    await checkBytePath(stack);
+    await checkPasteDetachByte(stack);
+    await checkReplay(stack);
+    await checkTtyResize(stack);
+    await checkDisconnect(stack);
+  } finally {
+    stack.close();
+  }
+
+  matrix.note(
+    'The reserved key moved: C-b (the tmux prefix) never reaches the TUI, C-b d detaches; 0x1d passes through .',
+    "Multi-client geometry is tmux's window-size latest (latest active client wins) .",
+    'A blocked client tty can leave a tmux client present; the idle lease remains the designed backstop either way — verify over a remote exec transport.',
+    'The harness TTY wrapper substitutes the operator-terminal kernel step for SIGWINCH delivery to the tmux CLIENT; everything from the client inward is real.',
+    'A remote exec transport (exec-stream latency, resize coalescing) is out of local scope, and requires a separate live check.',
+  );
+  matrix.print();
+  process.exit(matrix.rows.some((row) => row.verdict === 'FAIL') ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error('term-audit (tmux): harness failure:', error);
+  process.exit(1);
+});

--- a/container/agent-runner/src/code-runner/term-audit/term-audit.test.ts
+++ b/container/agent-runner/src/code-runner/term-audit/term-audit.test.ts
@@ -1,0 +1,104 @@
+/** Terminal behavior through the production tmux server and client. */
+import { describe, expect, test } from 'bun:test';
+import { SESSION_TERM_ENV } from '../term-env.js';
+import {
+  auditSessionEnv,
+  sleep,
+  spawnTmuxClient,
+  startTmuxStack,
+  waitFor,
+  type TmuxStack,
+  type TmuxTtyClient,
+} from './harness.js';
+import { CMD_PASTE_ON, CMD_SGR, CMD_SIZE, PROBE_PASTE_ON, PROBE_SGR_END, PROBE_WINCH } from './probe.js';
+
+test('the terminal audit uses the session environment', () => {
+  expect(SESSION_TERM_ENV.TERM).toBe('xterm-256color');
+  expect(SESSION_TERM_ENV.COLORTERM).toBe('truecolor');
+  expect(auditSessionEnv()).toMatchObject(SESSION_TERM_ENV);
+});
+
+async function withTerminal(fn: (stack: TmuxStack, client: TmuxTtyClient) => Promise<void>): Promise<void> {
+  const stack = await startTmuxStack();
+  const client = spawnTmuxClient(stack.socketPath, { cols: 100, rows: 40 });
+  try {
+    await waitFor(() => stack.evidence.clientCount === 1, 'the tmux client');
+    await fn(stack, client);
+  } finally {
+    client.kill();
+    stack.close();
+  }
+}
+
+describe.if(Bun.which('tmux') !== null)('tmux terminal integration', () => {
+  test('round-trips input and preserves truecolor output', async () => {
+    await withTerminal(async (stack, client) => {
+      expect(stack.log()).toContain('term=xterm-256color');
+      expect(stack.log()).toContain('colorterm=truecolor');
+      client.write('hello');
+      await waitFor(() => stack.rx().includes(Buffer.from('hello')), 'typed input at the probe');
+      client.write(CMD_SGR);
+      await waitFor(() => client.output().includes(PROBE_SGR_END), 'the color pattern');
+      // tmux may combine SGR sequences while preserving every color value.
+      for (const color of ['38;2;10;20;30', '48;2;200;100;50', '38;5;196', '48;5;24']) {
+        expect(client.output()).toContain(color);
+      }
+    });
+  }, 20_000);
+
+  test('a paste containing Ctrl-] reaches the process without detaching', async () => {
+    await withTerminal(async (stack, client) => {
+      await stack.type(CMD_PASTE_ON);
+      await waitFor(() => stack.log().includes(PROBE_PASTE_ON), 'bracketed paste support');
+      await sleep(100);
+      const paste = Buffer.from('\x1b[200~ab\x1dcd\x1b[201~', 'latin1');
+      client.write(paste);
+      await waitFor(() => stack.rx().includes(paste), 'the complete paste');
+      expect(stack.evidence.clientCount).toBe(1);
+    });
+  }, 20_000);
+
+  test('detach keeps the session and another client alive, and reattach sees the existing screen', async () => {
+    await withTerminal(async (stack, first) => {
+      const second = spawnTmuxClient(stack.socketPath);
+      const screenMarker = Buffer.from('retained-screen').toString('hex');
+      let third: TmuxTtyClient | undefined;
+      try {
+        await waitFor(() => stack.evidence.clientCount === 2, 'two clients');
+        first.write('retained-screen');
+        await waitFor(() => second.output().includes(screenMarker), 'output on the second client');
+        first.write(Buffer.from([0x02, 0x64]));
+        expect(await first.exited).toBe(0);
+        await waitFor(() => stack.evidence.clientCount === 1, 'one remaining client');
+        expect(stack.session.running).toBe(true);
+        third = spawnTmuxClient(stack.socketPath);
+        await waitFor(() => third!.output().includes(screenMarker), 'redraw on reattach');
+        second.write('still-live');
+        await waitFor(() => stack.rx().includes(Buffer.from('still-live')), 'input from the remaining client');
+      } finally {
+        second.kill();
+        third?.kill();
+      }
+    });
+  }, 20_000);
+
+  test('resize updates the process terminal and delivers SIGWINCH', async () => {
+    await withTerminal(async (stack, client) => {
+      const before = stack.log().length;
+      client.resize(121, 41);
+      await waitFor(() => stack.log().slice(before).includes(PROBE_WINCH), 'the child resize signal');
+      await stack.type(CMD_SIZE);
+      await waitFor(() => stack.log().slice(before).includes('stty=[41 121]'), 'the child terminal geometry');
+    });
+  }, 20_000);
+
+  test('client death clears human presence and leaves the session running', async () => {
+    await withTerminal(async (stack, client) => {
+      client.kill();
+      await client.exited;
+      await waitFor(() => stack.evidence.clientCount === 0, 'presence to clear');
+      expect(stack.evidence.attachedClientActivityAt).toBeUndefined();
+      expect(stack.session.running).toBe(true);
+    });
+  }, 20_000);
+});

--- a/container/agent-runner/src/code-runner/term-env.ts
+++ b/container/agent-runner/src/code-runner/term-env.ts
@@ -1,0 +1,22 @@
+/**
+ * Terminal-shaped environment the code runner forces into the PTY session
+ * . A tiny shared module so the term-audit harness stands up a
+ * session with the REAL terminal env (and tests pin it) without executing
+ * index.ts's main().
+ */
+export const SESSION_TERM_ENV: Record<string, string> = {
+  TERM: 'xterm-256color',
+  // The container has no terminal parent to advertise color depth, and TERM
+  // alone caps TUIs at 256 colors (term-audit: env-colorterm). The PTY is a
+  // pure byte pipe — truecolor SGR already traverses it byte-exact — so
+  // advertising 24-bit support is honest.
+  COLORTERM: 'truecolor',
+  // The image sets no locale at all, which a raw PTY never noticed: bytes
+  // crossed it untouched. tmux PARSES and re-renders the stream, and it
+  // decides UTF-8 support from LC_ALL/LC_CTYPE/LANG — with none set it runs
+  // non-UTF-8 and renders every multi-byte glyph (the TUI's filled blocks and
+  // box drawing) as replacement junk of the wrong width. C.UTF-8 is built
+  // into glibc, so this needs no locale package.
+  LANG: 'C.UTF-8',
+  LC_CTYPE: 'C.UTF-8',
+};

--- a/container/agent-runner/src/code-runner/tmux-evidence.test.ts
+++ b/container/agent-runner/src/code-runner/tmux-evidence.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test';
+
+import { TmuxEvidence } from './tmux-evidence.js';
+import type { TmuxExecResult } from './tmux-session.js';
+
+function evidenceWith(result: () => TmuxExecResult): TmuxEvidence {
+  return new TmuxEvidence({ socketPath: '/tmp/na.sock', exec: async () => result() });
+}
+
+describe('TmuxEvidence', () => {
+  test('no server reads as detached, never as an error', async () => {
+    const ev = evidenceWith(() => ({ exitCode: 1, stdout: '', stderr: 'no server running' }));
+    await ev.poll();
+    expect(ev.clientCount).toBe(0);
+    expect(ev.lastClientInputAt).toBe(0);
+    expect(ev.lastClientConnectAt).toBe(0);
+    expect(ev.attachedClientActivityAt).toBeUndefined();
+  });
+
+  test('a freshly attached client is connect evidence, not input evidence', async () => {
+    const t = 1_755_000_000; // seconds — tmux's own stamp unit
+    const ev = evidenceWith(() => ({ exitCode: 0, stdout: `${t} ${t}\n`, stderr: '' }));
+    await ev.poll();
+    expect(ev.clientCount).toBe(1);
+    expect(ev.lastClientConnectAt).toBe(t * 1000);
+    // activity == created: an attach happened, no keystroke did. Counting it
+    // as input would let an exec-shim orphan masquerade as a typing human.
+    expect(ev.lastClientInputAt).toBe(0);
+    // …but it IS live-client activity: the connected-client lease counts
+    // idle from the attach, and this client verifiably exists right now.
+    expect(ev.attachedClientActivityAt).toBe(t * 1000);
+  });
+
+  test('live-client activity dies with the connection — never high-water', async () => {
+    const t = 1_755_000_000;
+    let out = `${t} ${t + 40}\n`;
+    let code = 0;
+    const ev = evidenceWith(() => ({ exitCode: code, stdout: out, stderr: '' }));
+    await ev.poll();
+    expect(ev.attachedClientActivityAt).toBe((t + 40) * 1000);
+
+    // Detach: the marks persist (asserted elsewhere); the live stamp must not.
+    out = '';
+    await ev.poll();
+    expect(ev.attachedClientActivityAt).toBeUndefined();
+
+    // A dead server is equally not a live client.
+    out = `${t} ${t + 40}\n`;
+    code = 1;
+    await ev.poll();
+    expect(ev.attachedClientActivityAt).toBeUndefined();
+  });
+
+  test('activity past the connect stamp is input evidence; marks are high-water across detach', async () => {
+    const created = 1_755_000_000;
+    let out = `${created} ${created + 40}\n`;
+    let code = 0;
+    const ev = evidenceWith(() => ({ exitCode: code, stdout: out, stderr: '' }));
+    await ev.poll();
+    expect(ev.clientCount).toBe(1);
+    expect(ev.lastClientInputAt).toBe((created + 40) * 1000);
+
+    // Client detaches (server answers with no lines) — presence drops, but
+    // "a human was here recently" outlives the connection that proved it.
+    out = '';
+    await ev.poll();
+    expect(ev.clientCount).toBe(0);
+    expect(ev.lastClientInputAt).toBe((created + 40) * 1000);
+    expect(ev.lastClientConnectAt).toBe(created * 1000);
+
+    // Even a dead server never rolls the marks back.
+    code = 1;
+    await ev.poll();
+    expect(ev.lastClientInputAt).toBe((created + 40) * 1000);
+  });
+
+  test('multiple clients: newest stamp wins per mark', async () => {
+    const a = 1_755_000_000;
+    const b = a + 100;
+    const ev = evidenceWith(() => ({
+      exitCode: 0,
+      stdout: `${a} ${a + 500}\n${b} ${b}\n`,
+      stderr: '',
+    }));
+    await ev.poll();
+    expect(ev.clientCount).toBe(2);
+    expect(ev.lastClientConnectAt).toBe(b * 1000);
+    expect(ev.lastClientInputAt).toBe((a + 500) * 1000);
+    expect(ev.attachedClientActivityAt).toBe((a + 500) * 1000); // min idle = newest live activity
+  });
+
+  test('malformed lines are ignored, not crashed on', async () => {
+    const ev = evidenceWith(() => ({ exitCode: 0, stdout: 'garbage line\n', stderr: '' }));
+    await ev.poll();
+    expect(ev.clientCount).toBe(1); // a client exists even if its stamps are unreadable
+    expect(ev.lastClientInputAt).toBe(0);
+    // An unreadable stamp earns no lease — absent evidence expires, never holds.
+    expect(ev.attachedClientActivityAt).toBeUndefined();
+  });
+});

--- a/container/agent-runner/src/code-runner/tmux-evidence.ts
+++ b/container/agent-runner/src/code-runner/tmux-evidence.ts
@@ -1,0 +1,127 @@
+/**
+ * Human-presence evidence from tmux's live client list. Created/activity
+ * stamps distinguish a recent operator from a stale exec connection.
+ * Input/connect marks are high-water: recent human activity remains relevant
+ * after disconnect. tmux timestamps have second resolution; every consumer's
+ * window is at least ten seconds.
+ */
+import { TMUX_SOCKET_PATH, type TmuxExec, type TmuxExecResult } from './tmux-session.js';
+
+const defaultExec: TmuxExec = async (argv) => {
+  const proc = Bun.spawn(argv, { stdout: 'pipe', stderr: 'pipe', stdin: 'ignore' });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+};
+
+export interface TmuxEvidenceOptions {
+  socketPath?: string;
+  pollMs?: number;
+  exec?: TmuxExec;
+}
+
+export class TmuxEvidence {
+  private readonly socketPath: string;
+  private readonly pollMs: number;
+  private readonly exec: TmuxExec;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private polling = false;
+  private clients = 0;
+  private inputHighWater = 0;
+  private connectHighWater = 0;
+  private liveActivity = 0;
+
+  constructor(options: TmuxEvidenceOptions = {}) {
+    this.socketPath = options.socketPath ?? TMUX_SOCKET_PATH;
+    this.pollMs = options.pollMs ?? 1_000;
+    this.exec = options.exec ?? defaultExec;
+  }
+
+  get clientCount(): number {
+    return this.clients;
+  }
+
+  /** Epoch ms of the newest client keystroke ever observed (0 if none). */
+  get lastClientInputAt(): number {
+    return this.inputHighWater;
+  }
+
+  /** Epoch ms of the newest client connect ever observed (0 if none). */
+  get lastClientConnectAt(): number {
+    return this.connectHighWater;
+  }
+
+  /**
+   * Epoch ms of the newest LIVE client's activity stamp — undefined when no
+   * client is attached. NOT high-water: this is the connected-client lease's
+   * evidence (liveness v2) and must die with the connection it describes,
+   * where the marks above deliberately outlive it. A merely-attached client
+   * counts here (activity == created reads as the connect): "attached and
+   * silent" is exactly the case the lease exists to cover, and the orphan
+   * objection does not apply — the client must exist NOW, and a dead ssh
+   * leaves no tmux client behind.
+   */
+  get attachedClientActivityAt(): number | undefined {
+    return this.clients > 0 && this.liveActivity > 0 ? this.liveActivity : undefined;
+  }
+
+  start(): void {
+    this.timer = setInterval(() => void this.poll(), this.pollMs);
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  /** One poll — exposed for tests. A missing server reads as zero clients,
+   * never as an error: between child lives (or before first spawn) detached
+   * is the truthful and the fail-safe answer (absent escalates). */
+  async poll(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      const res: TmuxExecResult = await this.exec([
+        'tmux',
+        '-S',
+        this.socketPath,
+        'list-clients',
+        '-F',
+        '#{client_created} #{client_activity}',
+      ]);
+      if (res.exitCode !== 0) {
+        this.clients = 0;
+        this.liveActivity = 0;
+        return;
+      }
+      const lines = res.stdout.split('\n').filter((line) => line.trim().length > 0);
+      this.clients = lines.length;
+      // Rebuilt from THIS poll's clients only — a client that vanished takes
+      // its live-activity stamp with it (the high-water marks keep theirs).
+      let liveActivity = 0;
+      for (const line of lines) {
+        const [createdRaw, activityRaw] = line.trim().split(/\s+/);
+        const created = Number(createdRaw) * 1000;
+        const activity = Number(activityRaw) * 1000;
+        if (Number.isFinite(created)) this.connectHighWater = Math.max(this.connectHighWater, created);
+        // client_activity starts equal to client_created; only count it as
+        // INPUT evidence once it moves past the connect stamp, or a mere
+        // attach would masquerade as a keystroke. Connect evidence is already
+        // carried by the created stamp — same split the attach server kept.
+        if (Number.isFinite(activity) && Number.isFinite(created) && activity > created) {
+          this.inputHighWater = Math.max(this.inputHighWater, activity);
+        }
+        if (Number.isFinite(activity)) liveActivity = Math.max(liveActivity, activity);
+      }
+      this.liveActivity = liveActivity;
+    } catch {
+      this.clients = 0;
+      this.liveActivity = 0;
+    } finally {
+      this.polling = false;
+    }
+  }
+}

--- a/container/agent-runner/src/code-runner/tmux-session.test.ts
+++ b/container/agent-runner/src/code-runner/tmux-session.test.ts
@@ -1,0 +1,408 @@
+/**
+ * TmuxSession unit tests drive the CLI seam with a fake exec; the
+ * integration suite at the bottom exercises real tmux (skipped where the
+ * binary is absent — the image installs it, dev machines usually have it).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { shQuote, TmuxSession, type TmuxExec, type TmuxExecResult } from './tmux-session.js';
+
+const OK: TmuxExecResult = { exitCode: 0, stdout: '', stderr: '' };
+
+function tempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tmux-session-test-'));
+}
+
+interface FakeExec {
+  exec: TmuxExec;
+  calls: string[][];
+  envs: (Record<string, string> | undefined)[];
+  /** Override the response for a subcommand (matched on argv[2]); a function answers per call. */
+  respond: (subcommand: string, result: TmuxExecResult | (() => TmuxExecResult)) => void;
+}
+
+function fakeExec(): FakeExec {
+  const calls: string[][] = [];
+  const envs: (Record<string, string> | undefined)[] = [];
+  const responses = new Map<string, TmuxExecResult | (() => TmuxExecResult)>();
+  return {
+    calls,
+    envs,
+    respond: (subcommand, result) => void responses.set(subcommand, result),
+    exec: async (argv, opts) => {
+      calls.push(argv);
+      envs.push(opts?.env);
+      // argv = ['tmux', '-S', sock, <subcommand>, ...] — new-session rides
+      // behind '-f conf', so scan for the first non-flag token after the sock.
+      const subcommand = argv.slice(3).find((a) => !a.startsWith('-') && !a.endsWith('.conf'));
+      const response = responses.get(subcommand ?? '') ?? OK;
+      return typeof response === 'function' ? response() : response;
+    },
+  };
+}
+
+function session(fake: FakeExec, dir: string, overrides: Partial<ConstructorParameters<typeof TmuxSession>[0]> = {}) {
+  return new TmuxSession({
+    command: 'claude',
+    args: ['--model', 'sonnet'],
+    cwd: '/workspace/group',
+    env: { PATH: '/bin', SECRET: 'x' },
+    socketPath: path.join(dir, 'tmux.sock'),
+    confPath: path.join(dir, 'tmux.conf'),
+    restartDelayMs: 20,
+    maxRestartDelayMs: 80,
+    healthyRunMs: 10_000,
+    pollMs: 30,
+    exec: fake.exec,
+    ...overrides,
+  });
+}
+
+const disposables: TmuxSession[] = [];
+afterEach(() => {
+  for (const s of disposables.splice(0)) s.dispose();
+});
+
+describe('shQuote', () => {
+  test('wraps and escapes for the shell round trip tmux makes', () => {
+    expect(shQuote('plain')).toBe(`'plain'`);
+    expect(shQuote(`it's`)).toBe(`'it'\\''s'`);
+    expect(shQuote('a b')).toBe(`'a b'`);
+  });
+});
+
+describe('TmuxSession (fake exec)', () => {
+  test('start creates a detached session with quoted command, geometry, cwd — and env only there', async () => {
+    const fake = fakeExec();
+    const dir = tempDir();
+    const s = session(fake, dir);
+    disposables.push(s);
+    await s.start();
+
+    const create = fake.calls[0];
+    expect(create.slice(0, 3)).toEqual(['tmux', '-S', path.join(dir, 'tmux.sock')]);
+    expect(create).toContain('new-session');
+    expect(create).toContain('-d');
+    expect(create[create.indexOf('-s') + 1]).toBe('agent');
+    expect(create[create.indexOf('-c') + 1]).toBe('/workspace/group');
+    expect(create[create.length - 1]).toBe(`'claude' '--model' 'sonnet'`);
+    expect(fake.envs[0]).toMatchObject({ SECRET: 'x' });
+    expect(s.running).toBe(true);
+    expect(s.lastSpawnAt).toBeGreaterThan(0);
+    // The generated conf carries the technical floor.
+    const conf = fs.readFileSync(path.join(dir, 'tmux.conf'), 'utf8');
+    expect(conf).toContain('remain-on-exit on');
+    expect(conf).toContain('terminal-overrides ",*:RGB"');
+  });
+
+  test('onSpawn fires per life and a failed create throws', async () => {
+    const fake = fakeExec();
+    fake.respond('new-session', { exitCode: 1, stdout: '', stderr: 'duplicate session' });
+    const spawns: number[] = [];
+    const s = session(fake, tempDir(), { onSpawn: (at) => spawns.push(at) });
+    disposables.push(s);
+    await expect(s.start()).rejects.toThrow('duplicate session');
+    expect(spawns).toHaveLength(0);
+  });
+
+  test('write sends hex octets in order and chunks long payloads', async () => {
+    const fake = fakeExec();
+    const s = session(fake, tempDir());
+    disposables.push(s);
+    await s.start();
+    fake.calls.length = 0;
+
+    const paste = `\x1b[200~${'a'.repeat(300)}\x1b[201~\r`;
+    s.write(paste);
+    // Drain the write chain.
+    await new Promise((r) => setTimeout(r, 20));
+
+    const sends = fake.calls.filter((c) => c.includes('send-keys'));
+    expect(sends.length).toBeGreaterThan(1); // >256 octets → chunked
+    const octets = sends.flatMap((c) => c.slice(c.indexOf('-H') + 1));
+    const rebuilt = Buffer.from(octets.map((h) => parseInt(h, 16)));
+    expect(rebuilt.toString('utf8')).toBe(paste); // byte-faithful, ordered
+  });
+
+  test('a dead pane respawns with backoff, onSpawn re-fires, lastSpawnAt moves', async () => {
+    const fake = fakeExec();
+    const spawns: number[] = [];
+    const s = session(fake, tempDir(), { onSpawn: (at) => spawns.push(at) });
+    disposables.push(s);
+    await s.start();
+    const firstSpawn = s.lastSpawnAt;
+
+    fake.respond('list-panes', { exitCode: 0, stdout: '1\n', stderr: '' });
+    await new Promise((r) => setTimeout(r, 40)); // one poll observes the death
+    expect(s.running).toBe(false);
+    fake.respond('list-panes', { exitCode: 0, stdout: '0\n', stderr: '' });
+    await new Promise((r) => setTimeout(r, 60)); // backoff elapses, respawn-pane runs
+
+    expect(fake.calls.some((c) => c.includes('respawn-pane'))).toBe(true);
+    expect(spawns).toHaveLength(2);
+    expect(s.lastSpawnAt).toBeGreaterThanOrEqual(firstSpawn);
+    expect(s.running).toBe(true);
+  });
+
+  test('the argv is resolved for every life, and respawn carries the resolved command explicitly', async () => {
+    const fake = fakeExec();
+    const lives: Array<{ life: number; previousLifeHealthy: boolean | null }> = [];
+    const s = session(fake, tempDir(), {
+      args: (ctx) => {
+        lives.push(ctx);
+        return ctx.life === 1 ? ['--session-id', 'c1'] : ['--resume', 'c1'];
+      },
+    });
+    disposables.push(s);
+    await s.start();
+    const create = fake.calls.find((c) => c.includes('new-session'))!;
+    expect(create[create.length - 1]).toBe("'claude' '--session-id' 'c1'");
+    expect(lives).toEqual([{ life: 1, previousLifeHealthy: null }]);
+
+    fake.respond('list-panes', { exitCode: 0, stdout: '1\n', stderr: '' });
+    await new Promise((r) => setTimeout(r, 40)); // one poll observes the death
+    fake.respond('list-panes', { exitCode: 0, stdout: '0\n', stderr: '' });
+    await new Promise((r) => setTimeout(r, 60)); // backoff elapses, respawn-pane runs
+
+    // A bare respawn-pane would re-run the create-time argv; the second
+    // life's own command rides along instead.
+    const respawn = fake.calls.find((c) => c.includes('respawn-pane'))!;
+    expect(respawn[respawn.length - 1]).toBe("'claude' '--resume' 'c1'");
+    expect(lives).toEqual([
+      { life: 1, previousLifeHealthy: null },
+      { life: 2, previousLifeHealthy: false }, // died inside healthyRunMs (10 s here)
+    ]);
+    expect(s.running).toBe(true);
+  });
+
+  test('a life that outlives healthyRunMs is reported healthy to the next resolver call', async () => {
+    const fake = fakeExec();
+    const lives: Array<{ life: number; previousLifeHealthy: boolean | null }> = [];
+    const s = session(fake, tempDir(), {
+      healthyRunMs: 0,
+      args: (ctx) => {
+        lives.push(ctx);
+        return [];
+      },
+    });
+    disposables.push(s);
+    await s.start();
+
+    fake.respond('list-panes', { exitCode: 0, stdout: '1\n', stderr: '' });
+    await new Promise((r) => setTimeout(r, 40));
+    fake.respond('list-panes', { exitCode: 0, stdout: '0\n', stderr: '' });
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(lives.at(-1)).toEqual({ life: 2, previousLifeHealthy: true });
+    const respawn = fake.calls.find((c) => c.includes('respawn-pane'))!;
+    expect(respawn[respawn.length - 1]).toBe("'claude'");
+  });
+
+  test('a vanished server falls back to a full new-session respawn', async () => {
+    const fake = fakeExec();
+    const s = session(fake, tempDir());
+    disposables.push(s);
+    await s.start();
+    fake.calls.length = 0;
+
+    fake.respond('list-panes', { exitCode: 1, stdout: '', stderr: 'no server running' });
+    await new Promise((r) => setTimeout(r, 40));
+    fake.respond('list-panes', OK);
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(fake.calls.filter((c) => c.includes('new-session')).length).toBe(1);
+    expect(s.running).toBe(true);
+  });
+
+  test('detachClients detaches every client with the notice in its place, then waits for them to go', async () => {
+    const fake = fakeExec();
+    const dir = tempDir();
+    const s = session(fake, dir);
+    disposables.push(s);
+    await s.start();
+    fake.calls.length = 0;
+    // Still listed on the first look (the client is restoring its terminal), gone on the second.
+    let looks = 0;
+    fake.respond('list-clients', () =>
+      looks++ === 0 ? { exitCode: 0, stdout: '/dev/pts/3: agent\n', stderr: '' } : OK,
+    );
+    await expect(s.detachClients("retired; it's over")).resolves.toBe(true);
+    const sock = path.join(dir, 'tmux.sock');
+    // The life watcher's own list-panes polls interleave; only the detach's calls matter here.
+    const calls = fake.calls.filter((c) => c[3] !== 'list-panes');
+    expect(calls[0]).toEqual([
+      'tmux',
+      '-S',
+      sock,
+      'detach-client',
+      '-s',
+      'agent',
+      '-E',
+      `printf '%s\\n' 'retired; it'\\''s over'`,
+    ]);
+    expect(calls.slice(1)).toEqual([
+      ['tmux', '-S', sock, 'list-clients', '-t', 'agent'],
+      ['tmux', '-S', sock, 'list-clients', '-t', 'agent'],
+    ]);
+  });
+
+  test('detachClients gives up after its timeout and falls back to a plain detach when -E is refused', async () => {
+    const fake = fakeExec();
+    const dir = tempDir();
+    const s = session(fake, dir);
+    disposables.push(s);
+    await s.start();
+    fake.calls.length = 0;
+    fake.respond('detach-client', {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'usage: detach-client [-aP] [-s target-session] [-t target-client]',
+    });
+    fake.respond('list-clients', { exitCode: 0, stdout: '/dev/pts/3: agent\n', stderr: '' });
+    const started = Date.now();
+    await expect(s.detachClients('retired', 250)).resolves.toBe(false);
+    expect(Date.now() - started).toBeGreaterThanOrEqual(200);
+    const detaches = fake.calls.filter((c) => c[3] === 'detach-client');
+    expect(detaches).toHaveLength(2);
+    expect(detaches[0]).toContain('-E');
+    expect(detaches[1]).toEqual(['tmux', '-S', path.join(dir, 'tmux.sock'), 'detach-client', '-s', 'agent']);
+    // Polling stops with the timeout.
+    const looks = () => fake.calls.filter((c) => c[3] === 'list-clients').length;
+    const polled = looks();
+    expect(polled).toBeGreaterThanOrEqual(2);
+    await new Promise((r) => setTimeout(r, 250));
+    expect(looks()).toBe(polled);
+  });
+
+  test('dispose kills the server and stops writes', async () => {
+    const fake = fakeExec();
+    const s = session(fake, tempDir());
+    await s.start();
+    s.dispose();
+    const kills = fake.calls.filter((c) => c.includes('kill-server'));
+    expect(kills).toHaveLength(1);
+    fake.calls.length = 0;
+    s.write('after');
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.calls).toHaveLength(0);
+  });
+});
+
+const tmuxAvailable = Bun.which('tmux') !== null;
+
+describe.if(tmuxAvailable)('TmuxSession (real tmux)', () => {
+  test('bytes reach the pane process verbatim and a killed child respawns', async () => {
+    const dir = tempDir();
+    const rx = path.join(dir, 'rx');
+    const pidFile = path.join(dir, 'pid');
+    // stty raw -echo: the pane tty must not cook our bytes — the paste
+    // wrapper and CR are the payload under test. The pid file is written
+    // AFTER stty so its existence proves raw mode is up: bytes written
+    // before that land in a cooked tty and the test would race itself.
+    const s = new TmuxSession({
+      command: 'sh',
+      args: ['-c', `stty raw -echo; echo $$ > ${pidFile}; exec cat > ${rx}`],
+      cwd: dir,
+      env: { ...process.env } as Record<string, string>,
+      socketPath: path.join(dir, 'tmux.sock'),
+      confPath: path.join(dir, 'tmux.conf'),
+      restartDelayMs: 50,
+      pollMs: 50,
+    });
+    disposables.push(s);
+    await s.start();
+    const readyDeadline = Date.now() + 5_000;
+    while (!fs.existsSync(pidFile) && Date.now() < readyDeadline) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(fs.existsSync(pidFile)).toBe(true);
+
+    const paste = `\x1b[200~hello over tmux\x1b[201~\r`;
+    s.write(paste);
+    const deadline = Date.now() + 5_000;
+    let got = '';
+    while (Date.now() < deadline) {
+      try {
+        got = fs.readFileSync(rx, 'utf8');
+        if (got.length >= paste.length) break;
+      } catch {
+        // pane still booting
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(got).toBe(paste);
+
+    // Kill the child; remain-on-exit holds the pane and the watcher respawns.
+    const firstPid = fs.readFileSync(pidFile, 'utf8').trim();
+    const firstSpawnAt = s.lastSpawnAt;
+    process.kill(Number(firstPid), 'SIGKILL');
+    const respawnDeadline = Date.now() + 8_000;
+    while (Date.now() < respawnDeadline) {
+      const pid = fs.existsSync(pidFile) ? fs.readFileSync(pidFile, 'utf8').trim() : firstPid;
+      if (pid !== firstPid && s.lastSpawnAt > firstSpawnAt && s.running) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(s.lastSpawnAt).toBeGreaterThan(firstSpawnAt);
+    expect(s.running).toBe(true);
+  }, 20_000);
+
+  test('detachClients puts an attached client back on its own terminal with the notice', async () => {
+    const dir = tempDir();
+    const sock = path.join(dir, 'tmux.sock');
+    const s = new TmuxSession({
+      command: 'sleep',
+      args: ['60'],
+      cwd: dir,
+      env: { ...process.env } as Record<string, string>,
+      socketPath: sock,
+      confPath: path.join(dir, 'tmux.conf'),
+      restartDelayMs: 50,
+      pollMs: 50,
+    });
+    disposables.push(s);
+    await s.start();
+    // A second tmux server stands in for the operator's terminal: its pane is
+    // the pty the client attaches from, and what the client leaves behind
+    // after detaching is what the operator would read.
+    const outer = path.join(dir, 'outer.sock');
+    const exitFile = path.join(dir, 'client-exit');
+    const run = async (argv: string[]): Promise<string> => {
+      const proc = Bun.spawn(['tmux', '-S', outer, ...argv], { stdout: 'pipe', stderr: 'pipe', stdin: 'ignore' });
+      const [out] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+      return out;
+    };
+    const client =
+      `unset TMUX; tmux -S ${shQuote(sock)} attach-session -t agent; ` +
+      `echo "exit=$?" > ${shQuote(exitFile)}; sleep 30`;
+    await run(['new-session', '-d', '-s', 'outer', '-x', '80', '-y', '24', client]);
+    try {
+      const attached = Date.now() + 5_000;
+      let listed = '';
+      while (!listed.trim() && Date.now() < attached) {
+        const proc = Bun.spawn(['tmux', '-S', sock, 'list-clients'], {
+          stdout: 'pipe',
+          stderr: 'pipe',
+          stdin: 'ignore',
+        });
+        [listed] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+        if (!listed.trim()) await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(listed.trim()).not.toBe('');
+
+      const notice = '[nanoclaw] session retired after 4h idle; reconnect to wake it';
+      expect(await s.detachClients(notice)).toBe(true);
+
+      const exited = Date.now() + 5_000;
+      while (!fs.existsSync(exitFile) && Date.now() < exited) await new Promise((r) => setTimeout(r, 50));
+      expect(fs.readFileSync(exitFile, 'utf8').trim()).toBe('exit=0');
+      const screen = await run(['capture-pane', '-p', '-t', 'outer']);
+      expect(screen).toContain(notice);
+    } finally {
+      await run(['kill-server']);
+    }
+  }, 20_000);
+});

--- a/container/agent-runner/src/code-runner/tmux-session.ts
+++ b/container/agent-runner/src/code-runner/tmux-session.ts
@@ -1,0 +1,371 @@
+/**
+ * The tmux-owned interactive session . The session lives in a tmux server on a container-private
+ * socket; attach is a host-mediated exec into `tmux attach` — resize,
+ * redraw, multi-client, detach and scrollback are tmux's, not ours.
+ *
+ * Exposes the surface the mailbox delivery loop consumes (MailboxSession: write / running / lastSpawnAt) plus
+ * the per-life respawn contract: the session is the durable thing, the
+ * process inside it is disposable. On every child spawn — respawns included —
+ * onSpawn fires so per-life state (the mailbox readiness gate's state file)
+ * resets exactly like first boot; a respawn mid-ack-wait is detected by
+ * lastSpawnAt moving, and the pending claim is released, never acked.
+ *
+ * Delivery stays byte-faithful to the PTY era: write() feeds the pane's
+ * stdin through `send-keys -H` (hex octets), so the bracketed-paste wrapper
+ * and the bare-CR nudge arrive as the identical byte sequences the hardened
+ * ack machinery was proven against. The paste mechanics change transport;
+ * the contract does not.
+ *
+ * tmux is driven entirely through its CLI behind an injectable exec seam, so
+ * unit tests fake the binary and one integration test exercises real tmux.
+ */
+import fs from 'fs';
+import path from 'path';
+
+/** Container-private, like the agent-state file. The host-side attach
+ * resolution pins the same literal (src/cli/attach-resolve.ts) — a
+ * hand-synced contract, exactly like the attach-socket path before it. */
+export const TMUX_SOCKET_PATH = '/tmp/code-runner/tmux.sock';
+export const TMUX_SESSION_NAME = 'agent';
+const TMUX_CONF_PATH = '/tmp/code-runner/tmux.conf';
+
+/**
+ * The generated server config. Only the technical floor lives here — the
+ * term-audit matrix over tmux is the acceptance instrument that decides any
+ * further polish:
+ *  - default-terminal + RGB override: the pane advertises what the PTY-era
+ *    SESSION_TERM_ENV advertised (xterm-256color + truecolor), honestly —
+ *    tmux re-encodes SGR only when the outer terminal cannot carry it.
+ *  - escape-time: tmux's default 500ms ESC disambiguation reads as input lag
+ *    inside a TUI that treats bare ESC as a key.
+ *  - remain-on-exit: a dead claude leaves the pane (and every attached
+ *    client) in place for the respawn watcher instead of tearing the session
+ *    down mid-attach.
+ *  - status off: the session IS the window here — there are no other tmux
+ *    windows to switch between, so a status bar only steals a row and
+ *    announces plumbing the operator did not ask to see. With it off the
+ *    pane is exactly the client's geometry.
+ *  - set-titles + #{pane_title}: the agent's own OSC title (the CLI sets one)
+ *    reaches the operator's window/tab instead of tmux's session bookkeeping,
+ *    so a remote sandbox names itself like a local session would.
+ *  - allow-passthrough / extended-keys / extkeys: the CLI's documented tmux
+ *    requirements (code.claude.com/docs/en/terminal-config) — passthrough
+ *    lets its desktop notifications and progress reach the outer terminal
+ *    instead of being swallowed, and extended keys are what make Shift+Enter
+ *    a newline rather than a submit.
+ *  - set-clipboard on + the clipboard terminal-feature: tmux's DEFAULT is
+ *    'external', which only relays an application's own OSC 52 and leaves
+ *    tmux's own copy in a container-private buffer — so selecting text with
+ *    the mouse copies nothing to the operator's machine (measured on a
+ *    prototype). 'on' makes tmux emit OSC 52 itself, which rides the exec stream
+ *    and ssh back to the real terminal; the feature declaration is required
+ *    because the client's forced TERM carries no Ms capability.
+ */
+const TMUX_CONF = `set -g default-terminal "xterm-256color"
+set -as terminal-overrides ",*:RGB"
+set -s escape-time 10
+set -g history-limit 100000
+set -g focus-events on
+set -g mouse on
+set -g remain-on-exit on
+set -g set-clipboard on
+set -ag terminal-features ",xterm-256color:clipboard"
+set -g status off
+set -g set-titles on
+set -g set-titles-string "#{pane_title}"
+set -g allow-passthrough on
+set -s extended-keys on
+set -ag terminal-features ",xterm*:extkeys"
+`;
+
+export interface TmuxExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Exec seam: run one tmux CLI invocation. `env` is only ever passed on the
+ * server-starting call — the server inherits it and panes inherit the server. */
+export type TmuxExec = (argv: string[], opts?: { env?: Record<string, string> }) => Promise<TmuxExecResult>;
+
+const defaultExec: TmuxExec = async (argv, opts) => {
+  const proc = Bun.spawn(argv, {
+    env: opts?.env ?? process.env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    stdin: 'ignore',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+};
+
+/** tmux joins multi-arg shell-commands with spaces and hands them to sh — a
+ * respawn re-runs the same string — so each argv token is quoted once here
+ * and survives both trips. */
+export function shQuote(token: string): string {
+  return `'${token.replace(/'/g, `'\\''`)}'`;
+}
+
+/** What a per-life argv resolver learns about the life it is arming. */
+export interface LifeContext {
+  /** 1 for the first child life, counting every respawn. */
+  life: number;
+  /** Whether the previous life ran at least healthyRunMs; null on the first life. */
+  previousLifeHealthy: boolean | null;
+}
+
+export interface TmuxSessionOptions {
+  command: string;
+  /**
+   * The child's argv, or a resolver asked before EVERY life — respawns
+   * included — so a flag that depends on state the previous life left
+   * behind (a conversation to resume) is recomputed, never replayed from
+   * the create-time command. A resolver that throws costs that life its
+   * spawn (logged), and the watcher tries again after the backoff.
+   */
+  args: string[] | ((life: LifeContext) => string[]);
+  cwd: string;
+  env: Record<string, string>;
+  cols?: number;
+  rows?: number;
+  restartDelayMs?: number;
+  maxRestartDelayMs?: number;
+  /** A run at least this long resets the restart backoff. */
+  healthyRunMs?: number;
+  /** Fires on EVERY child spawn, respawns included (per-life state reset). */
+  onSpawn?: (at: number) => void;
+  socketPath?: string;
+  confPath?: string;
+  pollMs?: number;
+  exec?: TmuxExec;
+  now?: () => number;
+}
+
+const DEFAULTS = {
+  cols: 220,
+  rows: 50,
+  restartDelayMs: 1_000,
+  maxRestartDelayMs: 30_000,
+  healthyRunMs: 30_000,
+  socketPath: TMUX_SOCKET_PATH,
+  confPath: TMUX_CONF_PATH,
+  pollMs: 1_000,
+};
+
+/** send-keys octets per invocation. Chunking bounds argv size; the write
+ * queue serializes chunks so a paste always lands in order. */
+const HEX_CHUNK = 256;
+
+export class TmuxSession {
+  private readonly opts: Required<Omit<TmuxSessionOptions, 'onSpawn' | 'exec' | 'now'>> & {
+    onSpawn?: (at: number) => void;
+    exec: TmuxExec;
+    now: () => number;
+  };
+  private startedAt = 0;
+  private restartDelay: number;
+  private restartTimer: ReturnType<typeof setTimeout> | null = null;
+  private watchTimer: ReturnType<typeof setInterval> | null = null;
+  private alive = false;
+  private disposed = false;
+  private checking = false;
+  private lives = 0;
+  /** Whether the life that just ended ran at least healthyRunMs (null before the first respawn). */
+  private lastLifeHealthy: boolean | null = null;
+  /** Serializes send-keys chunks — delivery order is the paste's integrity. */
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(options: TmuxSessionOptions) {
+    this.opts = { ...DEFAULTS, exec: defaultExec, now: () => Date.now(), ...options };
+    this.restartDelay = this.opts.restartDelayMs;
+  }
+
+  /** Spawn time of the CURRENT child life (0 before the first spawn). */
+  get lastSpawnAt(): number {
+    return this.startedAt;
+  }
+
+  get running(): boolean {
+    return this.alive;
+  }
+
+  async start(): Promise<void> {
+    if (this.disposed) throw new Error('TmuxSession: start() after dispose()');
+    fs.mkdirSync(path.dirname(this.opts.confPath), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(this.opts.confPath, TMUX_CONF);
+    await this.spawnSession();
+    this.watchTimer = setInterval(() => void this.checkLife(), this.opts.pollMs);
+  }
+
+  /** Feed bytes to the pane exactly as the PTY write did — hex octets through
+   * send-keys, chunked and strictly ordered. Fire-and-forget like the PTY
+   * write; the ack machinery's windows dwarf the CLI round trip. */
+  write(data: Buffer | string): void {
+    const bytes = typeof data === 'string' ? Buffer.from(data, 'utf8') : data;
+    const hex: string[] = [];
+    for (const b of bytes) hex.push(b.toString(16).padStart(2, '0'));
+    for (let i = 0; i < hex.length; i += HEX_CHUNK) {
+      const chunk = hex.slice(i, i + HEX_CHUNK);
+      this.writeChain = this.writeChain.then(async () => {
+        if (this.disposed) return;
+        await this.tmux(['send-keys', '-t', TMUX_SESSION_NAME, '-H', ...chunk]);
+      });
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    if (this.restartTimer) clearTimeout(this.restartTimer);
+    this.restartTimer = null;
+    if (this.watchTimer) clearInterval(this.watchTimer);
+    this.watchTimer = null;
+    this.alive = false;
+    void this.tmux(['kill-server']);
+  }
+
+  /**
+   * Detach every attached client cleanly, leaving `notice` on its terminal —
+   * for a runner retiring under a still-attached operator. tmux's own detach
+   * restores the client's terminal (mouse reporting, bracketed paste, the
+   * alternate screen), which a client killed with the container never gets
+   * to do, and `-E` runs a command in the detached client's place, so the
+   * line lands on the operator's terminal after tmux has put it back. A tmux
+   * without `-E` gets a plain detach. Best-effort and bounded: true once no
+   * client is listed, false once `timeoutMs` passes; never throws.
+   */
+  async detachClients(notice: string, timeoutMs = 2_000): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const late = new Promise<boolean>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs);
+    });
+    const work = (async (): Promise<boolean> => {
+      const farewell = `printf '%s\\n' ${shQuote(notice)}`;
+      const detach = await this.tmux(['detach-client', '-s', TMUX_SESSION_NAME, '-E', farewell]);
+      if (detach.exitCode !== 0) await this.tmux(['detach-client', '-s', TMUX_SESSION_NAME]);
+      // detach-client returns once the server has told the clients; each
+      // still has to restore its terminal and print. Wait for them to go.
+      while (Date.now() < deadline) {
+        const clients = await this.tmux(['list-clients', '-t', TMUX_SESSION_NAME]);
+        if (clients.exitCode !== 0 || clients.stdout.trim() === '') return true;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      return false;
+    })();
+    try {
+      return await Promise.race([work.catch(() => false), late]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private tmux(args: string[], opts?: { env?: Record<string, string> }): Promise<TmuxExecResult> {
+    return this.opts.exec(['tmux', '-S', this.opts.socketPath, ...args], opts);
+  }
+
+  /** The pane command for the life about to start — the argv resolved for THIS life. */
+  private paneCommand(): string {
+    const { args } = this.opts;
+    const resolved =
+      typeof args === 'function' ? args({ life: this.lives + 1, previousLifeHealthy: this.lastLifeHealthy }) : args;
+    return [this.opts.command, ...resolved].map(shQuote).join(' ');
+  }
+
+  private async spawnSession(): Promise<void> {
+    const res = await this.tmux(
+      [
+        // Force UTF-8 on the server too: it decides from the locale of
+        // whoever starts it, and the runner's env is the container's.
+        '-u',
+        '-f',
+        this.opts.confPath,
+        'new-session',
+        '-d',
+        '-s',
+        TMUX_SESSION_NAME,
+        '-x',
+        String(this.opts.cols),
+        '-y',
+        String(this.opts.rows),
+        '-c',
+        this.opts.cwd,
+        this.paneCommand(),
+      ],
+      // The server is born from this client and inherits its env wholesale;
+      // panes inherit the server. This is the only call that carries env.
+      { env: this.opts.env },
+    );
+    if (res.exitCode !== 0) {
+      throw new Error(`tmux new-session failed (${res.exitCode}): ${res.stderr.trim()}`);
+    }
+    this.markSpawn();
+  }
+
+  private markSpawn(): void {
+    this.startedAt = this.opts.now();
+    this.alive = true;
+    this.lives++;
+    this.opts.onSpawn?.(this.startedAt);
+  }
+
+  /** One life-watch poll. remain-on-exit keeps a dead claude's pane (and its
+   * attached clients) in place; this schedules the respawn with the same
+   * backoff contract. */
+  private async checkLife(): Promise<void> {
+    if (this.disposed || this.checking || this.restartTimer) return;
+    this.checking = true;
+    try {
+      const res = await this.tmux(['list-panes', '-t', TMUX_SESSION_NAME, '-F', '#{pane_dead}']);
+      if (this.disposed) return;
+      if (res.exitCode !== 0) {
+        // Server or session gone entirely (killed, crashed): a full respawn
+        // re-creates both. Clients of a killed server are gone regardless.
+        this.alive = false;
+        this.scheduleRespawn(async () => this.spawnSession());
+        return;
+      }
+      const dead = res.stdout.trim().split('\n')[0] === '1';
+      if (!dead) return;
+      this.alive = false;
+      this.scheduleRespawn(async () => {
+        // A bare respawn-pane re-runs the pane's CREATE-time command; the
+        // command rides along explicitly so every life runs the argv
+        // resolved for it (a conversation that now has a transcript resumes
+        // it, a resume that could not load starts fresh).
+        const respawn = await this.tmux(['respawn-pane', '-k', '-t', TMUX_SESSION_NAME, this.paneCommand()]);
+        if (respawn.exitCode !== 0) {
+          // The session itself may have died between polls — fall through to
+          // the full path on the next check rather than looping here.
+          console.error(`[code-runner] tmux respawn-pane failed: ${respawn.stderr.trim()}`);
+          return;
+        }
+        this.markSpawn();
+      });
+    } catch (error) {
+      console.error('[code-runner] tmux life-check failed:', error);
+    } finally {
+      this.checking = false;
+    }
+  }
+
+  private scheduleRespawn(action: () => Promise<void>): void {
+    if (this.restartTimer) return;
+    const healthy = this.opts.now() - this.startedAt >= this.opts.healthyRunMs;
+    if (healthy) this.restartDelay = this.opts.restartDelayMs;
+    // The next life's argv resolver learns how this one ended: a life that
+    // never reached its healthy-run window is a boot that did not take.
+    this.lastLifeHealthy = healthy;
+    const delay = this.restartDelay;
+    this.restartDelay = Math.min(this.restartDelay * 2, this.opts.maxRestartDelayMs);
+    console.error(`[code-runner] session process exited — respawning in ${Math.round(delay / 1000)}s`);
+    this.restartTimer = setTimeout(() => {
+      this.restartTimer = null;
+      if (this.disposed) return;
+      void action().catch((error) => console.error('[code-runner] tmux respawn failed:', error));
+    }, delay);
+  }
+}

--- a/container/agent-runner/src/code-runner/turn-stamp.test.ts
+++ b/container/agent-runner/src/code-runner/turn-stamp.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The host-visible turn stamp: monotonic seq, tmp+rename, torn/absent reads
+ * as null, and the mailbox hook writes it beside the agent state on exactly
+ * the turn-boundary events.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+
+import { readAgentState } from './agent-state.js';
+import { readTurnState, writeTurnState } from './turn-stamp.js';
+
+// NEVER import mailbox-hook.ts here (it runs main() on import — see
+// mailbox-hook.test.ts); the hook is exercised as the subprocess claude runs.
+const HOOK = path.join(import.meta.dir, 'mailbox-hook.ts');
+
+let dir: string;
+let stampPath: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-turn-'));
+  stampPath = path.join(dir, 'code-turns', 'state.json');
+});
+
+describe('turn stamp file', () => {
+  it('absent reads as null', () => {
+    expect(readTurnState(stampPath)).toBeNull();
+  });
+
+  it('writes create the directory and count seq up from 1', () => {
+    const first = writeTurnState('busy', stampPath);
+    expect(first.seq).toBe(1);
+    expect(first.state).toBe('busy');
+    const second = writeTurnState('idle', stampPath);
+    expect(second.seq).toBe(2);
+    expect(readTurnState(stampPath)).toEqual(second);
+    expect(fs.readdirSync(path.dirname(stampPath))).toEqual(['state.json']); // no tmp leftovers
+  });
+
+  it('a torn or unrecognized file reads as null', () => {
+    fs.mkdirSync(path.dirname(stampPath), { recursive: true });
+    fs.writeFileSync(stampPath, '{"state":"bu');
+    expect(readTurnState(stampPath)).toBeNull();
+    fs.writeFileSync(stampPath, JSON.stringify({ state: 'weird', at: 'x', seq: 1 }));
+    expect(readTurnState(stampPath)).toBeNull();
+    fs.writeFileSync(stampPath, JSON.stringify({ state: 'idle', at: 'x' }));
+    expect(readTurnState(stampPath)).toBeNull();
+  });
+});
+
+describe('mailbox hook stamps the turn', () => {
+  function runHook(payload: unknown): number {
+    const proc = Bun.spawnSync(['bun', HOOK, path.join(dir, 'agent-state.json')], {
+      stdin: Buffer.from(JSON.stringify(payload)),
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...process.env,
+        NANOCLAW_MAIL_NOTICE: path.join(dir, 'mail-notice.json'),
+        NANOCLAW_CONTAINER_JSON: path.join(dir, 'container.json'),
+        NANOCLAW_TURN_STATE: stampPath,
+      },
+    });
+    return proc.exitCode;
+  }
+
+  beforeEach(() => {
+    fs.writeFileSync(path.join(dir, 'container.json'), JSON.stringify({ codeMode: true }));
+  });
+
+  it('UserPromptSubmit → busy, Stop → idle, SessionStart → idle; seq advances per event', () => {
+    expect(runHook({ hook_event_name: 'SessionStart' })).toBe(0);
+    expect(readTurnState(stampPath)).toMatchObject({ state: 'idle', seq: 1 });
+    expect(runHook({ hook_event_name: 'UserPromptSubmit' })).toBe(0);
+    expect(readTurnState(stampPath)).toMatchObject({ state: 'busy', seq: 2 });
+    expect(runHook({ hook_event_name: 'Stop' })).toBe(0);
+    expect(readTurnState(stampPath)).toMatchObject({ state: 'idle', seq: 3 });
+    // The agent state moved in lockstep.
+    expect(readAgentState(path.join(dir, 'agent-state.json'))?.state).toBe('idle');
+  });
+
+  it('tool-call events leave the turn stamp alone', () => {
+    expect(runHook({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: {} })).toBe(0);
+    expect(runHook({ hook_event_name: 'PostToolUse' })).toBe(0);
+    expect(readTurnState(stampPath)).toBeNull();
+  });
+
+  it('an unwritable stamp path never costs the agent state or the exit code', () => {
+    fs.mkdirSync(path.dirname(stampPath), { recursive: true });
+    fs.chmodSync(path.dirname(stampPath), 0o500);
+    try {
+      expect(runHook({ hook_event_name: 'UserPromptSubmit' })).toBe(0);
+      expect(readAgentState(path.join(dir, 'agent-state.json'))?.state).toBe('busy');
+    } finally {
+      fs.chmodSync(path.dirname(stampPath), 0o700);
+    }
+  });
+});

--- a/container/agent-runner/src/code-runner/turn-stamp.ts
+++ b/container/agent-runner/src/code-runner/turn-stamp.ts
@@ -1,0 +1,60 @@
+/**
+ * Turn stamp — the host-visible half of the idle/busy state.
+ *
+ * agent-state.ts lives under /tmp (container-private) because the mailbox
+ * delivery loop is its only reader. The host mirrors a coding session's
+ * progress to a chat surface (src/code-mode/surface) and needs the
+ * same two facts — is a turn running, and when did the last one end — so the
+ * mailbox hook stamps them a second time here, under /workspace, which IS
+ * the session dir on the host (the boundary request seam rides the same
+ * mount, boundary.ts).
+ *
+ * Deliberately a separate file from the agent state: the agent state is
+ * per child life (deleted on every spawn to re-arm the readiness gate) and
+ * carries the notify high-water mark; this stamp is per session, survives a
+ * respawn and a reap, and carries nothing the mailbox cares about. The host
+ * treats a stamp as informative only while the container is running.
+ *
+ * `seq` is a monotonic counter so a reader can tell a NEW idle stamp from
+ * the one it already acted on when two turns end inside one poll interval.
+ * The file is agent-writable like everything under /workspace; a forged
+ * stamp can only mislabel the agent's own session status.
+ *
+ * Same file discipline as the agent state: tmp+rename, and a torn or absent
+ * file parses as null.
+ */
+import fs from 'fs';
+import path from 'path';
+
+/** In-container home; host-side this is `<sessDir>/code-turns/state.json`. */
+export const TURN_STATE_PATH = '/workspace/code-turns/state.json';
+
+export interface TurnState {
+  state: 'idle' | 'busy';
+  /** ISO timestamp of the write. */
+  at: string;
+  /** Monotonic write counter for this session (starts at 1). */
+  seq: number;
+}
+
+export function readTurnState(filePath: string = TURN_STATE_PATH): TurnState | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf8')) as TurnState;
+    if (raw.state !== 'idle' && raw.state !== 'busy') return null;
+    if (typeof raw.seq !== 'number' || !Number.isFinite(raw.seq)) return null;
+    if (typeof raw.at !== 'string') return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+export function writeTurnState(state: TurnState['state'], filePath: string = TURN_STATE_PATH): TurnState {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o755 });
+  const previous = readTurnState(filePath);
+  const next: TurnState = { state, at: new Date().toISOString(), seq: (previous?.seq ?? 0) + 1 };
+  const tmp = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(next));
+  fs.renameSync(tmp, filePath);
+  return next;
+}

--- a/container/agent-runner/src/config.ts
+++ b/container/agent-runner/src/config.ts
@@ -9,7 +9,9 @@ import fs from 'fs';
 
 import type { McpServerConfig, ProviderSpeed } from './providers/types.js';
 
-const CONFIG_PATH = '/workspace/agent/container.json';
+// The path is fixed in production; the env override is a test seam for the
+// code runner's hook scripts, which run as claude subprocesses.
+const CONFIG_PATH = process.env.NANOCLAW_CONTAINER_JSON || '/workspace/agent/container.json';
 
 export interface RunnerConfig {
   provider: string;
@@ -20,6 +22,8 @@ export interface RunnerConfig {
   mcpServers: Record<string, McpServerConfig>;
   model?: string;
   effort?: string;
+  /** The group runs the code runner instead of the chat runner (host-selected at spawn). */
+  codeMode?: boolean;
   speed?: ProviderSpeed;
 }
 
@@ -57,6 +61,7 @@ export function runnerConfigFromRaw(raw: Record<string, unknown>): RunnerConfig 
     mcpServers: (raw.mcpServers as RunnerConfig['mcpServers']) || {},
     model: (raw.model as string) || undefined,
     effort: (raw.effort as string) || undefined,
+    codeMode: raw.codeMode === true || undefined,
     speed: readSpeed(raw),
   };
 }

--- a/container/agent-runner/src/db/index.ts
+++ b/container/agent-runner/src/db/index.ts
@@ -5,6 +5,7 @@ export {
   markProcessing,
   markCompleted,
   markFailed,
+  releaseProcessingClaims,
   getMessageIn,
   findQuestionResponse,
 } from './messages-in.js';

--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -111,3 +111,8 @@ export function findCliResponse(requestId: string): MessageInRow | undefined {
   const message = getAgentMailbox().operations.findCliResponse(requestId);
   return message && messageRow(message);
 }
+
+/** Store-neutral: whichever mailbox is composed owns the ack rows. */
+export function releaseProcessingClaims(ids: string[]): void {
+  getAgentMailbox().operations.releaseProcessingClaims(ids);
+}

--- a/container/agent-runner/src/mailbox/sqlite/index.ts
+++ b/container/agent-runner/src/mailbox/sqlite/index.ts
@@ -27,6 +27,7 @@ import {
   sqliteTimestamp,
   sqliteWriteMessageOut,
 } from './operations.js';
+import { releaseProcessingClaims as sqliteReleaseProcessingClaims } from './release.js';
 import type { MessageInRow } from '../../db/messages-in.js';
 import type { MessageOutRow } from '../../db/messages-out.js';
 import {
@@ -224,4 +225,5 @@ export class SqliteAgentMailbox implements AgentMailbox {
 
   clearContainerToolInFlight = sqliteClearContainerToolInFlight;
   clearStaleProcessingAcks = sqliteClearStaleProcessingAcks;
+  releaseProcessingClaims = sqliteReleaseProcessingClaims;
 }

--- a/container/agent-runner/src/mailbox/sqlite/operations.ts
+++ b/container/agent-runner/src/mailbox/sqlite/operations.ts
@@ -58,8 +58,14 @@ export function sqliteGetPendingMessages(isFirstPoll: boolean, limit: number): M
 
 function mark(ids: string[], status: string): void {
   if (ids.length === 0) return;
+  // A processing CLAIM only ever fills an empty slot: a row already carrying
+  // an ack (completed, failed, skipped) is terminal and must not be
+  // downgraded by a claim that raced it — the reader that acked has already
+  // consumed the message. Every other status is a write of the final word.
   const statement = getOutboundDb().prepare(
-    'INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, ?, ?)',
+    status === 'processing'
+      ? 'INSERT OR IGNORE INTO processing_ack (message_id, status, status_changed) VALUES (?, ?, ?)'
+      : 'INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, ?, ?)',
   );
   getOutboundDb().transaction(() => {
     for (const id of ids) statement.run(id, status, new Date().toISOString());

--- a/container/agent-runner/src/mailbox/sqlite/release.ts
+++ b/container/agent-runner/src/mailbox/sqlite/release.ts
@@ -1,0 +1,16 @@
+/**
+ * Return processing claims for retry without acknowledging their messages.
+ * A failed acknowledgment is terminal to Host delivery, so retry must delete
+ * only processing claims. SqliteAgentMailbox exposes this through the shared
+ * mailbox interface; callers do not depend on the storage implementation.
+ */
+import { getOutboundDb } from './connection.js';
+
+export function releaseProcessingClaims(ids: string[]): void {
+  if (ids.length === 0) return;
+  const db = getOutboundDb();
+  const stmt = db.prepare("DELETE FROM processing_ack WHERE message_id = ? AND status = 'processing'");
+  db.transaction(() => {
+    for (const id of ids) stmt.run(id);
+  })();
+}

--- a/container/agent-runner/src/mailbox/sqlite/sqlite.test.ts
+++ b/container/agent-runner/src/mailbox/sqlite/sqlite.test.ts
@@ -127,6 +127,51 @@ describe('SQLite runner mailbox canonical serialization', () => {
     ]);
   });
 
+  test('releaseProcessingClaims returns processing claims for retry and leaves acknowledged rows alone', async () => {
+    const { outbound } = initTestSessionDb();
+    const mailbox = new SqliteAgentMailbox();
+    await mailbox.start({ agentGroupId: 'agent', sessionId: 'session', mailbox: null });
+    mailbox.markMessages(['in-1', 'in-2'], 'processing');
+    mailbox.markMessages(['in-3'], 'completed');
+    const statuses = () =>
+      (
+        outbound.prepare('SELECT message_id, status FROM processing_ack ORDER BY message_id').all() as Array<{
+          message_id: string;
+          status: string;
+        }>
+      ).map((row) => `${row.message_id}:${row.status}`);
+    expect(statuses()).toEqual(['in-1:processing', 'in-2:processing', 'in-3:completed']);
+
+    mailbox.releaseProcessingClaims([]);
+    expect(statuses()).toEqual(['in-1:processing', 'in-2:processing', 'in-3:completed']);
+
+    // Only the named processing claims go; a completed ack is terminal and stays.
+    mailbox.releaseProcessingClaims(['in-1', 'in-3', 'unknown']);
+    expect(statuses()).toEqual(['in-2:processing', 'in-3:completed']);
+  });
+
+  test('a processing claim never downgrades an ack already on the row', async () => {
+    const { outbound } = initTestSessionDb();
+    const mailbox = new SqliteAgentMailbox();
+    await mailbox.start({ agentGroupId: 'agent', sessionId: 'session', mailbox: null });
+    mailbox.markMessages(['in-1'], 'completed');
+    mailbox.markMessages(['in-2'], 'processing');
+    // The race: a reader acked in-1 'completed'; a late claim for the same batch must not reopen it.
+    mailbox.markMessages(['in-1', 'in-2', 'in-3'], 'processing');
+    const statuses = (
+      outbound.prepare('SELECT message_id, status FROM processing_ack ORDER BY message_id').all() as Array<{
+        message_id: string;
+        status: string;
+      }>
+    ).map((row) => `${row.message_id}:${row.status}`);
+    expect(statuses).toEqual(['in-1:completed', 'in-2:processing', 'in-3:processing']);
+    // The final word still overwrites a claim.
+    mailbox.markMessages(['in-2'], 'completed');
+    expect(outbound.prepare("SELECT status FROM processing_ack WHERE message_id = 'in-2'").get()).toEqual({
+      status: 'completed',
+    });
+  });
+
   test('skips malformed pending inbound rows instead of crashing the runner', () => {
     const { inbound } = initTestSessionDb();
     inbound

--- a/container/agent-runner/src/mailbox/types.ts
+++ b/container/agent-runner/src/mailbox/types.ts
@@ -64,6 +64,14 @@ export interface MailboxOperations {
   setContainerToolInFlight(tool: string, declaredTimeoutMs: number | null): void;
   clearContainerToolInFlight(): void;
   clearStaleProcessingAcks(): void;
+  /**
+   * Give 'processing' claims back so the rows become fetchable again — the
+   * contract-correct retry at a life boundary. Deliberately NOT
+   * markMessages(ids, 'failed'): the host maps a container 'failed' ack
+   * through its complete statement to a TERMINAL 'completed', which drops
+   * mail instead of retrying it.
+   */
+  releaseProcessingClaims(ids: string[]): void;
 }
 
 export interface AgentMailbox {

--- a/container/code-mode/CLAUDE.md
+++ b/container/code-mode/CLAUDE.md
@@ -1,0 +1,138 @@
+# NanoClaw coding session
+
+You are the coding agent of a persistent sandbox. This CLI runs inside a tmux
+session in a container, and the working directory is `/workspace/group`. A
+human may be attached to this terminal, or may only be reading the chat
+surface bound to this session, or nobody may be watching. Work the same way
+in all three cases: do the task, keep the tree consistent, and report on the
+chat surface. An attached human detaches with Ctrl-b then d; keep working.
+
+What persists: everything under `/workspace`, including the working directory
+and `/workspace/tools`, plus the CLI's own state, so this conversation resumes
+after a restart when it can. What does not: the rest of the container, its
+home directory, running processes, and environment changes. When nobody is
+attached and no message arrives for a while, the container is retired; the
+next message starts it again.
+
+This file and `.claude/skills/` are mounted read-only by the host. The
+working directory starts with nothing else: the first task usually begins by
+checking a repository out here (see the `dev-git` skill).
+
+## How work arrives
+
+- **Terminal.** An attached human types a prompt. Your terminal output is
+  visible to whoever is attached and never reaches the chat surface.
+- **Mail.** Messages from the chat surface, and scheduled tasks, arrive as
+  mail. While you are idle the host types them into this terminal as a prompt
+  headed `[nanoclaw mail · sender · time]` or `[nanoclaw task · time]`; an
+  attached human sees the same text. A long message arrives as a preview that
+  ends with the command for its full text. A file sent with a message is
+  saved under `/workspace/inbox/<message id>/` and named after the text as
+  `[type: name — saved to path]`; read it from that path.
+- **Mid-turn.** While you work, a notice on a tool result reports how many new
+  messages are waiting. Finish the current step, then read them if they could
+  change what you are doing; otherwise they are delivered when the turn ends.
+- Some deployments deliver mail as channel events with a `reply` tool instead
+  of typing it. Treat both the same.
+
+```bash
+ncl inbox read              # show and consume waiting mail (a capped batch says so; read again)
+ncl inbox read --peek       # look without consuming
+ncl inbox read --id <id>    # one message in any state, e.g. the full text behind a preview
+```
+
+Consumed mail is not typed to you again. A message marked `context-only` is
+for your information and needs no reply. You do not need to poll: read mail
+when a mid-turn notice says it is waiting, and once more before you post a
+completion message so you answer everything that arrived.
+
+## Replying and reporting
+
+```bash
+ncl outbox send --text "..."                   # post to the chat surface bound to this session
+ncl outbox send --text "..." --reply-to <id>   # answer one message in its thread
+```
+
+Without `--reply-to`, a send goes to the session's default destination, the
+channel bound to this session. If no channel is bound, that send fails and
+says so; reply to a specific message instead. Only `ncl outbox send` (or the
+`reply` tool) reaches the chat surface.
+
+Post short, factual messages, and only at the points that matter:
+
+- when you take on a task from mail: one line saying what you will do;
+- when you finish: what changed, how you verified it, and what is left;
+- when you are blocked or the task is ambiguous: the concrete question.
+
+Never post transcripts, tool output, or repeated "still working" notes.
+
+When a chat surface is bound, the host mirrors the session to it without your
+help: a status that shows working while a turn runs, idle between turns, and
+suspended when the container has been retired; and after each completed turn
+the diff of the working tree, when it changed since the last one posted
+(tracked changes and new files, bounded in size, only while `/workspace/group`
+is a git repository). You never need to post a diff.
+
+`ncl help` lists the other host commands available to you.
+
+## Coding workflow
+
+- Understand before editing: read the code, find the project's build and test
+  commands, and check `git status` before you start.
+- Keep the tree buildable. Run the tests you touched, and the project's
+  formatter and linter when it has them.
+- Commit in small steps with messages that say what and why. The `dev-git`
+  skill covers checkout into this directory, author identity, local excludes
+  for host-mounted files, and commit hygiene; invoke it before the first
+  commit.
+- Never force-push, rewrite published history, or delete branches you did not
+  create unless the task says so.
+- Never commit secrets, credential stubs, or generated tokens. Review
+  `git diff --cached` before every commit.
+- When a task is ambiguous, ask on the chat surface with a concrete question
+  and continue with the part that is safe under any answer.
+
+## Stop and interrupt
+
+A human can interrupt the current turn with Escape in the terminal or with
+Stop on the chat surface. The action in flight stops where it is, and nothing
+else runs until the next message. On the first turn after an interruption,
+before anything else: check `git status`, finish or revert half-applied edits
+so the tree builds, and post one message saying where you were and what is
+half-done. Do not resume the interrupted action unless asked.
+
+## Tools and credentials
+
+The image is a Debian-based Node image running as the unprivileged user
+`node`: no root, no `sudo`, no `apt`, no Docker daemon. It ships Node, Bun,
+pnpm, npm, git, curl and unzip. Anything else goes under `/workspace/tools`
+with `/workspace/tools/bin` on `PATH`; check what is already there before
+installing. The `dev-toolchains` skill has the install recipe and the
+variables that keep caches in the workspace; invoke it when a project needs a
+toolchain the image lacks.
+
+Credentials stay outside the container. Outbound HTTPS goes through the
+configured gateway provider, which supplies access to connected services;
+honor the proxy and trust variables it provides (`HTTPS_PROXY`, `NO_PROXY`,
+`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`). The host refuses secret-shaped
+environment values. When a credential is unavailable or an operation is
+denied, report the origin and the operation on the chat surface. Do not ask
+for tokens.
+
+Most tool use runs without prompts. Writes to this file, to the CLI settings
+file, and to the host's permission policy are host-owned boundaries: they
+wait for a human decision and are denied when none arrives. Shell commands
+that name those paths are held the same way, so read this file with your
+file-reading tool rather than `cat`.
+
+## Do not
+
+- Read, print, copy, or send credential material anywhere, or route around
+  the gateway.
+- Install or modify system packages; everything you add lives under
+  `/workspace/tools`.
+- Start servers, watchers, or other long-lived processes without saying so on
+  the chat surface. They die when the container is retired; stop them when
+  the task is done.
+- Spam the chat surface: no transcripts, tool logs, or status repeats.
+- Edit this file, `.claude/skills/`, or the permission policy.

--- a/container/code-mode/skills/dev-git/SKILL.md
+++ b/container/code-mode/skills/dev-git/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: dev-git
+description: Check a repository out into the sandbox working directory, keep Git configuration in the persistent workspace, commit cleanly, and use the credentials and trust provided by the environment.
+---
+
+# Git in a persistent workspace
+
+## Configuration that survives a restart
+
+The container home is replaced on restart; `/workspace` is not. Keep global
+Git settings there, and repeat the export in every shell you use:
+
+```bash
+export GIT_CONFIG_GLOBAL=/workspace/.gitconfig
+```
+
+Set the author name and email the operator or the project asks for. Do not
+invent an identity; ask on the chat surface when neither has said.
+
+## Checking out into the working directory
+
+Check the project out at `/workspace/group` itself, not in a subdirectory:
+the chat surface's diff view follows a repository rooted there. The directory
+is never empty (the operating manual and `.claude/skills/` are mounted into
+it, read-only), so `git clone` refuses it and a plain checkout aborts when the
+project tracks its own `CLAUDE.md`. This sequence works either way:
+
+```bash
+cd /workspace/group
+git init
+git remote add origin <url>
+git fetch origin
+git symbolic-ref HEAD refs/heads/<branch>
+git reset origin/<branch>                 # index and HEAD; writes no files yet
+git ls-files --error-unmatch CLAUDE.md >/dev/null 2>&1 && git update-index --skip-worktree CLAUDE.md
+git checkout -- .                         # writes the tree, skipping the mounted manual
+git branch -u origin/<branch>
+printf '/CLAUDE.md\n/.claude/\n/.mcp.json\n' >> .git/info/exclude
+```
+
+The excludes keep the host-mounted files and the CLI's project config out of
+`git status` and out of commits; they belong in the local exclude file, never
+in a committed `.gitignore`. When the project tracks its own `CLAUDE.md`, the
+mounted manual shadows it; `git show HEAD:CLAUDE.md` prints the project's
+copy, and the skip-worktree mark keeps it out of status and commits.
+
+## Commit hygiene
+
+- One logical change per commit; the message says what changed and why.
+- Run the tests you touched before committing.
+- Stage deliberately with `git add <paths>` and review `git diff --cached`.
+  Never commit secrets, credential stubs, tokens, or build output.
+- Never force-push, rebase or amend published commits, or delete branches you
+  did not create unless the task says so.
+
+## Proxy and trust
+
+When your environment uses an HTTP proxy, HTTPS remotes can use it. An
+optional rewrite for tools that choose SSH URLs is:
+
+```bash
+git config --global url."https://github.com/".insteadOf git@github.com:
+git config --global --add url."https://github.com/".insteadOf ssh://git@github.com/
+```
+
+Honor `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`. If the environment supplies
+`SSL_CERT_FILE`, use that trust bundle for Git:
+
+```bash
+if [ -n "${SSL_CERT_FILE:-}" ]; then
+  git config --global http.sslCAInfo "$SSL_CERT_FILE"
+fi
+```
+
+## Credentials
+
+Credentials are supplied by the configured gateway provider. Report an
+authentication or authorization failure with the origin and operation; do not
+persist a token in a remote URL, file, or environment variable.

--- a/container/code-mode/skills/dev-toolchains/SKILL.md
+++ b/container/code-mode/skills/dev-toolchains/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: dev-toolchains
+description: Install the toolchain versions a project declares under the persistent /workspace/tools, keep package caches there, and honor the environment's proxy and trust.
+---
+
+# Project toolchains
+
+## What the image provides
+
+A Debian-based Node image running as the unprivileged user `node`: Node, Bun,
+pnpm, npm, git, curl and unzip (`node --version` tells the exact release). No
+root, no `sudo`, no `apt`, no Docker daemon. Everything else is installed
+under `/workspace/tools`, which survives a container restart; the home
+directory does not.
+
+## Layout and PATH
+
+```bash
+mkdir -p /workspace/tools/bin
+export PATH="/workspace/tools/bin:$PATH"
+```
+
+Install each tool under `/workspace/tools/<tool>/<version>/` and link its
+executables into `/workspace/tools/bin`. Check what is already there before
+installing, and use the versions the project declares (`.nvmrc`,
+`.tool-versions`, `package.json` engines, `go.mod`, `rust-toolchain.toml`).
+Keep your exports in `/workspace/tools/env.sh` and source it in each shell;
+the environment does not persist between sessions.
+
+## Install recipe
+
+1. Download the publisher's release archive for Linux and the container's
+   architecture (`uname -m`).
+2. Verify it against the publisher's checksum or signature; stop and report a
+   mismatch rather than installing.
+3. Unpack under `/workspace/tools/<tool>/<version>/`, then link:
+
+```bash
+ln -sf /workspace/tools/<tool>/<version>/bin/<tool> /workspace/tools/bin/<tool>
+```
+
+## Caches and homes in the workspace
+
+Point package managers at the workspace so downloads survive a restart and
+never land in the disposable home directory:
+
+```bash
+export npm_config_cache=/workspace/tools/cache/npm
+export PNPM_HOME=/workspace/tools/pnpm PNPM_STORE_DIR=/workspace/tools/cache/pnpm
+export GOPATH=/workspace/tools/go GOMODCACHE=/workspace/tools/cache/go
+export CARGO_HOME=/workspace/tools/cargo RUSTUP_HOME=/workspace/tools/rustup
+export PIP_CACHE_DIR=/workspace/tools/cache/pip
+```
+
+## Proxy and trust
+
+Honor the supplied proxy and trust configuration, including `HTTPS_PROXY`,
+`NO_PROXY`, `SSL_CERT_FILE` and `NODE_EXTRA_CA_CERTS`. Report inaccessible
+download origins to the operator on the chat surface.

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -1,0 +1,196 @@
+# Code mode
+
+Code mode runs Claude Code in a persistent tmux session inside an agent
+container. The workspace survives container restarts. Detaching a terminal
+leaves the agent running; attaching to a cold sandbox starts its container.
+
+A **sandbox** is a code-mode agent group: a durable workspace under
+`groups/<name>/` and a disposable session container that wakes on attach
+and retires on an idle lease.
+
+## Local terminal
+
+Rebuild the agent image after updating (it needs `tmux`), then start the
+Host normally. From the Host checkout:
+
+```sh
+bin/ncl sandboxes new my-project
+bin/ncl sandboxes list
+bin/ncl sandboxes attach my-project
+```
+
+Detach with **Ctrl-b, then d**. `new` lands you attached; `--no-attach`
+creates without handing the terminal over. An existing group can switch to
+code mode with `bin/ncl groups config update --id <group> --code-mode true`,
+followed by `bin/ncl groups restart --id <group>`; `bin/ncl groups attach
+<group>` is the same terminal as sandbox attachment. All of these verbs are
+host-only: an agent cannot invoke them through its mailbox.
+
+`sandboxes new` is the one path that also mints the coding session and, when
+a chat platform offers one, binds a surface to it; a group that entered code
+mode another way (a template with `codeMode: true`, or `groups config update
+--code-mode true`) shows in `sandboxes list` with no session and no surface
+until its first attach creates the session, and never gets a surface unless
+it is wired by hand.
+
+`list` shows `running` while a session container exists and `cold` once the
+idle lease retired it; the workspace is durable and the next attach wakes
+it again. The lease keeps a container up for 30 minutes after its last
+activity with nobody attached, and for a day with a terminal attached but
+silent; a running turn always counts as activity. When the lease expires an
+attached terminal is detached cleanly with a notice.
+
+Three more verbs read and steer the session from the terminal:
+
+```sh
+bin/ncl sandboxes status my-project   # active | processing | suspended, the last turn stamp
+bin/ncl sandboxes diff my-project     # the working tree against HEAD, tracked and new files
+bin/ncl sandboxes stop my-project     # interrupt the current turn (Escape in the session)
+```
+
+`diff` runs git inside the running session container, as the container's
+user, with the repository's external diff driver, textconv filters and
+fsmonitor hook switched off; the Host never runs git against the agent's
+tree. A cold sandbox has no diff until it wakes. The output is bounded (a
+cut is marked as such).
+
+## How the agent works
+
+The session's working directory is `/workspace/group`. On every spawn the
+Host stamps the operating manual from `container/code-mode/CLAUDE.md` at
+that directory's `CLAUDE.md`, and the dev skills from
+`container/code-mode/skills/*` under `.claude/skills/`, both read-only. The
+manual tells the agent how mail arrives, how to reply, how to work in the
+tree and what it must not do; `dev-git` covers checking a repository out
+into the working directory and committing cleanly; `dev-toolchains` covers
+installing project toolchains under the persistent `/workspace/tools`. A
+fork edits these files to change what its agents are told. A checkout
+missing them still boots the session, and `sandboxes new` and `sandboxes
+list` say so.
+
+Each sandbox session owns one Claude Code conversation, named by an id the
+runner keeps in the session directory (`code-session.json`, derived from
+the session id). The first life of the session starts the conversation
+under that id; every later life — a wake after the idle lease, a crash of
+the CLI inside the container — resumes it by id, so two sessions of the
+same group sharing a `~/.claude` store never continue each other's
+conversation. The CLI's SessionStart hook keeps the record current: after
+`/clear` the new conversation's id replaces the old one, and the next life
+resumes the conversation the operator was actually in. A resumed
+conversation the CLI cannot load is abandoned for a fresh one, once per
+boot, with both ids in the container log.
+
+Messages for the group arrive as mail. While the agent is idle the runner
+types them into the session as a prompt; while a turn runs a notice on the
+next tool result says how many are waiting. A file sent with a message is
+staged by the Host and appears after the text as `[type: name — saved to
+/workspace/inbox/<message id>/<name>]`, with or without a caption; `ncl
+inbox read --id` returns the same attachments structured. Inside the
+container:
+
+```sh
+ncl inbox read                 # show and consume waiting mail
+ncl inbox read --peek          # look without consuming
+ncl outbox send --text "..."   # post to the chat surface bound to this session
+```
+
+A send with no `--reply-to` goes to the session's default route: the chat
+surface bound to the session (below), or nowhere, in which case it fails and
+says so.
+
+## Permissions and the sandbox boundary
+
+Inside the container most tool use runs without prompts. Writes to the
+manual, to the CLI's settings file and to the Host's permission policy are
+boundaries: the CLI asks, and when nobody is attached the question becomes
+an approval card delivered to an approver the way other approvals are. A
+card nobody answers is denied before the CLI's own timeout; a Host restart
+denies every open question. The decision reaches the container through a
+read-only mount, so the agent cannot approve its own boundary crossing.
+
+What the card says is another matter. The request file rides the
+read-write workspace, so an agent can write a request that describes an
+action other than the one its hook is holding: the transport blocks
+self-approval, not a misleading card. Treat a boundary card as the agent
+asking, and read it the way you would read the agent's own message.
+
+`NANOCLAW_CODE_PERMISSION_MODE` (`auto`, the default, or `bypass`) sets the
+deployment posture; `--permission-mode` on `sandboxes new`, or
+`--permission-mode` on `groups config update`, overrides it per group.
+`bypass` must be selected explicitly. The Host composes the posture into a
+managed-settings file mounted read-only at the CLI's admin tier, so the
+agent cannot out-write it from any settings layer it can reach.
+
+## A chat surface for a coding session
+
+A chat platform can be a surface for a coding session: status while a turn
+runs, the diff after each turn, messages both ways, and a Stop that
+interrupts the turn. Code mode keeps everything a platform does not need
+to know — the mapper from the runner's turn stamp to a status, the diff
+collection (inside the session container, as above), the interrupt, the
+binding table and its wiring into the session, the runtime that ticks and
+long-polls — and asks the platform
+for one object, a `SessionSurfaceProvider` (`src/code-mode/surface/types.ts`):
+open a surface for a sandbox, spell it the way the adapter's inbound path
+will, accept a status or a view, report events, close. A provider registers
+with `registerSessionSurface(channelType, provider, { seam:
+SESSION_SURFACE_SEAM })`; with none registered, sandboxes are plain and the
+terminal verbs above are the surface.
+
+When a provider is registered, `sandboxes new` opens a surface for the new
+session through it and wires the sandbox to the surface with an ordinary
+group ↔ chat wiring in session mode `sandbox`: every message on the
+surface lands in the coding session, no mention needed, threads never
+apply, and the surface becomes the session's default outbound route. A
+conversation the adapter registered before the bind is adopted, not
+duplicated. `sandboxes status` shows the binding.
+
+A binding whose provider is not registered — the Host restored it at start
+before the platform's module activated, or the module left — waits: nothing
+is sent or recorded for it, `sandboxes status` shows it as not mirrored,
+and it goes live the moment a provider for its platform registers. The
+diff for a completed turn stays pending until the provider took it; a
+failed read of the tree (the exec, git) or a failed publish is retried on
+the next healthy tick, three times, before that turn is given up with a
+log line. A clean tree is not a failure: it settles the turn with nothing
+sent.
+
+## Configuration and dependencies
+
+Code mode uses the existing agent image, Claude Code installation, and
+mailbox. The image adds the distribution's `tmux` package. Workspace
+toolchains persist under `/workspace/tools`.
+
+`NANOCLAW_CODE_IDLE_TTL_MS` and `NANOCLAW_CODE_ATTACH_IDLE_TTL_MS` control
+idle retirement (defaults: 30 minutes unattached, 24 hours attached).
+`NANOCLAW_CODE_CHANNELS` (`dev` or `org`) delivers mail to the session
+through Claude Code's MCP channels (a research preview of the CLI) instead
+of typing it; unset, mail is typed into the terminal when the agent is
+idle. `NANOCLAW_CODE_ENV` is a JSON object of extra environment variables
+for code-mode containers; it never overrides the provider's credential
+lane.
+
+Code mode currently supports the `claude` provider only.
+
+## Extending code mode
+
+Modules attach without editing code mode:
+
+- `src/code-mode/hooks.ts`: `onSandboxCreated`, `onSandboxBound`,
+  `onSandboxRemoved`, `onRemoteAccessChanged` — named callbacks, awaited
+  in order, a throwing listener logged and skipped;
+- `extendResource('sandboxes', { … }, { seam })` in `src/cli/crud.ts`:
+  extra sub-verbs on `ncl sandboxes`;
+- `registerSessionSurface(channelType, provider, { seam })`: a chat
+  platform as a session surface;
+- `src/code-mode/sandboxes.ts`: the in-process `create` / `list` / `attach`
+  the verbs run, for a host component that lands a terminal in a sandbox
+  itself (the `AttachTarget` carries the live session handle and the
+  command; `SessionHandle.execStream` holds the exec in-process where the
+  driver offers it).
+
+Every registry carries a seam version. A registration on the wrong integer
+is refused, logged, and shown above `ncl sandboxes list`; the host boots
+either way. Contract-test helpers (`assertSandboxHook`, `assertSandboxVerb`,
+`assertSurfaceRegistered` under `src/code-mode/`) let a module's test prove
+its registration against the real composed tree.

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,10 +1,24 @@
 import { CENTRAL_DB_PATH } from '../src/config.js';
 import { closeDb, initDb } from '../src/db/connection.js';
-import { runMigrations } from '../src/db/migrations/index.js';
+import { getRegisteredMigrations, runMigrations } from '../src/db/migrations/index.js';
+// Side-effect import: every module that contributes migrations, in the one
+// graph this process and the host share. Without it a module migration is
+// invisible HERE and pending THERE — which on a dialect where 'auto' means
+// validate is `exit 1` at boot, right after this script said the DB was current.
+import '../src/db/migrations/registered-modules.js';
 
 const db = await initDb(CENTRAL_DB_PATH, { role: 'migration' });
 
 try {
+  // NAMED, not merely applied. A module migration is contributed by an
+  // installed composition rather than by the trunk barrel, so the operator's
+  // deploy transcript is the only place its identity is ever written down.
+  const modules = getRegisteredMigrations().filter((migration) => migration.name.startsWith('module:'));
+  console.log(
+    modules.length > 0
+      ? `Module migrations registered: ${modules.map((migration) => migration.name).join(', ')}`
+      : 'No module migrations are registered in this composition.',
+  );
   await runMigrations(db, undefined, { mode: 'migrate' });
   console.log('Central DB migrations are current.');
 } finally {

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -237,6 +237,16 @@ export interface ChannelAdapter {
     statusKind?: 'auto' | 'agent',
   ): Promise<void>;
   syncConversations?(): Promise<ConversationInfo[]>;
+  /**
+   * The platform id this adapter would stamp on inbound messages from a
+   * conversation the platform names `conversationId` (a Slack channel id, a
+   * Telegram chat id, …). The host uses it when IT learns of a conversation
+   * first — a channel opened on the host's behalf — so the messaging_groups
+   * row it writes is the one the adapter's inbound path resolves, not a
+   * near-duplicate in a different spelling. Adapters that encode platform
+   * ids expose this; callers without it cannot pre-register conversations.
+   */
+  conversationPlatformId?(conversationId: string): string;
   /** Resolve conversation type and human-readable metadata for host UI. */
   resolveConversation?(platformId: string): Promise<ResolvedConversation | null>;
   /** Legacy name-only resolver for adapters without richer conversation metadata. */

--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -95,6 +95,24 @@ describe('createChatSdkBridge', () => {
     });
     expect(typeof bridge.subscribe).toBe('function');
   });
+
+  it("spells a conversation's platform id through the adapter's own encoder, as inbound stores it", () => {
+    const seen: string[] = [];
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({
+        // The Slack adapter's shape: "<adapter>:<channel>[:<thread>]" in, "<adapter>:<channel>" out.
+        channelIdFromThreadId: (threadId: string) => {
+          seen.push(threadId);
+          const [adapter, channel] = threadId.split(':');
+          return `${adapter}:${channel}`;
+        },
+      }),
+      supportsThreads: true,
+    });
+    expect(bridge.conversationPlatformId!('C0123456789')).toBe('stub:C0123456789');
+    // The adapter's name is the prefix — nothing here hardcodes a platform.
+    expect(seen).toEqual(['stub:C0123456789']);
+  });
 });
 
 describe('createChatSdkBridge — instance identity', () => {

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -1003,6 +1003,16 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     };
   }
 
+  // The platform id of a conversation the host names first (a channel opened
+  // on its behalf): built by the SAME encoder onInbound stores through —
+  // adapter.channelIdFromThreadId over a channel-level thread id in the SDK's
+  // `<adapter>:<conversation>` form — so the messaging_groups row the host
+  // writes is exactly the one inbound resolves. The adapter's own decoder
+  // validates the spelling; a conversation id it rejects throws here rather
+  // than yielding a row nothing will ever match.
+  bridge.conversationPlatformId = (conversationId: string): string =>
+    adapter.channelIdFromThreadId(`${adapter.name}:${conversationId}`);
+
   return bridge;
 }
 

--- a/src/cli/attach-exec.test.ts
+++ b/src/cli/attach-exec.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The client half of `ncl groups attach` — response detection, TTY/plain
+ * argv selection, and the --json bypass (json must print the frame, never
+ * hand the terminal over).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { attachWarnings, isAttachResponse, resolveAttachExec } from './attach-exec.js';
+import type { ResponseFrame } from './frame.js';
+
+const attachData = {
+  attachExec: {
+    bin: 'docker',
+    argsTty: ['exec', '-it', 'c1', 'tmux', '-S', '/tmp/code-runner/tmux.sock', 'attach-session', '-t', 'agent'],
+    argsPlain: ['exec', '-i', 'c1', 'tmux', '-S', '/tmp/code-runner/tmux.sock', 'attach-session', '-t', 'agent'],
+  },
+};
+
+const okFrame = (data: unknown): ResponseFrame => ({ id: 'r', ok: true, data });
+const errFrame: ResponseFrame = { id: 'r', ok: false, error: { code: 'handler-error', message: 'nope' } };
+
+describe('isAttachResponse', () => {
+  it('accepts the exec shape and rejects near-misses', () => {
+    expect(isAttachResponse(attachData)).toBe(true);
+    expect(isAttachResponse(null)).toBe(false);
+    expect(isAttachResponse({})).toBe(false);
+    expect(isAttachResponse({ attachExec: { bin: 'docker', argsTty: 'not-array', argsPlain: [] } })).toBe(false);
+  });
+});
+
+describe('resolveAttachExec', () => {
+  it('selects TTY argv on a terminal, plain argv otherwise', () => {
+    expect(resolveAttachExec(okFrame(attachData), false, true)).toEqual({
+      bin: 'docker',
+      args: attachData.attachExec.argsTty,
+    });
+    expect(resolveAttachExec(okFrame(attachData), false, false)).toEqual({
+      bin: 'docker',
+      args: attachData.attachExec.argsPlain,
+    });
+  });
+
+  it('never execs for --json, errors, or non-attach data', () => {
+    expect(resolveAttachExec(okFrame(attachData), true, true)).toBeUndefined();
+    expect(resolveAttachExec(errFrame, false, true)).toBeUndefined();
+    expect(resolveAttachExec(okFrame({ groups: [] }), false, true)).toBeUndefined();
+  });
+
+  it('an attach response may carry warnings the client prints before handing the terminal over', () => {
+    const withWarnings = {
+      ...attachData,
+      warnings: ['name reserved for addresses; sandbox created without its own address'],
+    };
+    expect(resolveAttachExec(okFrame(withWarnings), false, true)?.bin).toBe('docker');
+    expect(attachWarnings(okFrame(withWarnings))).toEqual([
+      'name reserved for addresses; sandbox created without its own address',
+    ]);
+  });
+
+  it('warnings are only non-empty strings in an array; anything else is none', () => {
+    expect(attachWarnings(okFrame(attachData))).toEqual([]);
+    expect(attachWarnings(okFrame({ ...attachData, warnings: 'one' }))).toEqual([]);
+    expect(attachWarnings(okFrame({ ...attachData, warnings: ['ok', '', 3, null] }))).toEqual(['ok']);
+    expect(attachWarnings(errFrame)).toEqual([]);
+    expect(attachWarnings(okFrame(null))).toEqual([]);
+  });
+});

--- a/src/cli/attach-exec.ts
+++ b/src/cli/attach-exec.ts
@@ -1,0 +1,50 @@
+/**
+ * Attach-exec decision logic, extracted pure from the ncl client entry
+ * point so it is testable: which responses are attach responses, and what
+ * argv the client (which owns the terminal) should exec for them.
+ */
+import type { ResponseFrame } from './frame.js';
+
+export interface AttachExecSpec {
+  bin: string;
+  argsTty: string[];
+  argsPlain: string[];
+}
+
+export function isAttachResponse(data: unknown): data is { attachExec: AttachExecSpec } {
+  if (typeof data !== 'object' || data === null) return false;
+  const exec = (data as { attachExec?: unknown }).attachExec;
+  return (
+    typeof exec === 'object' &&
+    exec !== null &&
+    typeof (exec as { bin?: unknown }).bin === 'string' &&
+    Array.isArray((exec as { argsTty?: unknown }).argsTty) &&
+    Array.isArray((exec as { argsPlain?: unknown }).argsPlain)
+  );
+}
+
+/**
+ * Undefined = not an attach response (or --json, which must print the
+ * frame, never hand over the terminal). Otherwise the exact argv to exec.
+ */
+export function resolveAttachExec(
+  res: ResponseFrame,
+  json: boolean,
+  stdinIsTty: boolean,
+): { bin: string; args: string[] } | undefined {
+  if (json || !res.ok || !isAttachResponse(res.data)) return undefined;
+  const { bin, argsTty, argsPlain } = res.data.attachExec;
+  return { bin, args: stdinIsTty ? argsTty : argsPlain };
+}
+
+/**
+ * Warnings a verb attached to its response for the client to print before
+ * the terminal is handed over (an attach response prints nothing else).
+ * Only an array of non-empty strings counts; anything else is no warnings.
+ */
+export function attachWarnings(res: ResponseFrame): string[] {
+  if (!res.ok || typeof res.data !== 'object' || res.data === null) return [];
+  const warnings = (res.data as { warnings?: unknown }).warnings;
+  if (!Array.isArray(warnings)) return [];
+  return warnings.filter((w): w is string => typeof w === 'string' && w.trim().length > 0);
+}

--- a/src/cli/attach-resolve.ts
+++ b/src/cli/attach-resolve.ts
@@ -1,0 +1,42 @@
+/**
+ * Attach resolution — the shared host-side path from an agent group to the
+ * exec spec the ncl client runs. `groups attach` and `sandboxes attach |
+ * new` resolve through the exact same policy (code-mode/sandboxes.ts owns
+ * it); error texts are pinned by groups-attach.test.ts and must not drift.
+ *
+ * Attachment always execs the image's tmux client against the runner's
+ * private socket. Detach is Ctrl-b then d; exit codes are tmux's.
+ */
+import { attachSandbox, type AttachTarget } from '../code-mode/sandboxes.js';
+import type { SessionExecSpec } from '../drivers/index.js';
+import type { AgentGroup } from '../types.js';
+
+export { ATTACH_WAKE_WAIT_MS, type AttachTarget } from '../code-mode/sandboxes.js';
+
+/** What the ncl client needs to hand its terminal over (cli/attach-exec.ts). */
+export interface AttachResolution {
+  attachExec: SessionExecSpec;
+  group: string;
+  containerName: string;
+}
+
+/** The argv for an attach target: the driver's handle composes it — only the driver knows its exec dialect. */
+export function attachResolution(target: AttachTarget): AttachResolution {
+  return {
+    attachExec: target.handle.execSpec(target.command),
+    group: target.group,
+    containerName: target.containerName,
+  };
+}
+
+/**
+ * Resolve an attach for `group` and return the exec spec the driver's
+ * handle composed. The client (which owns the terminal) execs this; policy —
+ * which container, which entry — is decided host-side.
+ */
+export async function resolveAttachForGroup(
+  group: AgentGroup,
+  opts?: { wakeWaitMs?: number },
+): Promise<AttachResolution> {
+  return attachResolution(await attachSandbox(group, opts));
+}

--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -15,8 +15,10 @@
  *   ncl help
  *   ncl groups help
  */
+import { spawnSync } from 'child_process';
 import { randomUUID } from 'crypto';
 
+import { attachWarnings, resolveAttachExec } from './attach-exec.js';
 import { formatResponse } from './format.js';
 import type { RequestFrame } from './frame.js';
 import { parseArgv } from './parse-argv.js';
@@ -66,6 +68,22 @@ async function main(): Promise<void> {
   } catch (e) {
     process.stderr.write(formatTransportError(e));
     process.exit(2);
+  }
+
+  // Attach responses hand the terminal over instead of printing: the server
+  // decided which container and which entry (policy); this client owns the
+  // TTY, so the interactive exec has to happen here (`ncl groups attach`).
+  const attach = resolveAttachExec(res, json, process.stdin.isTTY === true);
+  if (attach) {
+    // Anything the verb wants said before the terminal is handed over (a
+    // sandbox name the account refused, say) rides as `warnings`; once the
+    // exec starts, nothing printed here would be seen.
+    for (const warning of attachWarnings(res)) process.stderr.write(`warning: ${warning}\n`);
+    const result = spawnSync(attach.bin, attach.args, { stdio: 'inherit' });
+    // A client that could not even start (runtime binary missing, not
+    // executable) has no exit status; say what went wrong instead of a bare 1.
+    if (result.error) process.stderr.write(`ncl: attach failed to start ${attach.bin}: ${result.error.message}\n`);
+    process.exit(result.status ?? 1);
   }
 
   const output =

--- a/src/cli/crud-extend.test.ts
+++ b/src/cli/crud-extend.test.ts
@@ -1,0 +1,137 @@
+/**
+ * extendResource: a module adds sub-verbs to a resource it does not own —
+ * before or after the resource registers — through the same registration
+ * (help, guard, host-only) a resource's own custom operations get; a verb
+ * that already exists, or a registration on the wrong seam, is refused and
+ * logged, never overwritten.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+import { log } from '../log.js';
+import { resetSeamRefusalsForTesting, seamRefusals } from '../seams.js';
+import { RESOURCE_EXTENSION_SEAM, extendResource, registerResource, type CustomOperation } from './crud.js';
+import { dispatch } from './dispatch.js';
+import type { CallerContext } from './frame.js';
+import { lookup } from './registry.js';
+
+const HOST: CallerContext = { caller: 'host' };
+let n = 0;
+const seam = { seam: RESOURCE_EXTENSION_SEAM };
+
+function op(reply: string, extra: Partial<CustomOperation> = {}): CustomOperation {
+  return { access: 'open', hostOnly: true, description: `${reply}.`, handler: async () => ({ reply }), ...extra };
+}
+
+function fresh(): string {
+  n += 1;
+  return `widgets${n}`;
+}
+
+beforeEach(() => {
+  resetSeamRefusalsForTesting();
+  vi.mocked(log.error).mockClear();
+});
+afterEach(() => resetSeamRefusalsForTesting());
+
+describe('extendResource', () => {
+  it('registers sub-verbs on a resource that already exists', async () => {
+    const plural = fresh();
+    registerResource({
+      name: 'widget',
+      plural,
+      table: 't',
+      description: 'w',
+      idColumn: 'id',
+      columns: [],
+      operations: {},
+    });
+    extendResource(plural, { 'remote enable': op('enabled') }, seam);
+    expect(lookup(`${plural}-remote-enable`)?.hostOnly).toBe(true);
+    const res = await dispatch({ id: 'r1', command: `${plural}-remote-enable`, args: {} }, HOST);
+    expect(res).toMatchObject({ ok: true, data: { reply: 'enabled' } });
+  });
+
+  it('queues sub-verbs until the resource registers', async () => {
+    const plural = fresh();
+    extendResource(plural, { status: op('queued') }, seam);
+    expect(lookup(`${plural}-status`)).toBeUndefined();
+    registerResource({
+      name: 'widget',
+      plural,
+      table: 't',
+      description: 'w',
+      idColumn: 'id',
+      columns: [],
+      operations: {},
+    });
+    const res = await dispatch({ id: 'r1', command: `${plural}-status`, args: {} }, HOST);
+    expect(res).toMatchObject({ ok: true, data: { reply: 'queued' } });
+  });
+
+  it('refuses a verb the resource already has — the original keeps answering', async () => {
+    const plural = fresh();
+    registerResource({
+      name: 'widget',
+      plural,
+      table: 't',
+      description: 'w',
+      idColumn: 'id',
+      columns: [],
+      operations: {},
+      customOperations: { status: op('original') },
+    });
+    extendResource(plural, { status: op('impostor'), extra: op('extra') }, seam);
+    expect(log.error).toHaveBeenCalledWith(
+      'Resource extension refused: verb already registered',
+      expect.objectContaining({ resource: plural, verb: 'status' }),
+    );
+    const res = await dispatch({ id: 'r1', command: `${plural}-status`, args: {} }, HOST);
+    expect(res).toMatchObject({ ok: true, data: { reply: 'original' } });
+    // The rest of the same extension still lands.
+    expect(lookup(`${plural}-extra`)).toBeDefined();
+  });
+
+  it('a queued verb that collides with the resource when it registers is refused, not fatal', async () => {
+    const plural = fresh();
+    extendResource(plural, { status: op('queued'), extra: op('extra') }, seam);
+    expect(() =>
+      registerResource({
+        name: 'widget',
+        plural,
+        table: 't',
+        description: 'w',
+        idColumn: 'id',
+        columns: [],
+        operations: {},
+        customOperations: { status: op('original') },
+      }),
+    ).not.toThrow();
+    expect(log.error).toHaveBeenCalledWith(
+      'Resource extension refused: verb already registered',
+      expect.objectContaining({ resource: plural, verb: 'status' }),
+    );
+    const res = await dispatch({ id: 'r1', command: `${plural}-status`, args: {} }, HOST);
+    expect(res).toMatchObject({ ok: true, data: { reply: 'original' } });
+    expect(lookup(`${plural}-extra`)).toBeDefined();
+  });
+
+  it('refuses the whole extension on a seam mismatch, and says so', () => {
+    const plural = fresh();
+    registerResource({
+      name: 'widget',
+      plural,
+      table: 't',
+      description: 'w',
+      idColumn: 'id',
+      columns: [],
+      operations: {},
+    });
+    extendResource(plural, { status: op('old') }, { seam: RESOURCE_EXTENSION_SEAM + 1 });
+    expect(lookup(`${plural}-status`)).toBeUndefined();
+    expect(seamRefusals()).toMatchObject([{ registry: 'resource-extension', registrant: `${plural} status` }]);
+  });
+});

--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -8,10 +8,12 @@
  */
 import { randomUUID } from 'crypto';
 
+import { seamAccepted } from '../seams.js';
 import { getDb } from '../db/connection.js';
 import { isUniqueViolation } from '../db/errors.js';
+import { log } from '../log.js';
 import { renderVerbHelp } from './help-render.js';
-import { register } from './registry.js';
+import { lookup, register } from './registry.js';
 import type { Access } from './registry.js';
 import type { CallerContext } from './frame.js';
 
@@ -524,30 +526,96 @@ export function registerResource(def: ResourceDef): void {
   // Custom operations. Declaring `args` opts the verb into strict validation;
   // every failure carries the verb's usage block so a caller (human or agent)
   // can fix the invocation without a second help round-trip.
-  if (def.customOperations) {
-    for (const [verb, op] of Object.entries(def.customOperations)) {
-      const declared = op.args;
-      register({
-        name: `${def.plural}-${verb.replace(/ /g, '-')}`,
-        action: `${def.plural}.${verb.replace(/ /g, '.')}`,
-        description: op.description,
-        access: op.access,
-        hostOnly: op.hostOnly,
-        resource: def.plural,
-        parseArgs: declared
-          ? (raw) => {
-              try {
-                return validateArgs(declared, normalizeArgs(raw));
-              } catch (e) {
-                const usage = renderVerbHelp(def, verb);
-                const msg = e instanceof Error ? e.message : String(e);
-                throw new Error(usage ? `${msg}\n\n${usage}` : msg, { cause: e });
-              }
-            }
-          : (raw) => normalizeArgs(raw),
-        handler: async (args, ctx) => op.handler(args as Record<string, unknown>, ctx),
-        formatHuman: op.formatHuman,
-      });
-    }
+  if (def.customOperations) registerCustomOperations(def, def.customOperations);
+
+  // Sub-verbs a module queued for this resource before it registered. The
+  // resource's own verbs are already in; a queued verb that collides with
+  // one is refused here (logged), never thrown — an extension must not be
+  // able to kill the boot of the resource it extends.
+  const queued = pendingExtensions.get(def.plural);
+  if (queued) {
+    pendingExtensions.delete(def.plural);
+    for (const ops of queued) registerCustomOperations(def, ops, { extension: true });
   }
+}
+
+function registerCustomOperations(
+  def: ResourceDef,
+  ops: Record<string, CustomOperation>,
+  { extension = false }: { extension?: boolean } = {},
+): void {
+  for (const [verb, op] of Object.entries(ops)) {
+    if (extension && lookup(`${def.plural}-${verb.replace(/ /g, '-')}`)) {
+      log.error('Resource extension refused: verb already registered', { resource: def.plural, verb });
+      continue;
+    }
+    const declared = op.args;
+    register({
+      name: `${def.plural}-${verb.replace(/ /g, '-')}`,
+      action: `${def.plural}.${verb.replace(/ /g, '.')}`,
+      description: op.description,
+      access: op.access,
+      hostOnly: op.hostOnly,
+      resource: def.plural,
+      parseArgs: declared
+        ? (raw) => {
+            try {
+              return validateArgs(declared, normalizeArgs(raw));
+            } catch (e) {
+              const usage = renderVerbHelp(def, verb);
+              const msg = e instanceof Error ? e.message : String(e);
+              throw new Error(usage ? `${msg}\n\n${usage}` : msg, { cause: e });
+            }
+          }
+        : (raw) => normalizeArgs(raw),
+      handler: async (args, ctx) => op.handler(args as Record<string, unknown>, ctx),
+      formatHuman: op.formatHuman,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resource extension — sub-verbs a module adds to a resource it does not own
+// ---------------------------------------------------------------------------
+
+/** Bump only on a breaking change to CustomOperation or to how verbs are named. */
+export const RESOURCE_EXTENSION_SEAM = 1;
+
+const pendingExtensions = new Map<string, Record<string, CustomOperation>[]>();
+
+/**
+ * Add sub-verbs to an existing resource (`extendResource('sandboxes', {
+ * 'remote enable': … })` registers `ncl sandboxes remote enable`) without
+ * editing the resource's own definition. Order-independent: registered at
+ * once when the resource exists, queued until it does otherwise. The verbs
+ * are ordinary custom operations — same help, same guard, same host-only
+ * rule. A verb the resource (or an earlier extension) already has is
+ * refused and logged, never overwritten; so is a registration whose
+ * `seam` is not this host's.
+ */
+export function extendResource(
+  plural: string,
+  ops: Record<string, CustomOperation>,
+  registration: { seam: number },
+): void {
+  const verbs = Object.keys(ops);
+  if (!seamAccepted('resource-extension', `${plural} ${verbs.join(', ')}`, RESOURCE_EXTENSION_SEAM, registration.seam))
+    return;
+  const accepted: Record<string, CustomOperation> = {};
+  for (const verb of verbs) {
+    const name = `${plural}-${verb.replace(/ /g, '-')}`;
+    if (lookup(name)) {
+      log.error('Resource extension refused: verb already registered', { resource: plural, verb });
+      continue;
+    }
+    accepted[verb] = ops[verb];
+  }
+  const def = resources.get(plural);
+  if (def) {
+    registerCustomOperations(def, accepted, { extension: true });
+    return;
+  }
+  const queue = pendingExtensions.get(plural) ?? [];
+  queue.push(accepted);
+  pendingExtensions.set(plural, queue);
 }

--- a/src/cli/resources/groups-attach.test.ts
+++ b/src/cli/resources/groups-attach.test.ts
@@ -1,0 +1,314 @@
+/**
+ * `ncl groups attach` through the real dispatch path .
+ *
+ * The verb is hostOnly — every attach is host-mediated, so an agent caller
+ * must be refused before the handler runs. The handler resolves the live
+ * runtime THROUGH THE SESSION DRIVER (the host's in-memory container name is
+ * a lineage label, not the runtime name) and returns the exec spec the
+ * driver's handle composed — the ncl client owns the terminal and performs
+ * the exec, so the handler's contract IS the returned argv.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../container-runner.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../container-runner.js')>();
+  return { ...orig, wakeContainer: vi.fn(async (): Promise<boolean> => false) };
+});
+vi.mock('../../drivers/index.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../drivers/index.js')>();
+  return { ...orig, getSessionDriver: vi.fn() };
+});
+
+import { wakeContainer } from '../../container-runner.js';
+import { getDb } from '../../db/connection.js';
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import { findSessionByAgentGroup, taskThreadId } from '../../db/sessions.js';
+import { ensureContainerConfig, updateContainerConfigScalars } from '../../db/container-configs.js';
+import { getSessionDriver } from '../../drivers/index.js';
+import type { SessionEventsDriver } from '../../drivers/session-events.js';
+import type { SessionHandle, SessionPhase, SessionStatus } from '../../drivers/types.js';
+import { dispatch } from '../dispatch.js';
+import type { CallerContext, RequestFrame, ResponseFrame } from '../frame.js';
+// Side-effect imports: register the groups-* commands and the code-mode
+// migration (the code_mode column this verb reads).
+import './groups.js';
+import '../../code-mode/index.js';
+
+const HOST: CallerContext = { caller: 'host' };
+const AGENT: CallerContext = {
+  caller: 'agent',
+  sessionId: 's1',
+  agentGroupId: 'g-code',
+  messagingGroupId: 'mg1',
+};
+
+const GROUP_ID = 'g-code';
+const FOLDER = 'code-folder';
+const TMUX_CLIENT = [
+  'env',
+  'TERM=xterm-256color',
+  'tmux',
+  '-u',
+  '-S',
+  '/tmp/code-runner/tmux.sock',
+  'attach-session',
+  '-t',
+  'agent',
+];
+/** The attach-activity stamp every attach-routed exec carries (liveness v2). */
+const ATTACH_STAMP = [
+  'sh',
+  '-c',
+  '{ mkdir -p /tmp/code-runner && date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/code-runner/attach-activity; } 2>/dev/null; n=0; until tmux -S /tmp/code-runner/tmux.sock has-session -t agent 2>/dev/null; do n=$((n+1)); if [ "$n" -ge 90 ]; then echo "code mode: terminal did not become ready within 90s; check the Host logs" >&2; exit 1; fi; sleep 1; done; exec "$@"',
+  'attach',
+];
+
+function attach(target: string, ctx: CallerContext = HOST): Promise<ResponseFrame> {
+  const req: RequestFrame = { id: 'r1', command: 'groups-attach', args: { id: target } };
+  return dispatch(req, ctx);
+}
+
+function errMsg(res: ResponseFrame): string {
+  if (res.ok) throw new Error('expected an error response');
+  return res.error.message;
+}
+
+/** A container-shaped handle: the exec dialect only the driver knows . */
+function handleFor(sessionId: string, name: string): SessionHandle {
+  return {
+    key: { installSlug: 'test-install', agentGroupId: GROUP_ID, sessionId },
+    name,
+    start: async () => {},
+    status: async () => ({ phase: 'running' }) as SessionStatus,
+    stop: async () => {},
+    execSpec: (command: string[]) => ({
+      bin: 'fake-exec',
+      argsTty: ['exec', '-i', '-t', '-n', 'agents', name, '-c', 'agent', '--', ...command],
+      argsPlain: ['exec', '-i', '-n', 'agents', name, '-c', 'agent', '--', ...command],
+    }),
+  };
+}
+
+/**
+ * Discovery reports the phase the listing itself observed — no per-handle
+ * probe. A bare handle is a running one; pair it with a phase to say otherwise.
+ */
+function installDriver(entries: (SessionHandle | [SessionHandle, SessionPhase])[]): void {
+  const snapshots = entries.map((entry) =>
+    Array.isArray(entry) ? { handle: entry[0], phase: entry[1] } : { handle: entry, phase: 'running' as SessionPhase },
+  );
+  const driver = {
+    kind: 'fake-container',
+    listSessions: vi.fn(async () => snapshots),
+    watchSessions: () => ({ stop: () => {} }),
+  } as unknown as SessionEventsDriver;
+  vi.mocked(getSessionDriver).mockReturnValue(driver);
+}
+
+beforeEach(async () => {
+  const db = await initTestDb();
+  await runMigrations(db);
+  await db.run(
+    'INSERT INTO agent_groups (id, name, folder, created_at) VALUES (?, ?, ?, ?)',
+    GROUP_ID,
+    'Code Group',
+    FOLDER,
+    new Date().toISOString(),
+  );
+  await ensureContainerConfig(GROUP_ID);
+  installDriver([]);
+  vi.mocked(wakeContainer).mockReset();
+  vi.mocked(wakeContainer).mockResolvedValue(false);
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await closeDb();
+});
+
+async function seedActiveSession(sessionId = 'sess-live', lastActive = new Date().toISOString()): Promise<void> {
+  await getDb().run(
+    `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, agent_provider, status, container_status, last_active, created_at)
+       VALUES (?, ?, NULL, NULL, NULL, 'active', 'running', ?, ?)`,
+    sessionId,
+    GROUP_ID,
+    lastActive,
+    lastActive,
+  );
+}
+
+/** A task-created session: messaging_group_id NULL, thread_id 'system:tasks:<series>'. */
+async function seedTaskSession(
+  sessionId: string,
+  seriesId = 'series-1',
+  createdAt = new Date().toISOString(),
+): Promise<void> {
+  await getDb().run(
+    `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, agent_provider, status, container_status, last_active, created_at)
+       VALUES (?, ?, NULL, ?, NULL, 'active', 'running', ?, ?)`,
+    sessionId,
+    GROUP_ID,
+    taskThreadId(seriesId),
+    createdAt,
+    createdAt,
+  );
+}
+
+/** A channel-wired session: a real messaging group behind it (FKs are on). */
+async function seedChannelSession(sessionId: string, createdAt = new Date().toISOString()): Promise<void> {
+  await getDb().run(
+    `INSERT OR IGNORE INTO messaging_groups (id, channel_type, platform_id, instance, created_at) VALUES ('mg1', 'test', 'chan-1', '', ?)`,
+    createdAt,
+  );
+  await getDb().run(
+    `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, agent_provider, status, container_status, last_active, created_at)
+       VALUES (?, ?, 'mg1', NULL, NULL, 'active', 'running', ?, ?)`,
+    sessionId,
+    GROUP_ID,
+    createdAt,
+    createdAt,
+  );
+}
+
+describe('groups attach', () => {
+  it('is operator-only: an agent caller is refused before the handler runs', async () => {
+    const res = await attach(GROUP_ID, AGENT);
+    expect(res.ok).toBe(false);
+    expect(errMsg(res)).toMatch(/operator-only/);
+  });
+
+  it('refuses a group that is not in code mode, pointing at the flag', async () => {
+    const res = await attach(GROUP_ID);
+    expect(res.ok).toBe(false);
+    expect(errMsg(res)).toMatch(/not a code-mode group/);
+    expect(errMsg(res)).toContain('--code-mode true');
+  });
+
+  it('refuses a group with no session rows at all — nothing to wake', async () => {
+    await updateContainerConfigScalars(GROUP_ID, { code_mode: 1 });
+    const res = await attach(GROUP_ID);
+    expect(res.ok).toBe(false);
+    expect(errMsg(res)).toMatch(/no session yet/);
+    expect(vi.mocked(wakeContainer)).not.toHaveBeenCalled();
+  });
+
+  it('no live runtime → wakes the session lazily and attaches to it', async () => {
+    await updateContainerConfigScalars(GROUP_ID, { code_mode: 1 });
+    await seedActiveSession('sess-cold');
+    // No handle before the wake; the wake brings the container up.
+    vi.mocked(wakeContainer).mockImplementation(async () => {
+      installDriver([handleFor('sess-cold', 'ncl-test-sess-cold')]);
+      return true;
+    });
+    const res = await attach(GROUP_ID);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unreachable');
+    expect((res.data as { containerName: string }).containerName).toBe('ncl-test-sess-cold');
+    expect(vi.mocked(wakeContainer)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(wakeContainer).mock.calls[0][0].id).toBe('sess-cold');
+  });
+
+  it('reports honestly when the wake itself fails', async () => {
+    await updateContainerConfigScalars(GROUP_ID, { code_mode: 1 });
+    await seedActiveSession('sess-cold');
+    vi.mocked(wakeContainer).mockResolvedValue(false);
+    const res = await attach(GROUP_ID);
+    expect(res.ok).toBe(false);
+    expect(errMsg(res)).toMatch(/did not come up/);
+  });
+
+  it('scans ALL active sessions and attaches to the one with a running runtime', async () => {
+    await updateContainerConfigScalars(GROUP_ID, { code_mode: 1 });
+    await seedActiveSession('sess-old', '2026-01-01T00:00:00.000Z'); // has the running container
+    await seedActiveSession('sess-new'); // newer, but its container is gone
+    installDriver([
+      [handleFor('sess-new', 'ncl-test-sess-new'), 'terminal'],
+      [handleFor('sess-old', 'ncl-test-sess-old'), 'running'],
+    ]);
+    const res = await attach(GROUP_ID);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unreachable');
+    expect((res.data as { containerName: string }).containerName).toBe('ncl-test-sess-old');
+    expect(vi.mocked(wakeContainer)).not.toHaveBeenCalled();
+  });
+
+  it('returns the exec spec THE DRIVER composed, resolving by folder too', async () => {
+    await updateContainerConfigScalars(GROUP_ID, { code_mode: 1 });
+    await seedActiveSession('sess-live');
+    installDriver([handleFor('sess-live', 'ncl-test-sess-live')]);
+
+    const res = await attach(FOLDER); // folder, not id — both resolve
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unreachable');
+    const data = res.data as {
+      attachExec: { bin: string; argsTty: string[]; argsPlain: string[] };
+      containerName: string;
+    };
+    expect(data.containerName).toBe('ncl-test-sess-live');
+    // The argv is the handle's, verbatim, around the host's ONE addition:
+    // the attach-activity stamp (policy, decided here — liveness v2), then the
+    // tmux client command.
+    expect(data.attachExec.bin).toBe('fake-exec');
+    expect(data.attachExec.argsTty).toEqual([
+      'exec',
+      '-i',
+      '-t',
+      '-n',
+      'agents',
+      'ncl-test-sess-live',
+      '-c',
+      'agent',
+      '--',
+      ...ATTACH_STAMP,
+      ...TMUX_CLIENT,
+    ]);
+    expect(data.attachExec.argsPlain).toEqual([
+      'exec',
+      '-i',
+      '-n',
+      'agents',
+      'ncl-test-sess-live',
+      '-c',
+      'agent',
+      '--',
+      ...ATTACH_STAMP,
+      ...TMUX_CLIENT,
+    ]);
+  });
+
+  it('opens a box whose only sessions are task-created', async () => {
+    await updateContainerConfigScalars(GROUP_ID, { code_mode: 1 });
+    await seedTaskSession('sess-task'); // no channel-wired rows anywhere
+    installDriver([handleFor('sess-task', 'ncl-test-sess-task')]);
+    const res = await attach(GROUP_ID);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unreachable');
+    expect((res.data as { containerName: string }).containerName).toBe('ncl-test-sess-task');
+  });
+
+  it('prefers the channel-wired session for the wake even when a task session is newer', async () => {
+    await updateContainerConfigScalars(GROUP_ID, { code_mode: 1 });
+    await seedChannelSession('sess-chat', '2026-01-01T00:00:00.000Z');
+    await seedTaskSession('sess-task'); // newer, but not what an operator means
+    vi.mocked(wakeContainer).mockImplementation(async () => {
+      installDriver([handleFor('sess-chat', 'ncl-test-sess-chat')]);
+      return true;
+    });
+    const res = await attach(GROUP_ID);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unreachable');
+    expect((res.data as { containerName: string }).containerName).toBe('ncl-test-sess-chat');
+    expect(vi.mocked(wakeContainer).mock.calls[0][0].id).toBe('sess-chat');
+  });
+
+  it('widens attach only: chat resolution still never sees a task session', async () => {
+    await updateContainerConfigScalars(GROUP_ID, { code_mode: 1 });
+    await seedTaskSession('sess-task');
+    installDriver([handleFor('sess-task', 'ncl-test-sess-task')]);
+    // resolveSession's agent-shared mode rides findSessionByAgentGroup —
+    // a task-only box must attach, yet look sessionless to chat routing.
+    expect(await findSessionByAgentGroup(GROUP_ID)).toBeUndefined();
+    const res = await attach(GROUP_ID);
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -70,6 +70,9 @@ registerProviderHostContract(TIERLESS_PROVIDER, {
   skillViews: [],
   files: [],
 });
+// Side-effect import: the code-mode migration adds the code_mode column the
+// config get/update presentation tests read.
+import '../../code-mode/index.js';
 
 function now(): string {
   return new Date().toISOString();
@@ -298,6 +301,66 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
     expect(resp.ok).toBe(false);
     expect((resp as { ok: false; error: { code: string; message: string } }).error.code).toBe('handler-error');
     expect((resp as { ok: false; error: { code: string; message: string } }).error.message).toMatch(/not found/i);
+  });
+});
+
+describe('groups config get/update present code_mode', () => {
+  beforeEach(async () => {
+    await runMigrations(await initTestDb());
+  });
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  it('shows code_mode as a boolean, false for a fresh config', async () => {
+    const GID = 'ag-codemode';
+    await createAgentGroup({ id: GID, name: 'cm', folder: 'cm', agent_provider: null, created_at: now() });
+    await ensureContainerConfig(GID);
+
+    const before = await dispatch({ id: 'r1', command: 'groups-config-get', args: { id: GID } }, { caller: 'host' });
+    expect(before.ok).toBe(true);
+    expect((before as { ok: true; data: { code_mode: boolean } }).data.code_mode).toBe(false);
+
+    const update = await dispatch(
+      { id: 'r2', command: 'groups-config-update', args: { id: GID, 'code-mode': 'true' } },
+      { caller: 'host' },
+    );
+    expect(update.ok).toBe(true);
+    // The update's own response must show the value it just wrote.
+    expect((update as { ok: true; data: { code_mode: boolean } }).data.code_mode).toBe(true);
+
+    const after = await dispatch({ id: 'r3', command: 'groups-config-get', args: { id: GID } }, { caller: 'host' });
+    expect((after as { ok: true; data: { code_mode: boolean } }).data.code_mode).toBe(true);
+  });
+
+  it('permission_mode is a closed pair: auto/bypass round-trip, "" clears, garbage refused', async () => {
+    const GID = 'ag-permmode';
+    await createAgentGroup({ id: GID, name: 'pm', folder: 'pm', agent_provider: null, created_at: now() });
+    await ensureContainerConfig(GID);
+
+    const before = await dispatch({ id: 'p1', command: 'groups-config-get', args: { id: GID } }, { caller: 'host' });
+    expect((before as { ok: true; data: { permission_mode: string | null } }).data.permission_mode).toBeNull();
+
+    const set = await dispatch(
+      { id: 'p2', command: 'groups-config-update', args: { id: GID, 'permission-mode': 'bypass' } },
+      { caller: 'host' },
+    );
+    expect(set.ok).toBe(true);
+    expect((set as { ok: true; data: { permission_mode: string | null } }).data.permission_mode).toBe('bypass');
+
+    // "" clears back to the deployment default (the timezone precedent).
+    const cleared = await dispatch(
+      { id: 'p3', command: 'groups-config-update', args: { id: GID, 'permission-mode': '' } },
+      { caller: 'host' },
+    );
+    expect((cleared as { ok: true; data: { permission_mode: string | null } }).data.permission_mode).toBeNull();
+
+    const bad = await dispatch(
+      { id: 'p4', command: 'groups-config-update', args: { id: GID, 'permission-mode': 'yolo' } },
+      { caller: 'host' },
+    );
+    expect(bad.ok).toBe(false);
+    expect((await getContainerConfig(GID))!.permission_mode).toBeNull();
   });
 });
 

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -10,6 +10,7 @@ import {
 import { buildAgentGroupImage, killContainer } from '../../container-runner.js';
 import { requestWake } from '../../request-wake.js';
 import { restartAgentGroupContainers } from '../../container-restart.js';
+import { fireSandboxRemoved } from '../../code-mode/hooks.js';
 import { createAgentGroup, getAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
 import { getDb, hasTable } from '../../db/connection.js';
 import { getSession } from '../../db/sessions.js';
@@ -240,6 +241,9 @@ registerResource({
         // genericDelete behaviour of throwing "not found" for unknown IDs.
         const exists = await db.get('SELECT 1 FROM agent_groups WHERE id = ? LIMIT 1', id);
         if (!exists) throw new Error(`group not found: ${id}`);
+        // A code-mode group is a sandbox; modules that attached state to it
+        // are told once its rows are gone (code-mode/hooks.ts).
+        const sandbox = (await getContainerConfig(id))?.code_mode === 1 ? await getAgentGroup(id) : undefined;
 
         const hasAgentDestinations = await hasTable(db, 'agent_destinations');
         const hasPendingApprovals = await hasTable(db, 'pending_approvals');
@@ -310,6 +314,7 @@ registerResource({
           return counts;
         });
 
+        if (sandbox) await fireSandboxRemoved(sandbox);
         return { deleted: id, removed };
       },
     },

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -10,7 +10,7 @@ import {
 import { buildAgentGroupImage, killContainer } from '../../container-runner.js';
 import { requestWake } from '../../request-wake.js';
 import { restartAgentGroupContainers } from '../../container-restart.js';
-import { createAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
+import { createAgentGroup, getAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
 import { getDb, hasTable } from '../../db/connection.js';
 import { getSession } from '../../db/sessions.js';
 import { writeSessionMessage } from '../../session-manager.js';
@@ -33,6 +33,7 @@ import {
 } from '../../templates/restamp.js';
 import { isValidTimezone } from '../../timezone.js';
 import type { AgentGroup, ContainerConfigRow } from '../../types.js';
+import { resolveAttachForGroup } from '../attach-resolve.js';
 import { registerResource } from '../crud.js';
 import { localizeIsoTimestamps } from '../format.js';
 
@@ -86,6 +87,8 @@ function presentConfig(row: ContainerConfigRow): Record<string, unknown> {
     packages_npm: JSON.parse(row.packages_npm),
     additional_mounts: JSON.parse(row.additional_mounts),
     cli_scope: row.cli_scope,
+    code_mode: row.code_mode === 1,
+    permission_mode: row.permission_mode ?? null,
     timezone: row.timezone,
     updated_at: row.updated_at,
   };
@@ -310,6 +313,24 @@ registerResource({
         return { deleted: id, removed };
       },
     },
+    attach: {
+      access: 'open',
+      hostOnly: true,
+      description:
+        "Attach this terminal to a code-mode agent's interactive session (host operators only).\n" +
+        'Usage: ncl groups attach <group-id-or-folder>. The host resolves the live session container ' +
+        'and the ncl client execs the attach client into it — every connection is host-mediated. ' +
+        'Detach with Ctrl-b then d; the session keeps running.',
+      handler: async (args) => {
+        const id = args.id as string;
+        if (!id) throw new Error('usage: ncl groups attach <group-id-or-folder>');
+        const group = (await getAgentGroup(id)) ?? (await getAgentGroupByFolder(id));
+        if (!group) throw new Error(`No agent group: ${id}`);
+        // Everything from the code-mode gate to the exec spec is shared with
+        // the sandbox verbs — code-mode/sandboxes.ts owns the policy.
+        return resolveAttachForGroup(group);
+      },
+    },
     restart: {
       access: 'approval',
       description:
@@ -391,6 +412,8 @@ registerResource({
         'Update container config scalar fields. Changes are saved but do NOT take effect until you run `ncl groups restart`. ' +
         'Use --id <group-id> and any of: --provider, --model, --effort, --speed, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope, ' +
         '--speed must be one of the speed tiers the group\'s provider declares (Claude: "standard", "fast"), or "" to follow the install default; a provider that declares none accepts only "". ' +
+        '--code-mode (true|false — the agent runs as an interactive coding session instead of the chat loop; takes effect on respawn), ' +
+        '--permission-mode (auto|bypass — code-mode permission posture override: auto keeps the CLI prompting, bypass skips prompts when explicitly selected; "" clears back to the deployment default; takes effect on respawn), ' +
         '--timezone (IANA id like "Europe/Lisbon"; "" clears back to the install default; scheduled-task times follow it immediately, message display after restart).',
       handler: async (args) => {
         const id = args.id as string;
@@ -410,6 +433,8 @@ registerResource({
             | 'max_messages_per_prompt'
             | 'cli_scope'
             | 'timezone'
+            | 'code_mode'
+            | 'permission_mode'
           >
         > = {};
         if (args.provider !== undefined) updates.provider = args.provider as string;
@@ -436,10 +461,24 @@ registerResource({
           }
           updates.cli_scope = scope;
         }
+        if (args['code-mode'] !== undefined || args.code_mode !== undefined) {
+          const mode = String(args['code-mode'] ?? args.code_mode);
+          if (mode !== 'true' && mode !== 'false') {
+            throw new Error('--code-mode must be true or false');
+          }
+          updates.code_mode = mode === 'true' ? 1 : 0;
+        }
+        if (args['permission-mode'] !== undefined || args.permission_mode !== undefined) {
+          const mode = String(args['permission-mode'] ?? args.permission_mode);
+          if (mode !== 'auto' && mode !== 'bypass' && mode !== '') {
+            throw new Error('--permission-mode must be auto, bypass, or "" to follow the deployment default');
+          }
+          updates.permission_mode = mode === '' ? null : mode;
+        }
 
         if (Object.keys(updates).length === 0) {
           throw new Error(
-            'Nothing to update — provide at least one of: --provider, --model, --effort, --speed, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope, --timezone',
+            'Nothing to update — provide at least one of: --provider, --model, --effort, --speed, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope, --code-mode, --permission-mode, --timezone',
           );
         }
 

--- a/src/cli/resources/index.ts
+++ b/src/cli/resources/index.ts
@@ -15,3 +15,4 @@ import './dropped-messages.js';
 import './approvals.js';
 import './sessions.js';
 import './tasks.js';
+import './sandboxes.js';

--- a/src/cli/resources/sandboxes-surface.test.ts
+++ b/src/cli/resources/sandboxes-surface.test.ts
@@ -1,0 +1,359 @@
+/**
+ * The surface core through the real dispatch path: with a provider
+ * registered, `sandboxes new` opens and wires a surface for the session;
+ * with none, the sandbox is plain; `status`, `diff` and `stop` are the
+ * terminal's view of the same state either way.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../container-runner.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../container-runner.js')>();
+  return { ...orig, wakeContainer: vi.fn(async (): Promise<boolean> => false) };
+});
+vi.mock('../../drivers/index.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../drivers/index.js')>();
+  return { ...orig, getSessionDriver: vi.fn() };
+});
+vi.mock('../../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../config.js')>();
+  return {
+    ...actual,
+    DATA_DIR: '/tmp/nanoclaw-test-sandboxes-surface/data',
+    GROUPS_DIR: '/tmp/nanoclaw-test-sandboxes-surface/groups',
+  };
+});
+
+const TEST_ROOT = '/tmp/nanoclaw-test-sandboxes-surface';
+
+import { insertSessionSurface } from '../../code-mode/surface/db.js';
+import {
+  SESSION_SURFACE_SEAM,
+  createSessionSurfaceRuntime,
+  getSessionSurfaceByGroup,
+  registerSessionSurface,
+  sandboxWorkspaceDir,
+  setSessionSurfaceRuntime,
+  type SessionSurfaceProvider,
+} from '../../code-mode/surface/index.js';
+import { noopSessionSurface, resetSessionSurfacesForTesting } from '../../code-mode/surface/registry.js';
+import { createAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
+import { ensureContainerConfig } from '../../db/container-configs.js';
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import {
+  createMessagingGroup,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { findSandboxSessions, updateSession } from '../../db/sessions.js';
+import { getSessionDriver } from '../../drivers/index.js';
+import type { SessionEventsDriver } from '../../drivers/session-events.js';
+import type { SessionHandle } from '../../drivers/types.js';
+import { dispatch } from '../dispatch.js';
+import type { CallerContext, RequestFrame, ResponseFrame } from '../frame.js';
+import './sandboxes.js';
+import './wirings.js';
+import '../../code-mode/index.js';
+
+const HOST: CallerContext = { caller: 'host' };
+
+function call(command: string, args: Record<string, unknown> = {}): Promise<ResponseFrame> {
+  const req: RequestFrame = { id: `r-${Math.random().toString(36).slice(2, 8)}`, command, args };
+  return dispatch(req, HOST);
+}
+
+function dataOf<T>(res: ResponseFrame): T {
+  if (!res.ok) throw new Error(`expected ok, got: ${res.error.message}`);
+  return res.data as T;
+}
+
+function fakeProvider() {
+  let n = 0;
+  const provider: SessionSurfaceProvider & { opens: string[] } = {
+    ...noopSessionSurface,
+    opens: [],
+    spell: async (surfaceId) => ({ platformId: `chat:${surfaceId}`, instance: 'chat' }),
+    open: vi.fn(async (sandbox) => {
+      provider.opens.push(sandbox.folder);
+      n += 1;
+      return { surfaceId: `C${n}`, sessionId: sandbox.id };
+    }),
+  };
+  return provider;
+}
+
+function installDriver(handles: SessionHandle[]): void {
+  const driver = {
+    kind: 'fake-container',
+    listSessions: vi.fn(async () => handles.map((handle) => ({ handle, phase: 'running' as const }))),
+    watchSessions: () => ({ stop: () => {} }),
+  } as unknown as SessionEventsDriver;
+  vi.mocked(getSessionDriver).mockReturnValue(driver);
+}
+
+beforeEach(async () => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(path.join(TEST_ROOT, 'groups'), { recursive: true });
+  await runMigrations(await initTestDb());
+  installDriver([]);
+  resetSessionSurfacesForTesting();
+});
+
+afterEach(async () => {
+  resetSessionSurfacesForTesting();
+  setSessionSurfaceRuntime(null);
+  await closeDb();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('sandboxes new with a session-surface provider', () => {
+  it('opens a surface through the provider and wires it into the coding session', async () => {
+    const provider = fakeProvider();
+    registerSessionSurface('chat', provider, { seam: SESSION_SURFACE_SEAM });
+    const res = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    const { id } = dataOf<{ id: string }>(res);
+    expect(provider.opens).toEqual(['t1']);
+
+    const row = (await getSessionSurfaceByGroup(id))!;
+    expect(row).toMatchObject({ provider: 'chat', surface_id: 'C1', session_id: id, title: 't1' });
+    const mg = (await getMessagingGroupByPlatform('chat', 'chat:C1', 'chat'))!;
+    expect(row.messaging_group_id).toBe(mg.id);
+    expect((await getMessagingGroupAgents(mg.id))[0]).toMatchObject({ agent_group_id: id, session_mode: 'sandbox' });
+
+    const status = dataOf<{ status: string; surface: { provider: string; surfaceId: string } | null }>(
+      await call('sandboxes-status', { id: 't1' }),
+    );
+    expect(status.status).toBe('suspended'); // no container yet
+    expect(status.surface).toMatchObject({ provider: 'chat', surfaceId: 'C1' });
+  });
+
+  it('with two providers registered the first that answers binds; the second is never asked', async () => {
+    const first = fakeProvider();
+    const second = fakeProvider();
+    registerSessionSurface('chat', first, { seam: SESSION_SURFACE_SEAM });
+    registerSessionSurface('other-chat', second, { seam: SESSION_SURFACE_SEAM });
+    const { id } = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't1', 'no-attach': true }));
+    expect(first.opens).toEqual(['t1']);
+    expect(second.opens).toEqual([]);
+    expect((await getSessionSurfaceByGroup(id))!.provider).toBe('chat');
+  });
+
+  it('a provider that passes (null) hands the turn to the next one', async () => {
+    const passing = { ...noopSessionSurface, open: vi.fn(async () => null) };
+    const second = fakeProvider();
+    registerSessionSurface('chat', passing, { seam: SESSION_SURFACE_SEAM });
+    registerSessionSurface('other-chat', second, { seam: SESSION_SURFACE_SEAM });
+    const { id } = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't1', 'no-attach': true }));
+    expect(passing.open).toHaveBeenCalledTimes(1);
+    expect(second.opens).toEqual(['t1']);
+    expect((await getSessionSurfaceByGroup(id))!.provider).toBe('other-chat');
+  });
+
+  it('with no provider registered the sandbox is plain, and status says so', async () => {
+    const res = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    const { id } = dataOf<{ id: string }>(res);
+    expect(await getSessionSurfaceByGroup(id)).toBeUndefined();
+    const status = await call('sandboxes-status', { id: 't1' });
+    expect(dataOf<{ surface: unknown }>(status).surface).toBeNull();
+    expect((status as { human?: string }).human).toContain('surface:  none');
+  });
+
+  it('a provider that answers null leaves the sandbox plain — the verb succeeds', async () => {
+    registerSessionSurface('chat', { ...noopSessionSurface }, { seam: SESSION_SURFACE_SEAM });
+    const res = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    expect(res.ok).toBe(true);
+    expect(await getSessionSurfaceByGroup(dataOf<{ id: string }>(res).id)).toBeUndefined();
+  });
+});
+
+describe("session mode 'sandbox' on the wirings resource", () => {
+  it('is refused for a chat group and accepted for a sandbox, on create and on update', async () => {
+    const { id: sandboxId } = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't1', 'no-attach': true }));
+    await createAgentGroup({
+      id: 'ag-chat',
+      name: 'chat',
+      folder: 'chat',
+      agent_provider: null,
+      created_at: new Date().toISOString(),
+    });
+    await ensureContainerConfig('ag-chat');
+    await createMessagingGroup({
+      id: 'mg-1',
+      channel_type: 'chat',
+      platform_id: 'chat:X',
+      instance: 'chat',
+      name: 'x',
+      is_group: 1,
+      unknown_sender_policy: 'public',
+      created_at: new Date().toISOString(),
+    });
+    const refused = await call('wirings-create', {
+      'messaging-group-id': 'mg-1',
+      'agent-group-id': 'ag-chat',
+      'session-mode': 'sandbox',
+    });
+    expect(refused.ok).toBe(false);
+    expect((refused as { error: { message: string } }).error.message).toContain('needs a code-mode group');
+
+    const shared = dataOf<{ id: string }>(
+      await call('wirings-create', { 'messaging-group-id': 'mg-1', 'agent-group-id': 'ag-chat' }),
+    );
+    const flipped = await call('wirings-update', { id: shared.id, 'session-mode': 'sandbox' });
+    expect(flipped.ok).toBe(false);
+
+    const ok = await call('wirings-create', {
+      'messaging-group-id': 'mg-1',
+      'agent-group-id': sandboxId,
+      'session-mode': 'sandbox',
+    });
+    expect(ok.ok).toBe(true);
+  });
+});
+
+describe('a binding restored before its provider registers', () => {
+  it('waits in the runtime, is marked not mirrored, and goes live the moment the provider registers', async () => {
+    const { id } = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't1', 'no-attach': true }));
+    // The row a previous host process wrote for a platform whose module has not activated yet.
+    await insertSessionSurface({
+      agent_group_id: id,
+      provider: 'chat',
+      surface_id: 'C9',
+      session_id: id,
+      messaging_group_id: null,
+      title: 't1',
+      last_status: null,
+      last_status_at: null,
+      stopped_at: null,
+      last_turn_seq: 0,
+      events_cursor: null,
+      archived_at: null,
+    });
+    const runtime = createSessionSurfaceRuntime({ watchEvents: false });
+    setSessionSurfaceRuntime(runtime);
+    await runtime.start();
+    expect(runtime.has(id)).toBe(false);
+    expect(runtime.isWaiting(id)).toBe(true);
+    await runtime.tick();
+    expect((await getSessionSurfaceByGroup(id))!.last_status).toBeNull();
+    let status = dataOf<{ surface: { mirrored: boolean } }>(await call('sandboxes-status', { id: 't1' }));
+    expect(status.surface.mirrored).toBe(false);
+
+    const provider = { ...fakeProvider(), status: vi.fn(async () => {}) };
+    registerSessionSurface('chat', provider, { seam: SESSION_SURFACE_SEAM });
+    for (let i = 0; i < 20 && !runtime.has(id); i++) await new Promise((r) => setImmediate(r));
+    expect(runtime.has(id)).toBe(true);
+    await runtime.tick();
+    expect(provider.status).toHaveBeenCalledWith({ surfaceId: 'C9', sessionId: id }, 'suspended', {});
+    expect((await getSessionSurfaceByGroup(id))!.last_status).toBe('suspended');
+    status = dataOf<{ surface: { mirrored: boolean } }>(await call('sandboxes-status', { id: 't1' }));
+    expect(status.surface.mirrored).toBe(true);
+    await runtime.stop();
+  });
+});
+
+describe('sandboxes status | diff | stop', () => {
+  it('status reads the running container and the turn stamp', async () => {
+    await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    const group = (await getAgentGroupByFolder('t1'))!;
+    const session = (await findSandboxSessions(group.id))[0];
+    await updateSession(session.id, { container_status: 'running' });
+    const dir = (await sandboxWorkspaceDir(group.id))!;
+    fs.mkdirSync(path.join(path.dirname(dir), 'code-turns'), { recursive: true });
+    fs.writeFileSync(
+      path.join(path.dirname(dir), 'code-turns', 'state.json'),
+      JSON.stringify({ state: 'busy', seq: 3, at: '2026-09-11T10:00:00.000Z' }),
+    );
+    const status = dataOf<{ status: string; running: boolean; turn: { seq: number } }>(
+      await call('sandboxes-status', { id: 't1' }),
+    );
+    expect(status).toMatchObject({ status: 'processing', running: true, turn: { seq: 3 } });
+  });
+
+  it('diff is read inside the running session, says when the session is cold, and when the tree is no repository', async () => {
+    await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    const group = (await getAgentGroupByFolder('t1'))!;
+    const session = (await findSandboxSessions(group.id))[0];
+    const dir = (await sandboxWorkspaceDir(group.id))!;
+    fs.mkdirSync(dir, { recursive: true });
+
+    // Cold: no container, no diff — the host does not read the tree itself.
+    const cold = await call('sandboxes-diff', { id: 't1' });
+    expect(dataOf<{ running: boolean; repository: boolean }>(cold)).toMatchObject({
+      running: false,
+      repository: false,
+    });
+    expect((cold as { human?: string }).human).toContain('not running');
+
+    // Live: the exec the driver composes runs git in the session; here the
+    // command runs on this machine with the workspace dir standing in for
+    // the container's /workspace/group.
+    const execs: string[][] = [];
+    installDriver([
+      {
+        key: { installSlug: 'test-install', agentGroupId: group.id, sessionId: session.id },
+        name: `ncl-${session.id}`,
+        start: async () => {},
+        status: async () => ({ phase: 'running' }),
+        stop: async () => {},
+        execSpec: (command: string[]) => {
+          execs.push(command);
+          const local = command.slice(1).map((a) => a.split('/workspace/group').join(dir));
+          return { bin: command[0], argsTty: local, argsPlain: local };
+        },
+      },
+    ]);
+    const before = await call('sandboxes-diff', { id: 't1' });
+    expect(dataOf<{ running: boolean; repository: boolean }>(before)).toMatchObject({
+      running: true,
+      repository: false,
+    });
+    expect((before as { human?: string }).human).toContain('not a git repository');
+    expect(execs[0].slice(0, 3)).toEqual(['git', '-C', '/workspace/group']);
+
+    const env = {
+      ...process.env,
+      GIT_AUTHOR_NAME: 't',
+      GIT_AUTHOR_EMAIL: 't@t',
+      GIT_COMMITTER_NAME: 't',
+      GIT_COMMITTER_EMAIL: 't@t',
+      HOME: dir,
+    };
+    execFileSync('git', ['-C', dir, 'init', '-q'], { env });
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'hello\n');
+    const after = dataOf<{ running: boolean; repository: boolean; content: string }>(
+      await call('sandboxes-diff', { id: 't1' }),
+    );
+    expect(after).toMatchObject({ running: true, repository: true });
+    expect(after.content).toContain('+hello');
+    expect(execs.every((c) => c[0] === 'git' || c[0] === 'sh')).toBe(true);
+  });
+
+  it('stop presses Escape in a live session through the driver, and reports when there is none', async () => {
+    await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    const cold = dataOf<{ interrupted: boolean }>(await call('sandboxes-stop', { id: 't1' }));
+    expect(cold.interrupted).toBe(false);
+
+    const group = (await getAgentGroupByFolder('t1'))!;
+    const session = (await findSandboxSessions(group.id))[0];
+    const execs: string[][] = [];
+    installDriver([
+      {
+        key: { installSlug: 'test-install', agentGroupId: group.id, sessionId: session.id },
+        name: `ncl-${session.id}`,
+        start: async () => {},
+        status: async () => ({ phase: 'running' }),
+        stop: async () => {},
+        execSpec: (command: string[]) => {
+          execs.push(command);
+          // `true` with the command as arguments: the exec is observed, not run.
+          return { bin: 'true', argsTty: command, argsPlain: command };
+        },
+      },
+    ]);
+    const live = dataOf<{ interrupted: boolean }>(await call('sandboxes-stop', { id: 't1' }));
+    expect(live.interrupted).toBe(true);
+    expect(execs).toEqual([['tmux', '-S', '/tmp/code-runner/tmux.sock', 'send-keys', '-t', 'agent', 'Escape']]);
+  });
+});

--- a/src/cli/resources/sandboxes.test.ts
+++ b/src/cli/resources/sandboxes.test.ts
@@ -1,0 +1,390 @@
+/**
+ * `ncl sandboxes new/list/attach` through the real dispatch path — the ssh
+ * sandbox lifecycle verbs.
+ *
+ * All three verbs are hostOnly: every sandbox interaction is host-mediated, so
+ * an agent caller must be refused before any handler runs. `new` must set
+ * code_mode BEFORE the first spawn (runner selection happens only at spawn),
+ * create the sandbox session (system:sandbox — attachable yet invisible to chat
+ * routing), and hand back the driver-composed exec spec verbatim.
+ *
+ * Mocks GROUPS_DIR/DATA_DIR (the create path writes a real workspace —
+ * groups-create-folder-reuse.test.ts precedent) plus the session driver and
+ * wakeContainer (groups-attach.test.ts precedent).
+ */
+import fs from 'fs';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../container-runner.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../container-runner.js')>();
+  return { ...orig, wakeContainer: vi.fn(async (): Promise<boolean> => false) };
+});
+vi.mock('../../drivers/index.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../drivers/index.js')>();
+  return { ...orig, getSessionDriver: vi.fn() };
+});
+vi.mock('../../group-init.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../group-init.js')>();
+  return { ...orig, initGroupFilesystem: vi.fn(orig.initGroupFilesystem) };
+});
+vi.mock('../../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../config.js')>();
+  return {
+    ...actual,
+    DATA_DIR: '/tmp/nanoclaw-test-sandboxes/data',
+    GROUPS_DIR: '/tmp/nanoclaw-test-sandboxes/groups',
+  };
+});
+
+const TEST_ROOT = '/tmp/nanoclaw-test-sandboxes';
+const GROUPS_DIR = path.join(TEST_ROOT, 'groups');
+
+import { wakeContainer } from '../../container-runner.js';
+import { initGroupFilesystem } from '../../group-init.js';
+import { getAgentGroupByFolder } from '../../db/agent-groups.js';
+import { getDb } from '../../db/connection.js';
+import { getContainerConfig, ensureContainerConfig } from '../../db/container-configs.js';
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import { SANDBOX_SYSTEM_THREAD_ID, findSandboxSessions, findSessionByAgentGroup } from '../../db/sessions.js';
+import { getSessionDriver } from '../../drivers/index.js';
+import type { SessionEventsDriver } from '../../drivers/session-events.js';
+import type { SessionHandle, SessionPhase, SessionStatus } from '../../drivers/types.js';
+import type { Session } from '../../types.js';
+import { dispatch } from '../dispatch.js';
+import type { CallerContext, RequestFrame, ResponseFrame } from '../frame.js';
+// Side-effect imports: register the sandboxes-* commands and the code-mode
+// migrations (the code_mode / permission_mode columns the verbs write).
+import './sandboxes.js';
+import '../../code-mode/index.js';
+
+const HOST: CallerContext = { caller: 'host' };
+const AGENT: CallerContext = {
+  caller: 'agent',
+  sessionId: 's1',
+  agentGroupId: 'g-agent',
+  messagingGroupId: 'mg1',
+};
+
+const TMUX_CLIENT = [
+  'env',
+  'TERM=xterm-256color',
+  'tmux',
+  '-u',
+  '-S',
+  '/tmp/code-runner/tmux.sock',
+  'attach-session',
+  '-t',
+  'agent',
+];
+
+function call(command: string, args: Record<string, unknown> = {}, ctx: CallerContext = HOST): Promise<ResponseFrame> {
+  const req: RequestFrame = { id: `r-${Math.random().toString(36).slice(2, 8)}`, command, args };
+  return dispatch(req, ctx);
+}
+
+function errMsg(res: ResponseFrame): string {
+  if (res.ok) throw new Error('expected an error response');
+  return res.error.message;
+}
+
+function dataOf<T>(res: ResponseFrame): T {
+  if (!res.ok) throw new Error(`expected ok, got: ${res.error.message}`);
+  return res.data as T;
+}
+
+/** A container-shaped handle: the exec dialect only the driver knows . */
+function handleFor(agentGroupId: string, sessionId: string, name: string): SessionHandle {
+  return {
+    key: { installSlug: 'test-install', agentGroupId, sessionId },
+    name,
+    start: async () => {},
+    status: async () => ({ phase: 'running' }) as SessionStatus,
+    stop: async () => {},
+    execSpec: (command: string[]) => ({
+      bin: 'fake-exec',
+      argsTty: ['exec', '-i', '-t', '-n', 'agents', name, '-c', 'agent', '--', ...command],
+      argsPlain: ['exec', '-i', '-n', 'agents', name, '-c', 'agent', '--', ...command],
+    }),
+  };
+}
+
+/** Discovery reports the phase the listing itself observed — no per-handle probe. */
+function installDriver(handles: SessionHandle[], phase: SessionPhase = 'running'): void {
+  const driver = {
+    kind: 'fake-container',
+    listSessions: vi.fn(async () => handles.map((handle) => ({ handle, phase }))),
+    watchSessions: () => ({ stop: () => {} }),
+  } as unknown as SessionEventsDriver;
+  vi.mocked(getSessionDriver).mockReturnValue(driver);
+}
+
+/** Wake succeeds and the woken session's container appears in driver discovery. */
+function wakeBringsPodUp(): void {
+  vi.mocked(wakeContainer).mockImplementation(async (session: Session) => {
+    installDriver([handleFor(session.agent_group_id, session.id, `ncl-${session.id}`)]);
+    return true;
+  });
+}
+
+beforeEach(async () => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(GROUPS_DIR, { recursive: true });
+  await runMigrations(await initTestDb());
+  installDriver([]);
+  vi.mocked(wakeContainer).mockReset();
+  vi.mocked(wakeContainer).mockResolvedValue(false);
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await closeDb();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('sandboxes — operator-only surface ', () => {
+  it('refuses every verb for an agent caller before the handler runs', async () => {
+    for (const command of ['sandboxes-new', 'sandboxes-list', 'sandboxes-attach']) {
+      const res = await call(command, { id: 'x' }, AGENT);
+      expect(res.ok).toBe(false);
+      expect(errMsg(res)).toMatch(/operator-only/);
+    }
+  });
+});
+
+describe('sandboxes new', () => {
+  it('creates a code-mode group with the flag set BEFORE the first spawn, and lands attached', async () => {
+    let codeModeAtWake: number | null | undefined;
+    vi.mocked(wakeContainer).mockImplementation(async (session: Session) => {
+      // spawn reads code_mode — it must already be 1 when the first wake happens.
+      codeModeAtWake = (await getContainerConfig(session.agent_group_id))?.code_mode;
+      installDriver([handleFor(session.agent_group_id, session.id, `ncl-${session.id}`)]);
+      return true;
+    });
+
+    const res = await call('sandboxes-new', { name: 't1' });
+    expect(res.ok).toBe(true);
+    const data = dataOf<{ attachExec: { bin: string; argsTty: string[] }; group: string; containerName: string }>(res);
+
+    expect(codeModeAtWake).toBe(1);
+    expect(vi.mocked(wakeContainer)).toHaveBeenCalledTimes(1);
+
+    // The argv is the driver handle's, with the attach-activity stamp riding in
+    // front of the tmux client command (liveness v2 — groups-attach.test.ts
+    // pins the stamp's exact shape).
+    expect(data.attachExec.bin).toBe('fake-exec');
+    expect(data.attachExec.argsTty.slice(-TMUX_CLIENT.length)).toEqual(TMUX_CLIENT);
+    expect(data.group).toBe('t1');
+
+    // The full creation machinery ran: DB row, workspace folder, config row.
+    const group = (await getAgentGroupByFolder('t1'))!;
+    expect(group).toBeDefined();
+    expect(fs.existsSync(path.join(GROUPS_DIR, 't1'))).toBe(true);
+    expect((await getContainerConfig(group.id))?.code_mode).toBe(1);
+
+    // The wake target is the sandbox session.
+    const doorSessions = await findSandboxSessions(group.id);
+    expect(doorSessions).toHaveLength(1);
+    expect(doorSessions[0].thread_id).toBe(SANDBOX_SYSTEM_THREAD_ID);
+    expect(vi.mocked(wakeContainer).mock.calls[0][0].id).toBe(doorSessions[0].id);
+  });
+
+  it('sandbox session is attachable yet invisible to chat routing', async () => {
+    wakeBringsPodUp();
+    const res = await call('sandboxes-new', { name: 't1' });
+    expect(res.ok).toBe(true);
+    const group = (await getAgentGroupByFolder('t1'))!;
+    // resolveSession's agent-shared mode must keep seeing no session at all.
+    expect(await findSessionByAgentGroup(group.id)).toBeUndefined();
+  });
+
+  it('--no-attach creates without waking anything and hands back the attach hint', async () => {
+    const res = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    expect(res.ok).toBe(true);
+    const data = dataOf<{ sandbox: string; id: string; sessionId: string; attach: string }>(res);
+    expect(data.sandbox).toBe('t1');
+    expect(data.attach).toBe('ncl sandboxes attach t1');
+    expect(vi.mocked(wakeContainer)).not.toHaveBeenCalled();
+    expect(await findSandboxSessions(data.id)).toHaveLength(1);
+    expect((await getContainerConfig(data.id))?.code_mode).toBe(1);
+  });
+
+  it('applies --permission-mode and --timezone at creation; validates both', async () => {
+    const res = await call('sandboxes-new', {
+      name: 't1',
+      'no-attach': true,
+      'permission-mode': 'bypass',
+      timezone: 'Europe/Lisbon',
+    });
+    expect(res.ok).toBe(true);
+    const cfg = (await getContainerConfig(dataOf<{ id: string }>(res).id))!;
+    expect(cfg.permission_mode).toBe('bypass');
+    expect(cfg.timezone).toBe('Europe/Lisbon');
+
+    const badMode = await call('sandboxes-new', { 'no-attach': true, 'permission-mode': 'yolo' });
+    expect(errMsg(badMode)).toContain('--permission-mode must be auto or bypass');
+    const badTz = await call('sandboxes-new', { 'no-attach': true, timezone: 'Mars/Olympus' });
+    expect(errMsg(badTz)).toContain('not an IANA timezone id');
+  });
+
+  it('validates the name against the folder grammar AND the driver label bound', async () => {
+    for (const bad of ['has/slash', 'global', 'a'.repeat(64), 'ends_']) {
+      const res = await call('sandboxes-new', { name: bad, 'no-attach': true });
+      expect(res.ok).toBe(false);
+      expect(errMsg(res)).toContain('invalid sandbox name');
+    }
+    // 63 chars, alphanumeric both ends: legal in both grammars.
+    const ok = await call('sandboxes-new', { name: 'a'.repeat(63), 'no-attach': true });
+    expect(ok.ok).toBe(true);
+  });
+
+  it('generates suffix-deduped names when --name is omitted', async () => {
+    const first = await call('sandboxes-new', { 'no-attach': true });
+    expect(dataOf<{ sandbox: string }>(first).sandbox).toBe('sandbox');
+    const second = await call('sandboxes-new', { 'no-attach': true });
+    expect(dataOf<{ sandbox: string }>(second).sandbox).toBe('sandbox-2');
+    // On-disk residue (no DB row) also blocks a generated name.
+    fs.mkdirSync(path.join(GROUPS_DIR, 'sandbox-3'));
+    const third = await call('sandboxes-new', { 'no-attach': true });
+    expect(dataOf<{ sandbox: string }>(third).sandbox).toBe('sandbox-4');
+  });
+
+  it('takes the positional as the name via the dispatch trim (`ncl sandboxes new t1`)', async () => {
+    // The client joins positionals: `ncl sandboxes new t1` → 'sandboxes-new-t1'
+    // → dispatch fallback → 'sandboxes-new' + id 't1'. The verb's most natural
+    // spelling must create THAT name, never a generated one.
+    const res = await call('sandboxes-new-t1', { 'no-attach': true });
+    expect(res.ok).toBe(true);
+    expect(dataOf<{ sandbox: string }>(res).sandbox).toBe('t1');
+    expect(await getAgentGroupByFolder('t1')).toBeDefined();
+    expect(await getAgentGroupByFolder('sandbox')).toBeUndefined();
+
+    // And the positional path hits the same collision refusal.
+    const again = await call('sandboxes-new-t1', { 'no-attach': true });
+    expect(again.ok).toBe(false);
+    expect(errMsg(again)).toContain("sandbox 't1' already exists");
+
+    // A positional name is validated like --name.
+    const bad = await call('sandboxes-new', { id: 'ends_', 'no-attach': true });
+    expect(errMsg(bad)).toContain('invalid sandbox name');
+  });
+
+  it('refuses conflicting positional and --name spellings', async () => {
+    const res = await call('sandboxes-new-t1', { name: 't2', 'no-attach': true });
+    expect(res.ok).toBe(false);
+    expect(errMsg(res)).toContain('conflicting sandbox names');
+    expect(await getAgentGroupByFolder('t1')).toBeUndefined();
+    expect(await getAgentGroupByFolder('t2')).toBeUndefined();
+    // Agreeing spellings are fine.
+    const ok = await call('sandboxes-new-t1', { name: 't1', 'no-attach': true });
+    expect(ok.ok).toBe(true);
+  });
+
+  it('refuses an existing sandbox name with the attach hint — never idempotent-returns', async () => {
+    const first = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    const firstId = dataOf<{ id: string }>(first).id;
+
+    const res = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    expect(res.ok).toBe(false);
+    expect(errMsg(res)).toContain("sandbox 't1' already exists");
+    expect(errMsg(res)).toContain('ncl sandboxes attach t1');
+    // Nothing was minted over the existing group.
+    expect((await getAgentGroupByFolder('t1'))!.id).toBe(firstId);
+  });
+
+  it('a failure after the group row is written rolls the whole creation back', async () => {
+    vi.mocked(initGroupFilesystem).mockImplementationOnce(async (group) => {
+      fs.mkdirSync(path.join(GROUPS_DIR, group.folder), { recursive: true });
+      throw new Error('disk full');
+    });
+    const res = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    expect(res.ok).toBe(false);
+    expect(errMsg(res)).toContain('disk full');
+    // No row, no config, no session, no folder: the name is free again.
+    expect(await getAgentGroupByFolder('t1')).toBeUndefined();
+    expect(await getDb().get('SELECT 1 AS x FROM container_configs')).toBeUndefined();
+    expect(await getDb().get('SELECT 1 AS x FROM sessions')).toBeUndefined();
+    expect(fs.existsSync(path.join(GROUPS_DIR, 't1'))).toBe(false);
+    const again = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    expect(again.ok).toBe(true);
+  });
+
+  it('refuses on-disk residue with no claiming DB row (folder-reuse refusal, A4)', async () => {
+    fs.mkdirSync(path.join(GROUPS_DIR, 'recycled'));
+    fs.writeFileSync(path.join(GROUPS_DIR, 'recycled', 'memory.md'), 'old group memory\n');
+
+    const res = await call('sandboxes-new', { name: 'recycled', 'no-attach': true });
+    expect(res.ok).toBe(false);
+    expect(errMsg(res)).toContain('already exists on disk');
+    expect(await getDb().get('SELECT * FROM agent_groups WHERE folder = ?', 'recycled')).toBeUndefined();
+    expect(fs.readFileSync(path.join(GROUPS_DIR, 'recycled', 'memory.md'), 'utf8')).toBe('old group memory\n');
+  });
+});
+
+describe('sandboxes list', () => {
+  it('lists exactly the code-mode groups — a chat-only group is not a sandbox', async () => {
+    await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    // A plain (non-code-mode) group.
+    await getDb().run(
+      'INSERT INTO agent_groups (id, name, folder, created_at) VALUES (?, ?, ?, ?)',
+      'g-chat',
+      'Chat',
+      'chat-folder',
+      new Date().toISOString(),
+    );
+    await ensureContainerConfig('g-chat');
+
+    const res = await call('sandboxes-list');
+    const rows = dataOf<{ sandbox: string; status: string; sessions: number }[]>(res);
+    expect(rows.map((r) => r.sandbox)).toEqual(['t1']);
+    expect(rows[0].sessions).toBe(1); // the sandbox session
+  });
+
+  it('shows cold after the lease reaped the container, running while the runtime lives', async () => {
+    await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    const group = (await getAgentGroupByFolder('t1'))!;
+    const sandboxSession = (await findSandboxSessions(group.id))[0];
+
+    // No live runtime → cold. The group and workspace are still listed:
+    // durable identity, disposable container.
+    let rows = dataOf<{ sandbox: string; status: string }[]>(await call('sandboxes-list'));
+    expect(rows).toEqual([expect.objectContaining({ sandbox: 't1', status: 'cold' })]);
+
+    // A live runtime for the sandbox session → running.
+    installDriver([handleFor(group.id, sandboxSession.id, `ncl-${sandboxSession.id}`)]);
+    rows = dataOf<{ sandbox: string; status: string }[]>(await call('sandboxes-list'));
+    expect(rows).toEqual([expect.objectContaining({ sandbox: 't1', status: 'running' })]);
+  });
+});
+
+describe('sandboxes attach', () => {
+  it('resolves by name via the dispatch trailing-positional trim (`ncl sandboxes attach t1`)', async () => {
+    wakeBringsPodUp();
+    await call('sandboxes-new', { name: 't1', 'no-attach': true });
+
+    // The client joins positionals: `ncl sandboxes attach t1` → 'sandboxes-attach-t1'.
+    const res = await call('sandboxes-attach-t1');
+    expect(res.ok).toBe(true);
+    const data = dataOf<{ attachExec: { bin: string; argsTty: string[] }; containerName: string }>(res);
+    expect(data.attachExec.argsTty.slice(-TMUX_CLIENT.length)).toEqual(TMUX_CLIENT);
+    expect(data.containerName).toBe(
+      `ncl-${(await findSandboxSessions((await getAgentGroupByFolder('t1'))!.id))[0].id}`,
+    );
+  });
+
+  it('a cold sandbox is woken lazily on attach', async () => {
+    await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    wakeBringsPodUp();
+
+    const res = await call('sandboxes-attach', { id: 't1' });
+    expect(res.ok).toBe(true);
+    expect(vi.mocked(wakeContainer)).toHaveBeenCalledTimes(1);
+  });
+
+  it('points an unknown name at `new`', async () => {
+    const res = await call('sandboxes-attach', { id: 'nope' });
+    expect(res.ok).toBe(false);
+    expect(errMsg(res)).toContain("no sandbox 'nope'");
+    expect(errMsg(res)).toContain('ncl sandboxes new --name nope');
+  });
+});

--- a/src/cli/resources/sandboxes.test.ts
+++ b/src/cli/resources/sandboxes.test.ts
@@ -449,3 +449,30 @@ describe('sandbox lifecycle hooks', () => {
     expect(human.split('\n')[0]).toContain("sandbox-hooks refused 'created:old-module'");
   });
 });
+
+describe('a checkout without the instruction bundle is loud', () => {
+  it('`new` carries the warnings for the client to print, and `list` repeats them above the table', async () => {
+    const emptyRoot = path.join(TEST_ROOT, 'empty-install');
+    fs.mkdirSync(emptyRoot, { recursive: true });
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(emptyRoot);
+    try {
+      const created = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+      const { warnings } = dataOf<{ warnings?: string[] }>(created);
+      expect(warnings).toHaveLength(2);
+      expect(warnings![0]).toContain('operating manual is missing');
+      const listed = await call('sandboxes-list');
+      const human = (listed as { human?: string }).human ?? '';
+      expect(human.split('\n')[0]).toMatch(/^warning: code mode: the operating manual is missing/);
+      expect(human).toContain('SANDBOX');
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+
+  it('the checked-in tree yields no warning on either verb', async () => {
+    const created = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    expect(dataOf<{ warnings?: string[] }>(created).warnings).toBeUndefined();
+    const listed = await call('sandboxes-list');
+    expect((listed as { human?: string }).human?.startsWith('SANDBOX')).toBe(true);
+  });
+});

--- a/src/cli/resources/sandboxes.test.ts
+++ b/src/cli/resources/sandboxes.test.ts
@@ -56,7 +56,15 @@ import type { CallerContext, RequestFrame, ResponseFrame } from '../frame.js';
 // Side-effect imports: register the sandboxes-* commands and the code-mode
 // migrations (the code_mode / permission_mode columns the verbs write).
 import './sandboxes.js';
+import './groups.js';
 import '../../code-mode/index.js';
+import {
+  SANDBOX_HOOKS_SEAM,
+  onSandboxCreated,
+  onSandboxRemoved,
+  resetSandboxHooksForTesting,
+} from '../../code-mode/hooks.js';
+import { resetSeamRefusalsForTesting, seamAccepted } from '../../seams.js';
 
 const HOST: CallerContext = { caller: 'host' };
 const AGENT: CallerContext = {
@@ -386,5 +394,58 @@ describe('sandboxes attach', () => {
     expect(res.ok).toBe(false);
     expect(errMsg(res)).toContain("no sandbox 'nope'");
     expect(errMsg(res)).toContain('ncl sandboxes new --name nope');
+  });
+});
+
+describe('sandbox lifecycle hooks', () => {
+  afterEach(() => {
+    resetSandboxHooksForTesting();
+    resetSeamRefusalsForTesting();
+  });
+
+  it('`new` fires onSandboxCreated after the rows exist; `groups delete` fires onSandboxRemoved after they are gone', async () => {
+    const events: string[] = [];
+    onSandboxCreated(
+      't',
+      async (g) => {
+        // The group and its config are already there for a listener to read.
+        expect((await getContainerConfig(g.id))?.code_mode).toBe(1);
+        events.push(`created:${g.folder}`);
+      },
+      { seam: SANDBOX_HOOKS_SEAM },
+    );
+    onSandboxRemoved(
+      't',
+      async (g) => {
+        expect(await getAgentGroupByFolder(g.folder)).toBeUndefined();
+        events.push(`removed:${g.folder}`);
+      },
+      { seam: SANDBOX_HOOKS_SEAM },
+    );
+    const created = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    const { id } = dataOf<{ id: string }>(created);
+    const deleted = await call('groups-delete', { id });
+    expect(deleted.ok).toBe(true);
+    expect(events).toEqual(['created:t1', 'removed:t1']);
+  });
+
+  it('a listener that throws never fails the verb', async () => {
+    onSandboxCreated(
+      'boom',
+      () => {
+        throw new Error('listener broke');
+      },
+      { seam: SANDBOX_HOOKS_SEAM },
+    );
+    const res = await call('sandboxes-new', { name: 't1', 'no-attach': true });
+    expect(res.ok).toBe(true);
+  });
+
+  it('`list` repeats a seam refusal above the table so the operator sees the module that did not load', async () => {
+    seamAccepted('sandbox-hooks', 'created:old-module', SANDBOX_HOOKS_SEAM, SANDBOX_HOOKS_SEAM + 1);
+    const res = await call('sandboxes-list');
+    expect(res.ok).toBe(true);
+    const human = (res as { human?: string }).human ?? '';
+    expect(human.split('\n')[0]).toContain("sandbox-hooks refused 'created:old-module'");
   });
 });

--- a/src/cli/resources/sandboxes.ts
+++ b/src/cli/resources/sandboxes.ts
@@ -18,6 +18,7 @@ import {
   type SandboxListRow,
 } from '../../code-mode/sandboxes.js';
 import { renderSeamRefusals } from '../../seams.js';
+import { codeModeBundleWarnings } from '../../code-mode/compose.js';
 import { collectSandboxDiff } from '../../code-mode/surface/diff-view.js';
 import { sandboxStatus, type SandboxStatus } from '../../code-mode/surface/index.js';
 import { interruptCodingSession } from '../../code-mode/surface/stop.js';
@@ -35,11 +36,12 @@ export async function resolveSandboxGroup(raw: unknown, verb: string): Promise<A
 }
 
 function renderSandboxTable(rows: SandboxListRow[]): string {
-  // A module this host refused (seam mismatch) is an operator's fact: it
-  // shows here, above the table, until the module is rebuilt.
-  const refused = renderSeamRefusals();
+  // Two operator facts show here, above the table, until they are fixed: a
+  // module this host refused (seam mismatch) and an install tree missing
+  // the instruction bundle the agent reads.
+  const notices = [...renderSeamRefusals(), ...codeModeBundleWarnings().map((w) => `warning: ${w}`)];
   const table = renderSandboxRows(rows);
-  return refused.length > 0 ? [...refused, table].join('\n') : table;
+  return notices.length > 0 ? [...notices, table].join('\n') : table;
 }
 
 function renderSandboxRows(rows: SandboxListRow[]): string {
@@ -102,22 +104,26 @@ registerResource({
         }
         const name = flagged ?? positional;
         const permissionMode = args['permission-mode'] ?? args.permission_mode;
-        const { group, session } = await createSandbox({
+        const { group, session, warnings } = await createSandbox({
           ...(name !== undefined ? { name } : {}),
           ...(args.provider !== undefined ? { provider: String(args.provider) } : {}),
           ...(permissionMode !== undefined ? { permissionMode: String(permissionMode) } : {}),
           ...(args.timezone !== undefined ? { timezone: String(args.timezone) } : {}),
         });
 
+        // The client prints `warnings` before it hands the terminal over
+        // (cli/attach-exec.ts); a --no-attach caller gets them in the data.
+        const warned = warnings.length > 0 ? { warnings } : {};
         if (args['no-attach'] === true || args.no_attach === true) {
           return {
             sandbox: group.folder,
             id: group.id,
             sessionId: session.id,
             attach: `ncl sandboxes attach ${group.folder}`,
+            ...warned,
           };
         }
-        return resolveAttachForGroup(group, { wakeWaitMs: NEW_SANDBOX_WAKE_WAIT_MS });
+        return { ...(await resolveAttachForGroup(group, { wakeWaitMs: NEW_SANDBOX_WAKE_WAIT_MS })), ...warned };
       },
     },
     list: {

--- a/src/cli/resources/sandboxes.ts
+++ b/src/cli/resources/sandboxes.ts
@@ -1,0 +1,136 @@
+/**
+ * `ncl sandboxes new | list | attach` — the sandbox lifecycle verbs.
+ *
+ * A sandbox IS a code-mode agent group. The lifecycle itself lives in
+ * code-mode/sandboxes.ts (create, list, attach); this resource parses the
+ * verb's arguments, renders, and hands the attach over to the ncl client,
+ * which owns the terminal and execs the attach client into the session.
+ *
+ * All three verbs are hostOnly + 'open': the socket IS the auth boundary
+ * (a host caller is the operator), and the guard refuses every agent
+ * caller before a handler runs — the identity story is unchanged.
+ */
+import {
+  createSandbox,
+  findSandboxGroup,
+  listSandboxes,
+  NEW_SANDBOX_WAKE_WAIT_MS,
+  type SandboxListRow,
+} from '../../code-mode/sandboxes.js';
+import type { AgentGroup } from '../../types.js';
+import { resolveAttachForGroup } from '../attach-resolve.js';
+import { registerResource } from '../crud.js';
+
+/** id-first, then folder — the attach resolution order; the not-found text names the verb. */
+export async function resolveSandboxGroup(raw: unknown, verb: string): Promise<AgentGroup> {
+  const id = raw === undefined || raw === null ? '' : String(raw);
+  if (!id) throw new Error(`usage: ncl sandboxes ${verb} <name-or-id>`);
+  const group = await findSandboxGroup(id);
+  if (!group) throw new Error(`no sandbox '${id}' — create it: ncl sandboxes new --name ${id}`);
+  return group;
+}
+
+function renderSandboxTable(rows: SandboxListRow[]): string {
+  if (rows.length === 0) return 'no sandboxes — create one: ncl sandboxes new [--name <name>]';
+  const header = ['SANDBOX', 'STATUS', 'SESSIONS', 'LAST-ACTIVE', 'ID'];
+  const cells = rows.map((r) => [r.sandbox, r.status, String(r.sessions), r.last_active ?? '-', r.id]);
+  const widths = header.map((h, i) => Math.max(h.length, ...cells.map((c) => c[i].length)));
+  const line = (c: string[]) =>
+    c
+      .map((v, i) => v.padEnd(widths[i]))
+      .join('  ')
+      .trimEnd();
+  return [line(header), ...cells.map(line)].join('\n');
+}
+
+registerResource({
+  name: 'sandbox',
+  plural: 'sandboxes',
+  // Nominal CRUD anchors: every verb below is a custom operation and
+  // operations is empty, so no generic op ever registers over these — they
+  // exist because ResourceDef requires them (help rendering reads them).
+  table: 'agent_groups',
+  description:
+    'Sandbox — a code-mode agent group: a durable workspace whose disposable session container wakes on attach and reaps on the idle lease. Operator-only.',
+  idColumn: 'id',
+  columns: [
+    { name: 'id', type: 'string', description: 'Agent group UUID.', generated: true },
+    {
+      name: 'folder',
+      type: 'string',
+      description:
+        'The sandbox name — the group folder under groups/ on the host, unique, and the session-driver group-folder label verbatim.',
+      generated: true,
+    },
+  ],
+  operations: {},
+  customOperations: {
+    new: {
+      access: 'open',
+      hostOnly: true,
+      description:
+        'Create a fresh sandbox and land attached to its coding session (host operators only).\n' +
+        'Usage: ncl sandboxes new [name] [--name <name>] [--provider <p>] [--permission-mode auto|bypass] ' +
+        '[--timezone <IANA id>] [--no-attach]. The name is the group folder (generated when omitted); ' +
+        'an existing name is refused — attach to it instead. --no-attach creates without handing the ' +
+        'terminal over (scripting). Detach later with Ctrl-b then d; the session keeps running until the ' +
+        'idle lease reaps the container — the workspace is durable and re-attach wakes it again.',
+      handler: async (args) => {
+        // `ncl sandboxes new t1` arrives through the dispatch trailing-
+        // positional trim as args.id — the same mechanism that makes
+        // `sandboxes attach t1` work. The positional IS the name; ignoring
+        // it would mint a generated-name box and land the caller attached
+        // to the wrong sandbox.
+        const positional = args.id === undefined ? undefined : String(args.id);
+        const flagged = args.name === undefined ? undefined : String(args.name);
+        if (positional !== undefined && flagged !== undefined && positional !== flagged) {
+          throw new Error(
+            `conflicting sandbox names: positional '${positional}' vs --name '${flagged}' — pass exactly one`,
+          );
+        }
+        const name = flagged ?? positional;
+        const permissionMode = args['permission-mode'] ?? args.permission_mode;
+        const { group, session } = await createSandbox({
+          ...(name !== undefined ? { name } : {}),
+          ...(args.provider !== undefined ? { provider: String(args.provider) } : {}),
+          ...(permissionMode !== undefined ? { permissionMode: String(permissionMode) } : {}),
+          ...(args.timezone !== undefined ? { timezone: String(args.timezone) } : {}),
+        });
+
+        if (args['no-attach'] === true || args.no_attach === true) {
+          return {
+            sandbox: group.folder,
+            id: group.id,
+            sessionId: session.id,
+            attach: `ncl sandboxes attach ${group.folder}`,
+          };
+        }
+        return resolveAttachForGroup(group, { wakeWaitMs: NEW_SANDBOX_WAKE_WAIT_MS });
+      },
+    },
+    list: {
+      access: 'open',
+      hostOnly: true,
+      description:
+        'List sandboxes (every code-mode group) with live runtime status (host operators only).\n' +
+        "Usage: ncl sandboxes list. STATUS 'running' means a live session runtime exists right now; " +
+        "'cold' means the idle lease reaped the container — the workspace is durable and " +
+        '`ncl sandboxes attach <name>` wakes it again. No reaper runs here: TTL posture is ' +
+        'the existing in-container lease, list only shows the result.',
+      handler: async () => listSandboxes(),
+      formatHuman: (data) => renderSandboxTable(data as SandboxListRow[]),
+    },
+    attach: {
+      access: 'open',
+      hostOnly: true,
+      description:
+        "Attach this terminal to a sandbox's coding session (host operators only).\n" +
+        'Usage: ncl sandboxes attach <name-or-id>. Resolution, lazy wake and the exec handover are ' +
+        'exactly `ncl groups attach`. Detach with Ctrl-b then d; the session keeps running.',
+      handler: async (args) => {
+        if (!args.id) throw new Error('usage: ncl sandboxes attach <name-or-id>');
+        return resolveAttachForGroup(await resolveSandboxGroup(args.id, 'attach'));
+      },
+    },
+  },
+});

--- a/src/cli/resources/sandboxes.ts
+++ b/src/cli/resources/sandboxes.ts
@@ -17,6 +17,7 @@ import {
   NEW_SANDBOX_WAKE_WAIT_MS,
   type SandboxListRow,
 } from '../../code-mode/sandboxes.js';
+import { renderSeamRefusals } from '../../seams.js';
 import type { AgentGroup } from '../../types.js';
 import { resolveAttachForGroup } from '../attach-resolve.js';
 import { registerResource } from '../crud.js';
@@ -31,6 +32,14 @@ export async function resolveSandboxGroup(raw: unknown, verb: string): Promise<A
 }
 
 function renderSandboxTable(rows: SandboxListRow[]): string {
+  // A module this host refused (seam mismatch) is an operator's fact: it
+  // shows here, above the table, until the module is rebuilt.
+  const refused = renderSeamRefusals();
+  const table = renderSandboxRows(rows);
+  return refused.length > 0 ? [...refused, table].join('\n') : table;
+}
+
+function renderSandboxRows(rows: SandboxListRow[]): string {
   if (rows.length === 0) return 'no sandboxes — create one: ncl sandboxes new [--name <name>]';
   const header = ['SANDBOX', 'STATUS', 'SESSIONS', 'LAST-ACTIVE', 'ID'];
   const cells = rows.map((r) => [r.sandbox, r.status, String(r.sessions), r.last_active ?? '-', r.id]);

--- a/src/cli/resources/sandboxes.ts
+++ b/src/cli/resources/sandboxes.ts
@@ -18,6 +18,9 @@ import {
   type SandboxListRow,
 } from '../../code-mode/sandboxes.js';
 import { renderSeamRefusals } from '../../seams.js';
+import { collectSandboxDiff } from '../../code-mode/surface/diff-view.js';
+import { sandboxStatus, type SandboxStatus } from '../../code-mode/surface/index.js';
+import { interruptCodingSession } from '../../code-mode/surface/stop.js';
 import type { AgentGroup } from '../../types.js';
 import { resolveAttachForGroup } from '../attach-resolve.js';
 import { registerResource } from '../crud.js';
@@ -139,6 +142,85 @@ registerResource({
       handler: async (args) => {
         if (!args.id) throw new Error('usage: ncl sandboxes attach <name-or-id>');
         return resolveAttachForGroup(await resolveSandboxGroup(args.id, 'attach'));
+      },
+    },
+    status: {
+      access: 'open',
+      hostOnly: true,
+      description:
+        "Show a sandbox's session state (host operators only).\n" +
+        'Usage: ncl sandboxes status <name-or-id>. Reports what the host reads for the coding session — ' +
+        'active (idle between turns), processing (a turn is running) or suspended (the container was ' +
+        'retired by the idle lease) — the last turn stamp, and the chat surface bound to it, if any.',
+      handler: async (args) => sandboxStatus(await resolveSandboxGroup(args.id, 'status')),
+      formatHuman: (data) => {
+        const d = data as SandboxStatus;
+        const lines = [
+          `${d.sandbox}: ${d.status}${d.running ? '' : ' (container not running)'}`,
+          `  turn:     ${d.turn ? `${d.turn.state} #${d.turn.seq} at ${d.turn.at}` : '-'}`,
+        ];
+        if (d.surface) {
+          lines.push(
+            `  surface:  ${d.surface.provider} ${d.surface.surfaceId} (${d.surface.title})` +
+              `${d.surface.archivedAt ? ' archived' : d.surface.stoppedAt ? ' stopped by the user' : ''}`,
+            `  mirrored: ${d.surface.mirrored ? 'yes' : 'no'}; last sent ${d.surface.lastStatus ?? '-'}` +
+              `${d.surface.lastStatusAt ? ` at ${d.surface.lastStatusAt}` : ''}`,
+          );
+        } else {
+          lines.push('  surface:  none');
+        }
+        return lines.join('\n');
+      },
+    },
+    diff: {
+      access: 'open',
+      hostOnly: true,
+      description:
+        "Show what changed in a sandbox's working tree (host operators only).\n" +
+        'Usage: ncl sandboxes diff <name-or-id>. The same view a chat surface gets after each turn: ' +
+        'tracked changes and new files against HEAD, bounded in size, read by git inside the running ' +
+        'session. Empty when the tree is clean; a workspace that is not a git repository says so; a ' +
+        'sandbox whose container is not running has no diff until it wakes.',
+      handler: async (args) => {
+        const group = await resolveSandboxGroup(args.id, 'diff');
+        const result = await collectSandboxDiff(group.id);
+        if (!result.live)
+          return { sandbox: group.folder, running: false, repository: false, content: '', truncated: false };
+        if (!result.ok) {
+          const message = result.error instanceof Error ? result.error.message : String(result.error);
+          throw new Error(`${group.folder}: the diff could not be read in the session — ${message}`);
+        }
+        const { view } = result;
+        return {
+          sandbox: group.folder,
+          running: true,
+          repository: view !== null,
+          ...(view ?? { content: '', truncated: false }),
+        };
+      },
+      formatHuman: (data) => {
+        const d = data as { sandbox: string; running: boolean; repository: boolean; content: string };
+        if (!d.running) return `${d.sandbox}: the session is not running — no diff collected (attach to wake it)`;
+        if (!d.repository) return `${d.sandbox}: the workspace is not a git repository`;
+        return d.content || `${d.sandbox}: no changes`;
+      },
+    },
+    stop: {
+      access: 'open',
+      hostOnly: true,
+      description:
+        "Interrupt a sandbox's current turn (host operators only).\n" +
+        'Usage: ncl sandboxes stop <name-or-id>. Presses Escape in the coding session, exactly as a human ' +
+        'at the terminal or a Stop on its chat surface would: the action in flight stops, the session ' +
+        'stays, and the next message resumes it. A sandbox with no running container has nothing to stop.',
+      handler: async (args) => {
+        const group = await resolveSandboxGroup(args.id, 'stop');
+        const interrupted = await interruptCodingSession(group.id);
+        return { sandbox: group.folder, interrupted };
+      },
+      formatHuman: (data) => {
+        const d = data as { sandbox: string; interrupted: boolean };
+        return d.interrupted ? `${d.sandbox}: interrupted` : `${d.sandbox}: not running — nothing to interrupt`;
       },
     },
   },

--- a/src/cli/resources/wirings.ts
+++ b/src/cli/resources/wirings.ts
@@ -8,6 +8,7 @@ import {
 import { hasDeclaredChannelDefaults } from '../../channels/channel-registry.js';
 import { getAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
 import { getDb } from '../../db/connection.js';
+import { getContainerConfig } from '../../db/container-configs.js';
 import {
   ensureAgentDestinationForWiring,
   getMessagingGroup,
@@ -28,8 +29,24 @@ const CREATE_ENUMS: Record<string, string[]> = {
   engage_mode: ['pattern', 'mention', 'mention-sticky'],
   sender_scope: ['all', 'known'],
   ignored_message_policy: ['drop', 'accumulate'],
-  session_mode: ['shared', 'per-thread', 'agent-shared'],
+  session_mode: ['shared', 'per-thread', 'agent-shared', 'sandbox'],
 };
+
+/**
+ * Session mode 'sandbox' routes into a coding session, which only a
+ * code-mode group has; a chat group wired that way would have no session
+ * to land in. The binding (code-mode/surface) writes such wirings for a
+ * sandbox it just opened; an operator may too, for a code-mode group only.
+ */
+async function requireCodeModeGroup(agentGroupId: unknown): Promise<void> {
+  const cfg = await getContainerConfig(String(agentGroupId));
+  if (cfg?.code_mode !== 1) {
+    throw new Error(
+      "session_mode 'sandbox' needs a code-mode group (the wiring is a chat surface for its coding session) — " +
+        'flip the group with: ncl groups config update --id <group> --code-mode true',
+    );
+  }
+}
 
 async function requireMessagingGroup(id: unknown): Promise<MessagingGroup> {
   const mg = await getMessagingGroup(String(id));
@@ -105,8 +122,8 @@ registerResource({
       name: 'session_mode',
       type: 'string',
       description:
-        '"shared" — one session per (agent, messaging group). "per-thread" — separate session per thread/topic; requires the wiring to honor thread ids (rejected when its thread policy resolves off — pair with --threads true where the channel context does not honor them). "agent-shared" — one session across all messaging groups wired to this agent. Note: threaded adapters in group chats force per-thread regardless of this setting.',
-      enum: ['shared', 'per-thread', 'agent-shared'],
+        '"shared" — one session per (agent, messaging group). "per-thread" — separate session per thread/topic; requires the wiring to honor thread ids (rejected when its thread policy resolves off — pair with --threads true where the channel context does not honor them). "agent-shared" — one session across all messaging groups wired to this agent. "sandbox" — the agent\'s coding session (code mode): the chat is a surface for that session, never a session of its own. Note: threaded adapters in group chats force per-thread regardless of this setting (except sandbox).',
+      enum: ['shared', 'per-thread', 'agent-shared', 'sandbox'],
       default: 'shared',
       updatable: true,
     },
@@ -136,6 +153,7 @@ registerResource({
   operations: { list: 'open', get: 'open', update: 'approval', delete: 'approval' },
   preUpdate: async (updates, current) => {
     const mg = await requireMessagingGroup(current.messaging_group_id);
+    if (updates.session_mode === 'sandbox') await requireCodeModeGroup(current.agent_group_id);
     if (updates.threads !== undefined) updates.threads = normalizeThreads(updates.threads);
 
     const merged: EngageValues = { ...current, ...updates };
@@ -255,6 +273,7 @@ registerResource({
         if (values.sender_scope === undefined) values.sender_scope = 'all';
         if (values.ignored_message_policy === undefined) values.ignored_message_policy = 'drop';
         if (values.session_mode === undefined) values.session_mode = 'shared';
+        if (values.session_mode === 'sandbox') await requireCodeModeGroup(values.agent_group_id);
         if (values.priority === undefined) values.priority = 0;
 
         // postCreate parity, in one transaction with the INSERT (a throw rolls

--- a/src/code-mode/compose.test.ts
+++ b/src/code-mode/compose.test.ts
@@ -1,0 +1,514 @@
+/**
+ * Code mode: the flag round-trip, spawn-time entrypoint selection
+ * , and the composition strip — capabilities stay, chat clothing
+ * goes, and the chat path is byte-identical to before.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { afterAll, beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+// Stub only the composer: the Claude host contract reads DEFAULT_PROJECT_DOC at
+// registration and validates its shape, so the real spec stays.
+vi.mock('../project-doc-compose.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../project-doc-compose.js')>()),
+  composeGroupProjectDoc: vi.fn(),
+}));
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+import { composeGroupProjectDoc } from '../project-doc-compose.js';
+import { DATA_DIR, GROUPS_DIR, INSTALL_SLUG } from '../config.js';
+import { configFromDb, type ContainerConfig } from '../container-config.js';
+import { buildMounts, composeSessionSpec, toMountSpecs } from '../container-runner.js';
+import { ensureContainerConfig, getContainerConfig, updateContainerConfigScalars } from '../db/container-configs.js';
+import { closeDb, initTestDb, runMigrations } from '../db/index.js';
+import { mountPolicy } from '../drivers/index.js';
+import { GROUP_FOLDER_LABEL, validateSpec, type SessionSpec } from '../drivers/types.js';
+import {
+  BOUNDARY_DECISIONS_SUBDIR,
+  MANAGED_SETTINGS_CONTAINER_PATH,
+  MANAGED_SETTINGS_FILE,
+  composeManagedSettings,
+} from './permissions.js';
+import {
+  DEV_INSTRUCTION_FILE,
+  DEV_SKILLS_STAMP_DIR,
+  devInstructionMounts,
+  devSkillMounts,
+  devStampDir,
+} from './compose.js';
+import type { AgentGroup, Session } from '../types.js';
+// Side-effect: registers the module:code-mode migration.
+import './index.js';
+
+const GROUP_ID = 'ag-code-mode-test';
+const FOLDER = 'code-mode-test';
+const agentGroup = { id: GROUP_ID, name: 'Code Mode Test', folder: FOLDER } as AgentGroup;
+const session = { id: 'sess-code-mode', agent_group_id: GROUP_ID, agent_provider: null } as Session;
+
+function cfg(codeMode: boolean | undefined, codePermissionMode?: 'auto' | 'bypass'): ContainerConfig {
+  return {
+    mcpServers: {},
+    packages: { apt: [], npm: [] },
+    additionalMounts: [],
+    skills: 'all',
+    agentGroupId: GROUP_ID,
+    codeMode,
+    codePermissionMode,
+  };
+}
+
+const groupDir = path.join(GROUPS_DIR, FOLDER);
+const sessDir = path.join(DATA_DIR, 'v2-sessions', GROUP_ID, session.id);
+
+beforeAll(() => {
+  fs.mkdirSync(groupDir, { recursive: true });
+  fs.writeFileSync(path.join(groupDir, 'container.json'), '{}\n');
+  fs.writeFileSync(path.join(groupDir, 'CLAUDE.md'), '# composed');
+  fs.mkdirSync(path.join(groupDir, '.claude-fragments'), { recursive: true });
+  fs.mkdirSync(sessDir, { recursive: true });
+  fs.mkdirSync(path.join(DATA_DIR, 'v2-sessions', GROUP_ID, '.claude-shared'), { recursive: true });
+});
+afterAll(() => {
+  fs.rmSync(groupDir, { recursive: true, force: true });
+  fs.rmSync(path.join(DATA_DIR, 'v2-sessions', GROUP_ID), { recursive: true, force: true });
+});
+
+describe('the group flag', () => {
+  beforeEach(async () => {
+    const db = await initTestDb();
+    await runMigrations(db);
+    await db.run(
+      'INSERT INTO agent_groups (id, name, folder, created_at) VALUES (?, ?, ?, ?)',
+      GROUP_ID,
+      'Code Mode Test',
+      FOLDER,
+      new Date().toISOString(),
+    );
+  });
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  it('round-trips through the module migration column and configFromDb', async () => {
+    await ensureContainerConfig(GROUP_ID);
+    await updateContainerConfigScalars(GROUP_ID, { code_mode: 1 });
+    const row = (await getContainerConfig(GROUP_ID))!;
+    expect(row.code_mode).toBe(1);
+    expect(configFromDb(row, agentGroup).codeMode).toBe(true);
+
+    await updateContainerConfigScalars(GROUP_ID, { code_mode: 0 });
+    expect(configFromDb((await getContainerConfig(GROUP_ID))!, agentGroup).codeMode).toBeUndefined();
+  });
+
+  it('permission_mode round-trips, clears to NULL, and never reads mangled values', async () => {
+    await ensureContainerConfig(GROUP_ID);
+    expect(configFromDb((await getContainerConfig(GROUP_ID))!, agentGroup).codePermissionMode).toBeUndefined();
+
+    await updateContainerConfigScalars(GROUP_ID, { permission_mode: 'bypass' });
+    expect(configFromDb((await getContainerConfig(GROUP_ID))!, agentGroup).codePermissionMode).toBe('bypass');
+
+    await updateContainerConfigScalars(GROUP_ID, { permission_mode: 'auto' });
+    expect(configFromDb((await getContainerConfig(GROUP_ID))!, agentGroup).codePermissionMode).toBe('auto');
+
+    // NULL = follow the deployment default again.
+    await updateContainerConfigScalars(GROUP_ID, { permission_mode: null });
+    expect((await getContainerConfig(GROUP_ID))!.permission_mode).toBeNull();
+    expect(configFromDb((await getContainerConfig(GROUP_ID))!, agentGroup).codePermissionMode).toBeUndefined();
+
+    // A hand-edited DB value must not silently pick a posture.
+    await updateContainerConfigScalars(GROUP_ID, { permission_mode: 'yolo' });
+    expect(configFromDb((await getContainerConfig(GROUP_ID))!, agentGroup).codePermissionMode).toBeUndefined();
+  });
+});
+
+describe('spawn-time entrypoint selection ', () => {
+  function specFor(codeMode: boolean | undefined, codePermissionMode?: 'auto' | 'bypass') {
+    // Only spawn configuration participates in entrypoint selection.
+    const input = {
+      agentGroup,
+      session,
+      containerName: 'ncl-code-mode-test',
+      mounts: [],
+      containerConfig: cfg(codeMode, codePermissionMode),
+      contribution: {},
+      gateway: {},
+      mailboxEnvironment: { NANOCLAW_MAILBOX_BACKEND: 'sqlite' },
+    } as unknown as Parameters<typeof composeSessionSpec>[0];
+    return composeSessionSpec(input);
+  }
+
+  it('every code knob actually REACHES the container, not just the settings list', () => {
+    // Live regression: NANOCLAW_CODE_PERMISSION_MODE was added to the list
+    // readEnvFile consults but never assigned into the spec's env, so the
+    // runner defaulted to prompting and a detached agent wedged on a y/n.
+    // Naming a knob and forwarding it are two edits; this pins the second.
+    vi.stubEnv('NANOCLAW_CODE_IDLE_TTL_MS', '120000');
+    vi.stubEnv('NANOCLAW_CODE_PERMISSION_MODE', 'bypass');
+    vi.stubEnv('NANOCLAW_CODE_ENV', '{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":"1"}');
+    try {
+      const code = specFor(true).containers.find((c) => c.role === 'agent')!;
+      expect(code.env.NANOCLAW_CODE_IDLE_TTL_MS).toBe('120000');
+      expect(code.env.NANOCLAW_CODE_PERMISSION_MODE).toBe('bypass');
+      expect(code.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBe('1');
+      // Chat mode is untouched by every one of them.
+      const chat = specFor(undefined).containers.find((c) => c.role === 'agent')!;
+      expect(chat.env.NANOCLAW_CODE_PERMISSION_MODE).toBeUndefined();
+      expect(chat.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('extra env cannot promote credential-named keys into the provider lane', () => {
+    vi.stubEnv('NANOCLAW_CODE_ENV', '{"ANTHROPIC_API_KEY":"deployment-chosen"}');
+    try {
+      const spec = specFor(true);
+      expect(spec.containers[0].contributedEnv?.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(() => validateSpec(spec, mountPolicy())).toThrow(/secret-shaped env/);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('the per-group permission override REACHES the container and beats the deployment', () => {
+    // The rule again: a knob that exists only in the DB configures
+    // nothing until composition assigns it into the spec's env — and the
+    // precedence (group > deployment) has to be visible AT the container,
+    // where the runner actually reads it.
+    vi.stubEnv('NANOCLAW_CODE_PERMISSION_MODE', 'bypass');
+    try {
+      const overridden = specFor(true, 'auto').containers.find((c) => c.role === 'agent')!;
+      expect(overridden.env.NANOCLAW_CODE_PERMISSION_MODE).toBe('auto');
+      const chat = specFor(undefined, 'auto').containers.find((c) => c.role === 'agent')!;
+      expect(chat.env.NANOCLAW_CODE_PERMISSION_MODE).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+    // No deployment value at all: the group's own mode still arrives.
+    const groupOnly = specFor(true, 'bypass').containers.find((c) => c.role === 'agent')!;
+    expect(groupOnly.env.NANOCLAW_CODE_PERMISSION_MODE).toBe('bypass');
+  });
+
+  it('a code-mode group gets the code runner; a chat group is untouched', () => {
+    const code = specFor(true).containers.find((c) => c.role === 'agent')!;
+    const chat = specFor(undefined).containers.find((c) => c.role === 'agent')!;
+    expect(code.args).toEqual(['cd /app && exec bun run start:code']);
+    expect(chat.args).toEqual(['exec bun run /app/src/index.ts']);
+    expect(code.command).toEqual(chat.command);
+    expect(code.image).toBe(chat.image); // same unchanged image — the type IS the entrypoint
+    // container.json keeps its one nested RO mount; no path override rides the env.
+    expect(code.env.NANOCLAW_CONTAINER_JSON).toBeUndefined();
+    expect(chat.env.NANOCLAW_CONTAINER_JSON).toBeUndefined();
+  });
+});
+
+describe('the composition strip', () => {
+  it('code mode drops composed instructions and chat skills, keeps state and source', async () => {
+    const paths = (await buildMounts(agentGroup, session, cfg(true), 'claude', {})).map((m) => m.containerPath);
+    expect(paths).not.toContain('/workspace/agent/CLAUDE.md');
+    expect(paths).not.toContain('/workspace/agent/.claude-fragments');
+    expect(paths).not.toContain('/app/CLAUDE.md');
+    expect(paths).not.toContain('/app/skills');
+    // Capabilities stay: provider state (settings, credentials state), runner
+    // source, and the session workspace still mount.
+    expect(paths).toContain('/home/node/.claude');
+    expect(paths).toContain('/app/src');
+    expect(paths).toContain('/workspace/agent/container.json');
+    expect(composeGroupProjectDoc).not.toHaveBeenCalled();
+  });
+
+  it('a chat group still composes and mounts its source contract', async () => {
+    const paths = (await buildMounts(agentGroup, session, cfg(undefined), 'claude', {})).map((m) => m.containerPath);
+    expect(paths).toContain('/workspace/agent/CLAUDE.md');
+    expect(paths.includes('/app/CLAUDE.md')).toBe(
+      fs.existsSync(path.join(process.cwd(), 'src', 'claude-md-compose.ts')),
+    );
+    expect(paths).toContain('/app/skills');
+    expect(paths).toContain('/home/node/.claude');
+    expect(paths).toContain('/workspace/agent/container.json');
+    expect(composeGroupProjectDoc).toHaveBeenCalled();
+  });
+});
+
+describe('the dev-instruction surface', () => {
+  const manualSource = path.join(process.cwd(), 'container', 'code-mode', 'CLAUDE.md');
+  const workspaceDir = path.join(sessDir, 'group');
+
+  beforeEach(() => {
+    vi.mocked(composeGroupProjectDoc).mockClear();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  it('prepares the writable cwd during chat so switching to code mode preserves its files', async () => {
+    await buildMounts(agentGroup, session, cfg(false), 'claude', {});
+    expect(fs.statSync(workspaceDir).uid).toBe(process.getuid!());
+    const marker = path.join(workspaceDir, 'chat-work.txt');
+    fs.writeFileSync(marker, 'keep this work');
+    await buildMounts(agentGroup, session, cfg(true), 'claude', {});
+    expect(fs.readFileSync(marker, 'utf8')).toBe('keep this work');
+    fs.accessSync(workspaceDir, fs.constants.W_OK);
+  });
+
+  it('code mode stamps the manual and nested-RO-mounts it at the runner cwd', async () => {
+    const mounts = await buildMounts(agentGroup, session, cfg(true), 'claude', {});
+    const manual = mounts.find((m) => m.containerPath === '/workspace/group/CLAUDE.md')!;
+    expect(manual).toBeDefined();
+    expect(manual.readonly).toBe(true);
+    expect(manual.mountClass).toBe('group-state');
+    // Stamped in the sibling stamp dir, never anywhere under <sessDir>: the
+    // session dir is the RW /workspace, and a stamp inside it would be
+    // agent-editable through the back of this RO mount.
+    expect(manual.hostPath).toBe(path.join(devStampDir(sessDir), DEV_INSTRUCTION_FILE));
+    expect(fs.readFileSync(manual.hostPath, 'utf8')).toBe(fs.readFileSync(manualSource, 'utf8'));
+    // The cwd's backing dir still gets created for the session.
+    expect(fs.existsSync(workspaceDir)).toBe(true);
+    // Still the one instruction surface: no chat composition on this path.
+    expect(composeGroupProjectDoc).not.toHaveBeenCalled();
+  });
+
+  it('a cwd the host cannot write into costs neither the manual NOR the session', async () => {
+    // Regression: every session whose /workspace/group was
+    // created by a root container EACCES'd here and the spawn died — an
+    // instruction file took down the agent it was meant to inform. With the
+    // stamp outside the session dir entirely, that cwd cannot even cost the
+    // manual anymore.
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.chmodSync(workspaceDir, 0o500);
+    try {
+      const mounts = await buildMounts(agentGroup, session, cfg(true), 'claude', {});
+      expect(mounts.some((m) => m.containerPath === '/workspace')).toBe(true);
+      expect(mounts.some((m) => m.containerPath === '/workspace/group/CLAUDE.md')).toBe(true);
+    } finally {
+      fs.chmodSync(workspaceDir, 0o700);
+    }
+  });
+
+  it('an unwritable stamp root degrades to no manual rather than throwing', () => {
+    // The stamp dir is a sibling of the session dir, so the failure that
+    // costs the surface is the GROUP sessions dir refusing the mkdir.
+    const roGroupDir = path.join(DATA_DIR, 'v2-sessions', 'ro-group-manual');
+    fs.mkdirSync(roGroupDir, { recursive: true });
+    fs.chmodSync(roGroupDir, 0o500);
+    try {
+      expect(devInstructionMounts(path.join(roGroupDir, 'sess'), GROUP_ID)).toEqual([]);
+    } finally {
+      fs.chmodSync(roGroupDir, 0o700);
+      fs.rmSync(roGroupDir, { recursive: true, force: true });
+    }
+  });
+
+  it('never stamps under the RW /workspace source — custody holds through the back door', () => {
+    // A stamp under <sessDir> is the same inode
+    // RW at /workspace/... and RO at the nested mount, and an agent that runs
+    // as the host uid owns it — editing the "host-owned" words in place. Every stamped surface must live outside <sessDir>.
+    const mounts = devInstructionMounts(sessDir, GROUP_ID);
+    expect(mounts.length).toBeGreaterThan(0);
+    for (const mount of mounts) {
+      expect(mount.hostPath.startsWith(`${sessDir}${path.sep}`)).toBe(false);
+    }
+  });
+
+  it('survives the mount policy the drivers enforce at prepare', async () => {
+    // The manual cannot ride as 'install-surface' (its install-tree source is
+    // not in the enumerated surfaceRoots), which is exactly why it is stamped
+    // into the session subtree. Prove the composed result passes the real
+    // policy — the failure mode here is every code-mode spawn denied.
+    const mounts = await buildMounts(agentGroup, session, cfg(true), 'claude', {});
+    const spec: SessionSpec = {
+      key: { installSlug: INSTALL_SLUG, agentGroupId: GROUP_ID, sessionId: session.id },
+      // composeSessionSpec always stamps this, and the group-state pin joins the
+      // group subtree through it — a spec without it is not one this host can produce.
+      labels: { [GROUP_FOLDER_LABEL]: FOLDER },
+      containers: [{ role: 'agent', image: 'nanoclaw-agent:test', env: {}, mounts: toMountSpecs(mounts, GROUP_ID) }],
+      network: 'shared-private',
+      hardening: 'standard',
+      resources: {},
+      runtimeTier: 'container',
+      stopGraceSeconds: 1,
+    };
+    expect(() => validateSpec(spec, mountPolicy())).not.toThrow();
+  });
+
+  it('chat mode prepares the cwd without mounting the code-mode instructions', async () => {
+    const paths = (await buildMounts(agentGroup, session, cfg(undefined), 'claude', {})).map((m) => m.containerPath);
+    expect(paths).not.toContain('/workspace/group/CLAUDE.md');
+    expect(paths.some((p) => p.startsWith('/workspace/group/.claude/skills/'))).toBe(false);
+    expect(fs.existsSync(workspaceDir)).toBe(true);
+  });
+});
+
+describe('the managed permission settings ', () => {
+  const stampedPath = path.join(sessDir, MANAGED_SETTINGS_FILE);
+
+  afterEach(() => {
+    fs.rmSync(stampedPath, { force: true });
+  });
+
+  it('code mode stamps the policy and nested-RO-mounts it at the admin tier', async () => {
+    const mounts = await buildMounts(agentGroup, session, cfg(true), 'claude', {});
+    const managed = mounts.find((m) => m.containerPath === MANAGED_SETTINGS_CONTAINER_PATH)!;
+    expect(managed).toBeDefined();
+    expect(managed.readonly).toBe(true);
+    // 'group-state' pins hostPath + scope only, never containerPath — which is
+    // exactly why the /etc target passes both drivers' mount policy.
+    expect(managed.mountClass).toBe('group-state');
+    expect(managed.hostPath).toBe(stampedPath);
+    // No deployment env, no group override: the safe end.
+    expect(JSON.parse(fs.readFileSync(stampedPath, 'utf8'))).toEqual(composeManagedSettings('auto'));
+  });
+
+  it("the stamp's own workspace spelling is RO-covered — the write-through channel", async () => {
+    // Same inode as the admin tier: without this cover a Bash redirect at the
+    // /workspace path rewrote the policy the /etc mount exists to pin.
+    const mounts = await buildMounts(agentGroup, session, cfg(true), 'claude', {});
+    const cover = mounts.find((m) => m.containerPath === `/workspace/${MANAGED_SETTINGS_FILE}`)!;
+    expect(cover).toBeDefined();
+    expect(cover.readonly).toBe(true);
+    expect(cover.hostPath).toBe(stampedPath);
+  });
+
+  it('the boundary decision dir mounts RO in the workspace — host-writes-only by kernel', async () => {
+    const mounts = await buildMounts(agentGroup, session, cfg(true), 'claude', {});
+    const decisions = mounts.find((m) => m.containerPath === `/workspace/${BOUNDARY_DECISIONS_SUBDIR}`)!;
+    expect(decisions).toBeDefined();
+    expect(decisions.readonly).toBe(true);
+    expect(decisions.mountClass).toBe('group-state');
+    expect(decisions.hostPath).toBe(path.join(sessDir, BOUNDARY_DECISIONS_SUBDIR));
+    expect(fs.statSync(decisions.hostPath).isDirectory()).toBe(true);
+    // Chat mode gets no decision channel at all.
+    const chatPaths = (await buildMounts(agentGroup, session, cfg(undefined), 'claude', {})).map(
+      (m) => m.containerPath,
+    );
+    expect(chatPaths).not.toContain(`/workspace/${BOUNDARY_DECISIONS_SUBDIR}`);
+  });
+
+  it("a bypass group's stamp carries the escape hatch, not the boundary rules", async () => {
+    await buildMounts(agentGroup, session, cfg(true, 'bypass'), 'claude', {});
+    expect(JSON.parse(fs.readFileSync(stampedPath, 'utf8'))).toEqual(composeManagedSettings('bypass'));
+  });
+
+  it('the group override beats a bypass deployment at the stamp too', async () => {
+    vi.stubEnv('NANOCLAW_CODE_PERMISSION_MODE', 'bypass');
+    try {
+      await buildMounts(agentGroup, session, cfg(true, 'auto'), 'claude', {});
+      expect(JSON.parse(fs.readFileSync(stampedPath, 'utf8'))).toEqual(composeManagedSettings('auto'));
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('chat mode gets neither the stamp nor the mount', async () => {
+    const paths = (await buildMounts(agentGroup, session, cfg(undefined), 'claude', {})).map((m) => m.containerPath);
+    expect(paths).not.toContain(MANAGED_SETTINGS_CONTAINER_PATH);
+    expect(fs.existsSync(stampedPath)).toBe(false);
+  });
+
+  it('survives the mount policy the drivers enforce at prepare', async () => {
+    // The failure this guards: a policy file whose class pinning fails denies
+    // every code-mode spawn — the posture must never cost the session.
+    const mounts = await buildMounts(agentGroup, session, cfg(true), 'claude', {});
+    const spec: SessionSpec = {
+      key: { installSlug: INSTALL_SLUG, agentGroupId: GROUP_ID, sessionId: session.id },
+      // composeSessionSpec always stamps this, and the group-state pin joins the
+      // group subtree through it — a spec without it is not one this host can produce.
+      labels: { [GROUP_FOLDER_LABEL]: FOLDER },
+      containers: [{ role: 'agent', image: 'nanoclaw-agent:test', env: {}, mounts: toMountSpecs(mounts, GROUP_ID) }],
+      network: 'shared-private',
+      hardening: 'standard',
+      resources: {},
+      runtimeTier: 'container',
+      stopGraceSeconds: 1,
+    };
+    expect(() => validateSpec(spec, mountPolicy())).not.toThrow();
+  });
+});
+
+describe('the dev skill bundle', () => {
+  const bundleSource = path.join(process.cwd(), 'container', 'code-mode', 'skills');
+  const stampRoot = path.join(devStampDir(sessDir), DEV_SKILLS_STAMP_DIR);
+
+  afterEach(() => {
+    fs.rmSync(stampRoot, { recursive: true, force: true });
+  });
+
+  it('stamps each shipped skill outside the session dir and nested-RO-mounts it at the CLI discovery path', async () => {
+    const mounts = await buildMounts(agentGroup, session, cfg(true), 'claude', {});
+    for (const name of ['dev-toolchains', 'dev-git']) {
+      const skill = mounts.find((m) => m.containerPath === `/workspace/group/.claude/skills/${name}`)!;
+      expect(skill).toBeDefined();
+      expect(skill.readonly).toBe(true);
+      expect(skill.mountClass).toBe('group-state');
+      // Stamped in the sibling stamp dir (<stampDir>/code-mode-skills/<name>):
+      // NEVER into <sessDir>/group (the cycle-3 EACCES spawn-killer) and never
+      // under <sessDir> at all (the RW-/workspace custody hole).
+      expect(skill.hostPath).toBe(path.join(stampRoot, name));
+      expect(skill.hostPath.startsWith(`${sessDir}${path.sep}`)).toBe(false);
+      expect(fs.readFileSync(path.join(skill.hostPath, 'SKILL.md'), 'utf8')).toBe(
+        fs.readFileSync(path.join(bundleSource, name, 'SKILL.md'), 'utf8'),
+      );
+    }
+  });
+
+  it('re-stamps fresh on every spawn — a stale file from a past boot does not survive', () => {
+    fs.mkdirSync(path.join(stampRoot, 'dev-git'), { recursive: true });
+    fs.writeFileSync(path.join(stampRoot, 'dev-git', 'stale.md'), 'from a previous boot');
+    devSkillMounts(sessDir, GROUP_ID);
+    expect(fs.existsSync(path.join(stampRoot, 'dev-git', 'stale.md'))).toBe(false);
+    expect(fs.existsSync(path.join(stampRoot, 'dev-git', 'SKILL.md'))).toBe(true);
+  });
+
+  it('refuses a skill name outside the closed charset — that skill only, fail-closed', () => {
+    // A fixture install tree under the test data root, NEVER the checked-in
+    // one: an interrupted run must not leave a stray dir in the shipped
+    // bundle for the build to sweep up.
+    const fixtureRoot = path.join(DATA_DIR, 'fixture-install');
+    const fixtureSkills = path.join(fixtureRoot, 'container', 'code-mode', 'skills');
+    fs.mkdirSync(path.join(fixtureSkills, 'Bad Name!'), { recursive: true });
+    fs.cpSync(path.join(bundleSource, 'dev-git'), path.join(fixtureSkills, 'dev-git'), { recursive: true });
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(fixtureRoot);
+    try {
+      const mounts = devSkillMounts(sessDir, GROUP_ID);
+      expect(mounts.some((m) => m.containerPath.includes('Bad'))).toBe(false);
+      // The well-named skills still mount.
+      expect(mounts.map((m) => m.containerPath)).toContain('/workspace/group/.claude/skills/dev-git');
+    } finally {
+      cwdSpy.mockRestore();
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('an unwritable stamp root costs the bundle, NEVER the session — and never throws', () => {
+    const roGroupDir = path.join(DATA_DIR, 'v2-sessions', 'ro-group-skills');
+    fs.mkdirSync(roGroupDir, { recursive: true });
+    fs.chmodSync(roGroupDir, 0o500);
+    try {
+      expect(devSkillMounts(path.join(roGroupDir, 'sess'), GROUP_ID)).toEqual([]);
+    } finally {
+      fs.chmodSync(roGroupDir, 0o700);
+      fs.rmSync(roGroupDir, { recursive: true, force: true });
+    }
+  });
+
+  it('survives the mount policy the drivers enforce at prepare', async () => {
+    // Same failure mode the manual's policy test guards: a class the stamped
+    // path cannot satisfy would deny every code-mode spawn, forever, on retry.
+    const mounts = await buildMounts(agentGroup, session, cfg(true), 'claude', {});
+    expect(mounts.some((m) => m.containerPath === '/workspace/group/.claude/skills/dev-toolchains')).toBe(true);
+    const spec: SessionSpec = {
+      key: { installSlug: INSTALL_SLUG, agentGroupId: GROUP_ID, sessionId: session.id },
+      // composeSessionSpec always stamps this, and the group-state pin joins the
+      // group subtree through it — a spec without it is not one this host can produce.
+      labels: { [GROUP_FOLDER_LABEL]: FOLDER },
+      containers: [{ role: 'agent', image: 'nanoclaw-agent:test', env: {}, mounts: toMountSpecs(mounts, GROUP_ID) }],
+      network: 'shared-private',
+      hardening: 'standard',
+      resources: {},
+      runtimeTier: 'container',
+      stopGraceSeconds: 1,
+    };
+    expect(() => validateSpec(spec, mountPolicy())).not.toThrow();
+  });
+});

--- a/src/code-mode/compose.test.ts
+++ b/src/code-mode/compose.test.ts
@@ -19,6 +19,7 @@ vi.mock('../log.js', () => ({
 }));
 
 import { composeGroupProjectDoc } from '../project-doc-compose.js';
+import { log } from '../log.js';
 import { DATA_DIR, GROUPS_DIR, INSTALL_SLUG } from '../config.js';
 import { configFromDb, type ContainerConfig } from '../container-config.js';
 import { buildMounts, composeSessionSpec, toMountSpecs } from '../container-runner.js';
@@ -33,8 +34,11 @@ import {
   composeManagedSettings,
 } from './permissions.js';
 import {
+  BUNDLED_DEV_SKILLS,
   DEV_INSTRUCTION_FILE,
   DEV_SKILLS_STAMP_DIR,
+  codeModeBundleStatus,
+  codeModeBundleWarnings,
   devInstructionMounts,
   devSkillMounts,
   devStampDir,
@@ -510,5 +514,58 @@ describe('the dev skill bundle', () => {
       stopGraceSeconds: 1,
     };
     expect(() => validateSpec(spec, mountPolicy())).not.toThrow();
+  });
+});
+
+describe('the bundle is loud when missing', () => {
+  it('the checked-in tree carries the manual and every bundled skill — no warnings', () => {
+    const status = codeModeBundleStatus();
+    expect(status.manual).toBe(true);
+    expect(status.missingSkills).toEqual([]);
+    for (const name of BUNDLED_DEV_SKILLS) expect(status.skills).toContain(name);
+    expect(codeModeBundleWarnings(status)).toEqual([]);
+  });
+
+  it('a tree without the bundle names each missing piece, and the spawn logs it', () => {
+    const fixtureRoot = path.join(DATA_DIR, 'fixture-install-empty');
+    fs.mkdirSync(fixtureRoot, { recursive: true });
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(fixtureRoot);
+    try {
+      const status = codeModeBundleStatus();
+      expect(status).toEqual({ manual: false, skills: [], missingSkills: [...BUNDLED_DEV_SKILLS] });
+      const warnings = codeModeBundleWarnings(status);
+      expect(warnings).toHaveLength(2);
+      expect(warnings[0]).toContain('operating manual is missing');
+      expect(warnings[1]).toContain('dev-git, dev-toolchains');
+      // The stamp helpers still boot the session — and say why it has no manual.
+      expect(devInstructionMounts(sessDir, GROUP_ID)).toEqual([]);
+      expect(log.warn).toHaveBeenCalledWith(
+        'Code mode: operating manual missing from the install tree — the agent boots without it',
+        expect.anything(),
+      );
+      expect(log.warn).toHaveBeenCalledWith(
+        'Code mode: dev skill bundle missing from the install tree — the agent boots without it',
+        expect.anything(),
+      );
+    } finally {
+      cwdSpy.mockRestore();
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('a partial bundle reports only what is missing', () => {
+    const fixtureRoot = path.join(DATA_DIR, 'fixture-install-partial');
+    const skills = path.join(fixtureRoot, 'container', 'code-mode', 'skills');
+    fs.mkdirSync(path.join(skills, 'dev-git'), { recursive: true });
+    fs.writeFileSync(path.join(skills, 'dev-git', 'SKILL.md'), '# dev-git');
+    fs.mkdirSync(path.join(skills, 'no-skill-file'));
+    fs.writeFileSync(path.join(fixtureRoot, 'container', 'code-mode', 'CLAUDE.md'), '# manual');
+    try {
+      const status = codeModeBundleStatus(fixtureRoot);
+      expect(status).toEqual({ manual: true, skills: ['dev-git'], missingSkills: ['dev-toolchains'] });
+      expect(codeModeBundleWarnings(status)).toHaveLength(1);
+    } finally {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/code-mode/compose.ts
+++ b/src/code-mode/compose.ts
@@ -1,0 +1,176 @@
+/**
+ * Code mode: the dev-instruction surface.
+ *
+ * The code runner starts the interactive CLI at /workspace/group
+ * (code-runner/index.ts), and the CLI auto-reads the CLAUDE.md at its cwd —
+ * that file is the one instruction surface a code-mode session gets after the
+ * composition strip. The manual itself ships in the install tree
+ * (container/code-mode/CLAUDE.md), but it cannot bind onto the agent straight
+ * from there: the install-surface rule is an enumerated release-surface
+ * allowlist (drivers `surfaceRoots`) that does not name it, and every other
+ * class would refuse the path. So it takes the container.json route instead —
+ * host-stamped into the group's sessions subtree on every spawn, then
+ * nested-RO-mounted over the RW workspace: 'group-state' by the sessions-root
+ * rule, host-owned words the agent reads but cannot edit. Never via ~/.claude,
+ * which is RW agent-editable group state — and never under <sessDir> itself,
+ * which IS the RW /workspace (see devStampDir).
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { log } from '../log.js';
+
+import type { VolumeMount } from '../providers/provider-container-registry.js';
+
+/** The code runner's session cwd (code-runner/index.ts `WORKSPACE_DIR`). */
+export const CODE_WORKSPACE_DIR = '/workspace/group';
+
+/** Host-side name of the stamped manual, inside the session's stamp dir. */
+export const DEV_INSTRUCTION_FILE = 'code-mode-CLAUDE.md';
+
+/** Host-side dir of the stamped skill bundle, inside the session's stamp dir. */
+export const DEV_SKILLS_STAMP_DIR = 'code-mode-skills';
+
+/**
+ * Host-side stamp root for a session's dev-instruction surface: a SIBLING of
+ * the session dir (`<v2-sessions>/<group>/.code-mode-stamps/<sessionId>`),
+ * never a path inside it.
+ *
+ * <sessDir> itself is bind-mounted RW at /workspace, so a stamp under it is
+ * the same inode twice: RO at the nested mount the CLI reads, RW at its
+ * /workspace path — and an edit at the RW path shows straight through the RO
+ * one. Caught in review: a driver that runs
+ * the agent container as the host uid (fsGroup does not apply to hostPath
+ * volumes) owns the 644 stamps outright, so `sed -i`
+ * on /workspace/code-mode-skills/<name>/SKILL.md rewrote the "host-owned"
+ * operating instructions for the rest of the session. The
+ * sibling stays under the group's sessions subtree — the 'group-state' rule
+ * still vouches for it — but appears nowhere in the container except the RO
+ * mounts composed here. Per-session so a spawning sibling session never
+ * re-stamps over files a live session has mounted.
+ */
+export function devStampDir(sessDir: string): string {
+  return path.join(path.dirname(sessDir), '.code-mode-stamps', path.basename(sessDir));
+}
+
+/**
+ * A skill dir's name becomes a container mount path segment; refuse anything
+ * outside a closed charset rather than trusting whatever the install tree
+ * grew. Fail-closed: a name this cannot vouch for costs that skill, only.
+ */
+const SKILL_NAME_RE = /^[a-z0-9][a-z0-9._-]*$/;
+
+/**
+ * Stamp the dev-instruction surface for a code-mode session and return its
+ * mounts: the operating manual plus the dev skill bundle (devSkillMounts).
+ *
+ * The stamp lands OUTSIDE the session dir entirely (devStampDir), for two
+ * measured reasons. Not into `<sessDir>/group`: that is the container's own
+ * working directory, and one left root-owned by a past root container
+ * EACCES'd the host's write on every session that predated the move out.
+ * And not anywhere else under `<sessDir>` either: that dir IS the RW
+ * /workspace, so a stamp there is agent-editable at its RW path and the
+ * edit shows through the nested RO mount (the custody hole
+ * devStampDir documents).
+ *
+ * Failure is never fatal. An instruction surface is worth a session's
+ * knowledge, never a session's existence — anything unexpected here costs
+ * the manual (logged) and the agent still boots.
+ */
+export function devInstructionMounts(sessDir: string, scope: string): VolumeMount[] {
+  try {
+    // The runner's cwd backing dir must exist even when the manual is absent
+    // (a degraded install without the file must not cost the session its cwd).
+    // buildMounts prepares it in every mode too; repeated here so this helper
+    // holds on its own.
+    fs.mkdirSync(path.join(sessDir, 'group'), { recursive: true });
+  } catch (error) {
+    // Already there (possibly owned by a past container) is the common case
+    // and is fine — we never write INTO it.
+    log.debug('Code mode: workspace dir not created by the host', { sessDir, error: String(error) });
+  }
+  const mounts: VolumeMount[] = [];
+  const source = path.join(process.cwd(), 'container', 'code-mode', 'CLAUDE.md');
+  if (fs.existsSync(source)) {
+    const stamped = path.join(devStampDir(sessDir), DEV_INSTRUCTION_FILE);
+    try {
+      fs.mkdirSync(devStampDir(sessDir), { recursive: true });
+      fs.copyFileSync(source, stamped);
+      mounts.push({
+        hostPath: stamped,
+        containerPath: `${CODE_WORKSPACE_DIR}/CLAUDE.md`,
+        readonly: true,
+        mountClass: 'group-state',
+        scope,
+      });
+    } catch (error) {
+      log.warn('Code mode: operating manual not stamped — the agent boots without it', {
+        sessDir,
+        error: String(error),
+      });
+    }
+  }
+  mounts.push(...devSkillMounts(sessDir, scope));
+  return mounts;
+}
+
+/**
+ * Stamp the dev skill bundle (container/code-mode/skills/<name>/) for a
+ * code-mode session and return one mount per skill.
+ *
+ * Same route as the manual, generalized: the bundle ships in the install tree
+ * but cannot bind from there (not in the drivers' `surfaceRoots`), so each
+ * skill dir is host-stamped into `<stampDir>/code-mode-skills/<name>/` —
+ * outside `<sessDir>` altogether, because that dir is the RW /workspace and
+ * a stamp under it would be agent-editable through the back of the RO mount
+ * (devStampDir has the incident) — and nested-RO-mounted at the CLI's skill
+ * discovery path under the cwd. 'group-state' by the sessions-root rule:
+ * host-owned words the agent reads but cannot edit.
+ *
+ * Never throws, same rule as every code-mode mount function: anything
+ * unexpected costs that skill's mount (logged), never the session.
+ */
+export function devSkillMounts(sessDir: string, scope: string): VolumeMount[] {
+  const source = path.join(process.cwd(), 'container', 'code-mode', 'skills');
+  let names: string[];
+  try {
+    names = fs
+      .readdirSync(source, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    // An install tree without the bundle is a degraded install, not a failed
+    // session — older release artifacts simply don't carry the dir.
+    return [];
+  }
+  const mounts: VolumeMount[] = [];
+  for (const name of names) {
+    if (!SKILL_NAME_RE.test(name)) {
+      log.warn('Code mode: dev skill name refused — outside the closed charset', { name });
+      continue;
+    }
+    const stamped = path.join(devStampDir(sessDir), DEV_SKILLS_STAMP_DIR, name);
+    try {
+      // Fresh stamp every spawn: a skill file removed from the install tree must not
+      // survive here through a stale copy from a previous boot.
+      fs.rmSync(stamped, { recursive: true, force: true });
+      fs.mkdirSync(path.dirname(stamped), { recursive: true });
+      fs.cpSync(path.join(source, name), stamped, { recursive: true });
+    } catch (error) {
+      log.warn('Code mode: dev skill not stamped — the agent boots without it', {
+        name,
+        sessDir,
+        error: String(error),
+      });
+      continue;
+    }
+    mounts.push({
+      hostPath: stamped,
+      containerPath: `${CODE_WORKSPACE_DIR}/.claude/skills/${name}`,
+      readonly: true,
+      mountClass: 'group-state',
+      scope,
+    });
+  }
+  return mounts;
+}

--- a/src/code-mode/compose.ts
+++ b/src/code-mode/compose.ts
@@ -25,6 +25,63 @@ import type { VolumeMount } from '../providers/provider-container-registry.js';
 /** The code runner's session cwd (code-runner/index.ts `WORKSPACE_DIR`). */
 export const CODE_WORKSPACE_DIR = '/workspace/group';
 
+/** The bundle's home in the install tree: the manual beside a `skills/` dir of skill dirs. */
+export const CODE_MODE_BUNDLE_DIR = path.join('container', 'code-mode');
+
+/** The skills the bundle ships; a tree missing one of these is degraded. */
+export const BUNDLED_DEV_SKILLS: readonly string[] = ['dev-git', 'dev-toolchains'];
+
+export interface CodeModeBundleStatus {
+  /** container/code-mode/CLAUDE.md is present. */
+  manual: boolean;
+  /** Skill dirs present under container/code-mode/skills/. */
+  skills: string[];
+  /** Bundled skills the tree lacks. */
+  missingSkills: string[];
+}
+
+/**
+ * What of the instruction surface this install tree carries. The stamping
+ * below is fail-open by design (an instruction file is never worth a
+ * session), so a tree without the bundle must be LOUD somewhere else: the
+ * sandbox verbs read this and warn (`sandboxes new`, `sandboxes list`).
+ */
+export function codeModeBundleStatus(root: string = process.cwd()): CodeModeBundleStatus {
+  const manual = fs.existsSync(path.join(root, CODE_MODE_BUNDLE_DIR, 'CLAUDE.md'));
+  let skills: string[] = [];
+  try {
+    skills = fs
+      .readdirSync(path.join(root, CODE_MODE_BUNDLE_DIR, 'skills'), { withFileTypes: true })
+      .filter(
+        (entry) =>
+          entry.isDirectory() && fs.existsSync(path.join(root, CODE_MODE_BUNDLE_DIR, 'skills', entry.name, 'SKILL.md')),
+      )
+      .map((entry) => entry.name)
+      .sort();
+  } catch {
+    // No skills dir at all: reported as every bundled skill missing.
+  }
+  return { manual, skills, missingSkills: BUNDLED_DEV_SKILLS.filter((name) => !skills.includes(name)) };
+}
+
+/** One operator-facing line per missing piece; empty when the bundle is whole. */
+export function codeModeBundleWarnings(status: CodeModeBundleStatus = codeModeBundleStatus()): string[] {
+  const warnings: string[] = [];
+  if (!status.manual) {
+    warnings.push(
+      `code mode: the operating manual is missing from this checkout (${CODE_MODE_BUNDLE_DIR}/CLAUDE.md) — ` +
+        'the agent boots without instructions; restore the file or update the checkout',
+    );
+  }
+  if (status.missingSkills.length > 0) {
+    warnings.push(
+      `code mode: dev skills missing from this checkout (${status.missingSkills.join(', ')} under ` +
+        `${CODE_MODE_BUNDLE_DIR}/skills/) — the agent boots without them`,
+    );
+  }
+  return warnings;
+}
+
 /** Host-side name of the stamped manual, inside the session's stamp dir. */
 export const DEV_INSTRUCTION_FILE = 'code-mode-CLAUDE.md';
 
@@ -90,8 +147,12 @@ export function devInstructionMounts(sessDir: string, scope: string): VolumeMoun
     log.debug('Code mode: workspace dir not created by the host', { sessDir, error: String(error) });
   }
   const mounts: VolumeMount[] = [];
-  const source = path.join(process.cwd(), 'container', 'code-mode', 'CLAUDE.md');
-  if (fs.existsSync(source)) {
+  const source = path.join(process.cwd(), CODE_MODE_BUNDLE_DIR, 'CLAUDE.md');
+  if (!fs.existsSync(source)) {
+    // Fail-open, but never silent: the spawn goes on and the log says why
+    // the agent has no manual (the sandbox verbs repeat it to the operator).
+    log.warn('Code mode: operating manual missing from the install tree — the agent boots without it', { source });
+  } else {
     const stamped = path.join(devStampDir(sessDir), DEV_INSTRUCTION_FILE);
     try {
       fs.mkdirSync(devStampDir(sessDir), { recursive: true });
@@ -131,7 +192,7 @@ export function devInstructionMounts(sessDir: string, scope: string): VolumeMoun
  * unexpected costs that skill's mount (logged), never the session.
  */
 export function devSkillMounts(sessDir: string, scope: string): VolumeMount[] {
-  const source = path.join(process.cwd(), 'container', 'code-mode', 'skills');
+  const source = path.join(process.cwd(), CODE_MODE_BUNDLE_DIR, 'skills');
   let names: string[];
   try {
     names = fs
@@ -140,7 +201,8 @@ export function devSkillMounts(sessDir: string, scope: string): VolumeMount[] {
       .map((entry) => entry.name);
   } catch {
     // An install tree without the bundle is a degraded install, not a failed
-    // session — older release artifacts simply don't carry the dir.
+    // session — but a loud one (the sandbox verbs repeat this to the operator).
+    log.warn('Code mode: dev skill bundle missing from the install tree — the agent boots without it', { source });
     return [];
   }
   const mounts: VolumeMount[] = [];

--- a/src/code-mode/contract.test.ts
+++ b/src/code-mode/contract.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertSandboxVerb } from './contract.js';
+import '../cli/resources/sandboxes.js';
+
+describe('assertSandboxVerb', () => {
+  it('sees the trunk sandbox verbs through the real resource', () => {
+    for (const verb of ['new', 'list', 'attach']) expect(() => assertSandboxVerb(verb)).not.toThrow();
+    expect(() => assertSandboxVerb('remote enable')).toThrow('ncl sandboxes remote enable is not registered');
+  });
+});

--- a/src/code-mode/contract.ts
+++ b/src/code-mode/contract.ts
@@ -1,0 +1,36 @@
+/**
+ * Contract-test helpers for the code-mode seams.
+ *
+ * A module that plugs into code mode proves it did so against the REAL
+ * composed tree: its test imports the real barrels, then asserts through
+ * these that its hook, verb or surface provider is registered. Each helper
+ * throws with the refusal's reason when it is not, so a seam-version
+ * mismatch reads as the failure it is.
+ */
+import { lookup } from '../cli/registry.js';
+import { sandboxHookNames, type SandboxHookKind } from './hooks.js';
+import { seamRefusals } from '../seams.js';
+
+function refusalNote(registry: string, registrant: string): string {
+  const refused = seamRefusals().find((r) => r.registry === registry && r.registrant === registrant);
+  return refused
+    ? ` (refused: seam ${refused.wanted} expected, ${refused.got === undefined ? 'none' : refused.got} given)`
+    : '';
+}
+
+/** The hook `name` is registered for `kind`. */
+export function assertSandboxHook(kind: SandboxHookKind, name: string): void {
+  if (!sandboxHookNames(kind).includes(name)) {
+    throw new Error(
+      `sandbox hook '${kind}:${name}' is not registered${refusalNote('sandbox-hooks', `${kind}:${name}`)}`,
+    );
+  }
+}
+
+/** `ncl sandboxes <verb>` exists (a multi-word verb is space-separated: 'remote enable'). */
+export function assertSandboxVerb(verb: string): void {
+  const name = `sandboxes-${verb.replace(/ /g, '-')}`;
+  if (!lookup(name)) {
+    throw new Error(`ncl sandboxes ${verb} is not registered${refusalNote('resource-extension', `sandboxes ${verb}`)}`);
+  }
+}

--- a/src/code-mode/hooks.test.ts
+++ b/src/code-mode/hooks.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The sandbox lifecycle hooks: ordered, error-isolated, named for contract
+ * tests, and refused on a seam mismatch — logged, listed, never thrown.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+import { log } from '../log.js';
+import { renderSeamRefusals, resetSeamRefusalsForTesting, seamRefusals } from '../seams.js';
+import { assertSandboxHook } from './contract.js';
+import {
+  SANDBOX_HOOKS_SEAM,
+  fireRemoteAccessChanged,
+  fireSandboxBound,
+  fireSandboxCreated,
+  fireSandboxRemoved,
+  onRemoteAccessChanged,
+  onSandboxBound,
+  onSandboxCreated,
+  onSandboxRemoved,
+  resetSandboxHooksForTesting,
+  sandboxHookNames,
+} from './hooks.js';
+
+const group = { id: 'ag-1', name: 'one', folder: 'one' };
+const seam = { seam: SANDBOX_HOOKS_SEAM };
+
+beforeEach(() => {
+  resetSandboxHooksForTesting();
+  resetSeamRefusalsForTesting();
+  vi.mocked(log.error).mockClear();
+});
+afterEach(() => {
+  resetSandboxHooksForTesting();
+  resetSeamRefusalsForTesting();
+});
+
+describe('sandbox hooks', () => {
+  it('fires callbacks in registration order with the event arguments', async () => {
+    const seen: string[] = [];
+    onSandboxCreated('a', async (g) => void seen.push(`a:${g.folder}`), seam);
+    onSandboxCreated('b', (g) => void seen.push(`b:${g.folder}`), seam);
+    await fireSandboxCreated(group);
+    expect(seen).toEqual(['a:one', 'b:one']);
+
+    const bound: string[] = [];
+    onSandboxBound('s', (g, surface) => void bound.push(`${g.id}/${surface.channelType}/${surface.surfaceId}`), seam);
+    await fireSandboxBound(group, {
+      channelType: 'chat',
+      surfaceId: 'C1',
+      sessionId: 'ag-1',
+      messagingGroupId: 'mg-1',
+    });
+    expect(bound).toEqual(['ag-1/chat/C1']);
+
+    const removed: string[] = [];
+    onSandboxRemoved('r', (g) => void removed.push(g.id), seam);
+    await fireSandboxRemoved(group);
+    expect(removed).toEqual(['ag-1']);
+
+    const states: boolean[] = [];
+    onRemoteAccessChanged('ra', (state) => void states.push(state.enabled), seam);
+    await fireRemoteAccessChanged({ enabled: true, name: 'box' });
+    await fireRemoteAccessChanged({ enabled: false });
+    expect(states).toEqual([true, false]);
+  });
+
+  it('a throwing callback is logged and the rest still run — a hook never fails the verb', async () => {
+    const seen: string[] = [];
+    onSandboxCreated(
+      'boom',
+      () => {
+        throw new Error('listener broke');
+      },
+      seam,
+    );
+    onSandboxCreated('after', () => void seen.push('after'), seam);
+    await expect(fireSandboxCreated(group)).resolves.toBeUndefined();
+    expect(seen).toEqual(['after']);
+    expect(log.error).toHaveBeenCalledWith(
+      'Sandbox hook failed — continuing',
+      expect.objectContaining({ hook: 'created', name: 'boom' }),
+    );
+  });
+
+  it('unregister removes exactly that callback', async () => {
+    const seen: string[] = [];
+    const off = onSandboxCreated('a', () => void seen.push('a'), seam);
+    onSandboxCreated('b', () => void seen.push('b'), seam);
+    off();
+    await fireSandboxCreated(group);
+    expect(seen).toEqual(['b']);
+    expect(sandboxHookNames('created')).toEqual(['b']);
+  });
+
+  it('names are visible to contract tests', () => {
+    onSandboxRemoved('door', () => {}, seam);
+    expect(() => assertSandboxHook('removed', 'door')).not.toThrow();
+    expect(() => assertSandboxHook('removed', 'nobody')).toThrow("sandbox hook 'removed:nobody' is not registered");
+  });
+
+  it('a seam mismatch is refused: logged, listed for the operator, never registered, never thrown', async () => {
+    const seen: string[] = [];
+    const off = onSandboxCreated('old-module', () => void seen.push('old'), { seam: SANDBOX_HOOKS_SEAM + 1 });
+    expect(typeof off).toBe('function');
+    await fireSandboxCreated(group);
+    expect(seen).toEqual([]);
+    expect(sandboxHookNames('created')).toEqual([]);
+    expect(log.error).toHaveBeenCalledWith(
+      'Registration refused: seam version mismatch',
+      expect.objectContaining({ registry: 'sandbox-hooks', registrant: 'created:old-module' }),
+    );
+    expect(seamRefusals()).toEqual([
+      { registry: 'sandbox-hooks', registrant: 'created:old-module', wanted: SANDBOX_HOOKS_SEAM, got: 2 },
+    ]);
+    expect(renderSeamRefusals()[0]).toContain("sandbox-hooks refused 'created:old-module'");
+    // The contract helper names the refusal so a module's test reads the cause.
+    expect(() => assertSandboxHook('created', 'old-module')).toThrow(/refused: seam 1 expected, 2 given/);
+  });
+});

--- a/src/code-mode/hooks.ts
+++ b/src/code-mode/hooks.ts
@@ -1,0 +1,137 @@
+/**
+ * Sandbox lifecycle hooks — where a module attaches to code mode without
+ * code mode knowing it exists.
+ *
+ * Four events, each a list of named callbacks:
+ *   - `onSandboxCreated(group)`: `sandboxes new` minted a group and its
+ *     sandbox session; the first spawn has not happened yet;
+ *   - `onSandboxBound(group, surface)`: a chat surface was opened for the
+ *     group's coding session (code-mode/surface);
+ *   - `onSandboxRemoved(group)`: `groups delete` removed a code-mode group,
+ *     rows and workspace gone;
+ *   - `onRemoteAccessChanged(state)`: a remote-terminal module turned
+ *     remote access on or off for this host.
+ *
+ * Callbacks are awaited in registration order; a callback that throws is
+ * logged and skipped, never propagated — a hook is a listener, not a gate,
+ * and no module may fail a verb it did not implement. Registration carries
+ * `{ seam }` (SANDBOX_HOOKS_SEAM); a mismatch is refused, logged and shown
+ * by `ncl sandboxes list` (src/seams.ts).
+ */
+import { log } from '../log.js';
+import type { AgentGroup } from '../types.js';
+import { seamAccepted } from '../seams.js';
+
+/** Bump only on a breaking change to a hook's arguments. */
+export const SANDBOX_HOOKS_SEAM = 1;
+
+export type SandboxHookKind = 'created' | 'bound' | 'removed' | 'remote-access-changed';
+
+export type SandboxGroup = Pick<AgentGroup, 'id' | 'name' | 'folder'>;
+
+/** What the binding knows about a surface, platform-agnostic. */
+export interface BoundSurface {
+  /** The chat platform the surface lives on (an adapter's channel type). */
+  channelType: string;
+  /** The provider's id for the surface (a channel id, a thread id, …). */
+  surfaceId: string;
+  /** The provider's id for the session behind it. */
+  sessionId: string;
+  /** The messaging_groups row the surface is wired through. */
+  messagingGroupId: string;
+}
+
+export interface RemoteAccessState {
+  enabled: boolean;
+  /** This host's name at the remote end, when it has one. */
+  name?: string;
+  /** The address a terminal connects to, when known. */
+  host?: string;
+}
+
+export type SandboxCreatedCallback = (group: SandboxGroup) => void | Promise<void>;
+export type SandboxBoundCallback = (group: SandboxGroup, surface: BoundSurface) => void | Promise<void>;
+export type SandboxRemovedCallback = (group: SandboxGroup) => void | Promise<void>;
+export type RemoteAccessChangedCallback = (state: RemoteAccessState) => void | Promise<void>;
+
+interface Registered<T> {
+  name: string;
+  callback: T;
+}
+
+const created: Registered<SandboxCreatedCallback>[] = [];
+const bound: Registered<SandboxBoundCallback>[] = [];
+const removed: Registered<SandboxRemovedCallback>[] = [];
+const remoteAccess: Registered<RemoteAccessChangedCallback>[] = [];
+
+export interface HookRegistration {
+  seam: number;
+}
+
+/** Undo the registration. */
+export type Unregister = () => void;
+
+function add<T>(list: Registered<T>[], kind: SandboxHookKind, name: string, callback: T, seam: number): Unregister {
+  if (!seamAccepted('sandbox-hooks', `${kind}:${name}`, SANDBOX_HOOKS_SEAM, seam)) return () => {};
+  const entry = { name, callback };
+  list.push(entry);
+  return () => {
+    const at = list.indexOf(entry);
+    if (at >= 0) list.splice(at, 1);
+  };
+}
+
+export function onSandboxCreated(name: string, callback: SandboxCreatedCallback, reg: HookRegistration): Unregister {
+  return add(created, 'created', name, callback, reg.seam);
+}
+
+export function onSandboxBound(name: string, callback: SandboxBoundCallback, reg: HookRegistration): Unregister {
+  return add(bound, 'bound', name, callback, reg.seam);
+}
+
+export function onSandboxRemoved(name: string, callback: SandboxRemovedCallback, reg: HookRegistration): Unregister {
+  return add(removed, 'removed', name, callback, reg.seam);
+}
+
+export function onRemoteAccessChanged(
+  name: string,
+  callback: RemoteAccessChangedCallback,
+  reg: HookRegistration,
+): Unregister {
+  return add(remoteAccess, 'remote-access-changed', name, callback, reg.seam);
+}
+
+async function fire<T extends (...args: never[]) => void | Promise<void>>(
+  list: Registered<T>[],
+  kind: SandboxHookKind,
+  args: Parameters<T>,
+): Promise<void> {
+  for (const { name, callback } of [...list]) {
+    try {
+      await callback(...args);
+    } catch (err) {
+      log.error('Sandbox hook failed — continuing', { hook: kind, name, err });
+    }
+  }
+}
+
+/** Fired by code mode itself; a module never fires these two. */
+export const fireSandboxCreated = (group: SandboxGroup): Promise<void> => fire(created, 'created', [group]);
+export const fireSandboxRemoved = (group: SandboxGroup): Promise<void> => fire(removed, 'removed', [group]);
+/** Fired by the surface core once a binding row and its wiring exist. */
+export const fireSandboxBound = (group: SandboxGroup, surface: BoundSurface): Promise<void> =>
+  fire(bound, 'bound', [group, surface]);
+/** Fired by whichever module owns remote access when it flips the state. */
+export const fireRemoteAccessChanged = (state: RemoteAccessState): Promise<void> =>
+  fire(remoteAccess, 'remote-access-changed', [state]);
+
+/** The names registered for a hook, in order — for contract tests (contract.ts). */
+export function sandboxHookNames(kind: SandboxHookKind): string[] {
+  const list = { created, bound, removed, 'remote-access-changed': remoteAccess }[kind];
+  return list.map((entry) => entry.name);
+}
+
+/** Test seam. */
+export function resetSandboxHooksForTesting(): void {
+  for (const list of [created, bound, removed, remoteAccess]) list.length = 0;
+}

--- a/src/code-mode/index.ts
+++ b/src/code-mode/index.ts
@@ -3,11 +3,16 @@
  * (the code runner) instead of the chat loop.
  *
  * Registered here: the two container_configs columns the feature reads at
- * spawn. Behaviour changes only for groups whose config sets code_mode;
- * every other group is untouched by this import.
+ * spawn, and the host half of the sandbox boundary confirm (it follows the
+ * delivery lifecycle: cards need an adapter). Behaviour changes only for
+ * groups whose config sets code_mode; every other group is untouched by
+ * this import.
  */
 import type { DbDriver } from '../db/driver.js';
 import { registerMigration } from '../db/migrations/index.js';
+import { onDeliveryAdapterReady } from '../delivery.js';
+import { onHostShutdown } from '../host-lifecycle.js';
+import { startCodeBoundaryWatcher, stopCodeBoundaryWatcher } from '../modules/approvals/code-boundary.js';
 
 registerMigration({
   version: 1,
@@ -27,4 +32,13 @@ registerMigration({
     // validates, and configFromDb reads anything unrecognized as absent.
     await db.exec(`ALTER TABLE container_configs ADD COLUMN permission_mode TEXT`);
   },
+});
+
+/** Detached boundary confirmation follows the Host delivery lifecycle. */
+onDeliveryAdapterReady((adapter) => {
+  startCodeBoundaryWatcher(adapter);
+});
+
+onHostShutdown(() => {
+  stopCodeBoundaryWatcher();
 });

--- a/src/code-mode/index.ts
+++ b/src/code-mode/index.ts
@@ -13,6 +13,10 @@ import { registerMigration } from '../db/migrations/index.js';
 import { onDeliveryAdapterReady } from '../delivery.js';
 import { onHostShutdown } from '../host-lifecycle.js';
 import { startCodeBoundaryWatcher, stopCodeBoundaryWatcher } from '../modules/approvals/code-boundary.js';
+// The chat surface for a coding session: its own table migration (a new
+// table, independent of the columns below), the routing resolver, the
+// sandbox-created hook and the host lifecycle of the mirror.
+import './surface/index.js';
 
 registerMigration({
   version: 1,

--- a/src/code-mode/index.ts
+++ b/src/code-mode/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Code mode — a group whose agent runs as an interactive coding session
+ * (the code runner) instead of the chat loop.
+ *
+ * Registered here: the two container_configs columns the feature reads at
+ * spawn. Behaviour changes only for groups whose config sets code_mode;
+ * every other group is untouched by this import.
+ */
+import type { DbDriver } from '../db/driver.js';
+import { registerMigration } from '../db/migrations/index.js';
+
+registerMigration({
+  version: 1,
+  name: 'module:code-mode:group-flag',
+  async up(db: DbDriver) {
+    await db.exec(`ALTER TABLE container_configs ADD COLUMN code_mode BIGINT NOT NULL DEFAULT 0`);
+  },
+});
+
+registerMigration({
+  version: 2,
+  name: 'module:code-mode:permission-mode',
+  async up(db: DbDriver) {
+    // Per-group permission posture. NULL = follow the deployment default
+    // (NANOCLAW_CODE_PERMISSION_MODE); 'auto' | 'bypass' override it.
+    // TEXT with no CHECK, matching cli_scope's precedent — the ncl write path
+    // validates, and configFromDb reads anything unrecognized as absent.
+    await db.exec(`ALTER TABLE container_configs ADD COLUMN permission_mode TEXT`);
+  },
+});

--- a/src/code-mode/permissions.test.ts
+++ b/src/code-mode/permissions.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Code mode: the host-owned permission posture — mode
+ * precedence, both composed policies pinned byte-for-byte in the direction
+ * that matters (bypass must carry NO boundary rules; auto must carry ALL of
+ * them plus the bypass-flag lock), and the stamp's failure mode.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+import {
+  BOUNDARY_ASK_RULES,
+  BOUNDARY_DECISIONS_SUBDIR,
+  MANAGED_SETTINGS_CONTAINER_PATH,
+  MANAGED_SETTINGS_FILE,
+  boundaryDecisionMounts,
+  composeManagedSettings,
+  managedSettingsMounts,
+  resolveCodePermissionMode,
+} from './permissions.js';
+
+describe('resolveCodePermissionMode', () => {
+  it('group override wins in both directions', () => {
+    expect(resolveCodePermissionMode('auto', 'bypass')).toBe('auto');
+    expect(resolveCodePermissionMode('bypass', undefined)).toBe('bypass');
+  });
+
+  it('an unset or hand-mangled group value follows the deployment', () => {
+    expect(resolveCodePermissionMode(null, 'bypass')).toBe('bypass');
+    expect(resolveCodePermissionMode(undefined, 'bypass')).toBe('bypass');
+    expect(resolveCodePermissionMode('BYPASS', 'bypass')).toBe('bypass'); // not a silent group override
+    expect(resolveCodePermissionMode('yes', undefined)).toBe('auto');
+  });
+
+  it('everything unset reads as the safe end', () => {
+    expect(resolveCodePermissionMode(null, undefined)).toBe('auto');
+    expect(resolveCodePermissionMode(null, 'never-heard-of-it')).toBe('auto');
+  });
+});
+
+describe('composeManagedSettings', () => {
+  it('bypass is the full escape hatch: no ask rules, no bypass lock', () => {
+    // A bypass group's gateway is the approver — resurrecting
+    // any local ask would put the one prompt back where no one answers it.
+    expect(composeManagedSettings('bypass')).toEqual({
+      permissions: { defaultMode: 'bypassPermissions' },
+    });
+  });
+
+  it('auto pins the boundary: every ask rule present, bypass flag disabled', () => {
+    const settings = composeManagedSettings('auto') as {
+      permissions: { defaultMode: string; disableBypassPermissionsMode: string; allow: string[]; ask: string[] };
+    };
+    expect(settings.permissions.defaultMode).toBe('default');
+    // The agent must not be able to lift its own posture with a nested
+    // `claude --dangerously-skip-permissions`.
+    expect(settings.permissions.disableBypassPermissionsMode).toBe('disable');
+    expect(settings.permissions.ask).toEqual([...BOUNDARY_ASK_RULES]);
+    // The permissive inside — and every boundary path is absolute (`//`),
+    // never resolved relative to the settings file's directory.
+    expect(settings.permissions.allow).toContain('Bash');
+    for (const rule of settings.permissions.ask) {
+      if (!rule.startsWith('Bash(')) expect(rule).toMatch(/^(Edit|Write)\(\/\//);
+    }
+  });
+
+  it('the boundaries cover release and all three custody paths', () => {
+    const ask = BOUNDARY_ASK_RULES.join('\n');
+    expect(ask).toContain(`//workspace/${MANAGED_SETTINGS_FILE}`); // the policy's own stamp
+    expect(ask).toContain('//home/node/.claude/settings.json'); // the hooks' home
+    expect(ask).toContain('//workspace/group/CLAUDE.md'); // the operating manual
+  });
+});
+
+describe('managedSettingsMounts', () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('stamps the composed policy and mounts it RO at the admin tier AND over its own workspace spelling', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-perms-'));
+    const mounts = managedSettingsMounts(dir, 'ag-1', 'auto');
+    // Two mounts, one inode: the /etc tier the CLI reads, and the RO cover
+    // over the /workspace path an in-place Bash redirect used to write the
+    // policy through (found in review).
+    expect(mounts).toHaveLength(2);
+    const [admin, cover] = mounts;
+    expect(admin.hostPath).toBe(path.join(dir, MANAGED_SETTINGS_FILE));
+    expect(admin.containerPath).toBe(MANAGED_SETTINGS_CONTAINER_PATH);
+    expect(cover.hostPath).toBe(admin.hostPath);
+    expect(cover.containerPath).toBe(`/workspace/${MANAGED_SETTINGS_FILE}`);
+    for (const mount of mounts) {
+      expect(mount.readonly).toBe(true);
+      expect(mount.mountClass).toBe('group-state');
+      expect(mount.scope).toBe('ag-1');
+    }
+    expect(JSON.parse(fs.readFileSync(admin.hostPath, 'utf8'))).toEqual(composeManagedSettings('auto'));
+  });
+
+  it('restamps on every call — a flipped mode never serves the old policy', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-perms-'));
+    managedSettingsMounts(dir, 'ag-1', 'auto');
+    const [mount] = managedSettingsMounts(dir, 'ag-1', 'bypass');
+    expect(JSON.parse(fs.readFileSync(mount.hostPath, 'utf8'))).toEqual(composeManagedSettings('bypass'));
+  });
+
+  it('an unwritable session dir costs the file, never the session', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-perms-'));
+    fs.chmodSync(dir, 0o500);
+    try {
+      expect(managedSettingsMounts(dir, 'ag-1', 'auto')).toEqual([]);
+    } finally {
+      fs.chmodSync(dir, 0o700);
+    }
+  });
+});
+
+describe('boundaryDecisionMounts', () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('prepares the host-side decisions dir and mounts it RO in the workspace', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-perms-'));
+    const mounts = boundaryDecisionMounts(dir, 'ag-1');
+    expect(mounts).toHaveLength(1);
+    const mount = mounts[0];
+    expect(mount.hostPath).toBe(path.join(dir, BOUNDARY_DECISIONS_SUBDIR));
+    expect(mount.containerPath).toBe(`/workspace/${BOUNDARY_DECISIONS_SUBDIR}`);
+    // RO is the whole point: a decision the agent can write is a boundary
+    // the agent can approve (found in review).
+    expect(mount.readonly).toBe(true);
+    expect(mount.mountClass).toBe('group-state');
+    expect(fs.statSync(mount.hostPath).isDirectory()).toBe(true);
+  });
+
+  it('a dir it cannot prepare costs the mount — the hook then denies, never polls open', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-perms-'));
+    fs.chmodSync(dir, 0o500);
+    try {
+      expect(boundaryDecisionMounts(dir, 'ag-1')).toEqual([]);
+    } finally {
+      fs.chmodSync(dir, 0o700);
+    }
+  });
+});

--- a/src/code-mode/permissions.ts
+++ b/src/code-mode/permissions.ts
@@ -1,0 +1,221 @@
+/**
+ * Code mode: the host-owned permission posture.
+ *
+ * Until now the only knob was the deployment-level NANOCLAW_CODE_PERMISSION_MODE
+ * env the runner reads at boot; the CLI's own permission config lived in the RW
+ * ~/.claude mount, which the agent can edit. This module makes the posture a
+ * host-owned artifact: a managed-settings policy file composed per spawn from
+ * the deployment mode + the group's override, stamped into the session dir and
+ * nested-RO-mounted at the CLI's admin policy tier — the one settings layer
+ * nothing the agent can write ever outranks.
+ *
+ * Verified by string-inspecting the release binary at @anthropic-ai/claude-code
+ * 2.1.197; the image pins 2.1.257 (container/cli-tools.json). Re-verify these
+ * facts when the pin moves a minor:
+ *   - on linux the policy dir resolves to /etc/claude-code (darwin/windows get
+ *     their own paths; the container is linux), file `managed-settings.json`;
+ *   - the policy `permissions` block accepts allow / deny / ask / defaultMode /
+ *     disableBypassPermissionsMode ("disable") / additionalDirectories;
+ *   - rule paths: a `//` prefix is an absolute filesystem path (a single `/`
+ *     resolves relative to the settings file's own directory);
+ *   - Bash rules support `prefix:*` prefix matching;
+ *   - precedence is deny > ask > allow, so an ask boundary survives a broad
+ *     allow, and PreToolUse hooks still run under --dangerously-skip-permissions.
+ * Because the managed tier verified exactly as documented, there is no
+ * belt-and-suspenders copy in the cwd project settings — one authority, stated
+ * once.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+
+import type { VolumeMount } from '../providers/provider-container-registry.js';
+
+/** Mirrors the container's claude-args vocabulary (auto = the CLI prompts). */
+
+export type CodePermissionMode = 'auto' | 'bypass';
+
+/** Host-side name of the stamped policy file — beside the runner cwd, never
+ *  inside it (the compose.ts EACCES rule: `<sessDir>/group` may be root-owned
+ *  by a past container; `<sessDir>` is the host's own mkdir). */
+export const MANAGED_SETTINGS_FILE = 'code-mode-managed-settings.json';
+
+/** The CLI's admin policy tier on linux (verified at 2.1.197 — see header). */
+export const MANAGED_SETTINGS_CONTAINER_PATH = '/etc/claude-code/managed-settings.json';
+
+/**
+ * Group override > deployment default > 'auto'. Anything unrecognized on
+ * either side reads as unset rather than throwing at spawn — the same
+ * safe-end rule as the runner's resolvePermissionMode.
+ */
+export function resolveCodePermissionMode(
+  groupMode: string | null | undefined,
+  deploymentMode: string | undefined,
+): CodePermissionMode {
+  if (groupMode === 'auto' || groupMode === 'bypass') return groupMode;
+  return deploymentMode === 'bypass' ? 'bypass' : 'auto';
+}
+
+/**
+ * The deployment-level mode, read exactly where composeSessionSpec reads its
+ * code knobs: host process env first, then the .env file (readEnvFile never
+ * loads into process.env — see env.ts).
+ */
+export function deploymentPermissionMode(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return (
+    env.NANOCLAW_CODE_PERMISSION_MODE?.trim() ||
+    readEnvFile(['NANOCLAW_CODE_PERMISSION_MODE']).NANOCLAW_CODE_PERMISSION_MODE?.trim() ||
+    undefined
+  );
+}
+
+/**
+ * The permissive inside: the sandbox boundary is the container, so tool use
+ * within it should not queue prompts nobody reads. `ask` beats `allow`
+ * (deny > ask > allow, verified — header), so the boundary rules below still
+ * interrupt.
+ */
+export const SANDBOX_ALLOW_RULES: readonly string[] = ['Bash', 'Read', 'Edit', 'Write', 'Glob', 'Grep'];
+
+/**
+ * The statically expressible boundaries : actions whose effects outlive
+ * or escape the sandbox ask, everything else inside flows.
+ *
+ * - Custody-adjacent writes, by their in-container paths (`//` = absolute):
+ *   this file's own stamp, the settings.json the mailbox hooks live in, and
+ *   the group operating manual's mount point.
+ *
+ * These rules gate the Edit/Write TOOLS only — a Bash redirect to the same
+ * paths matches none of them, and 'Bash' is broadly allowed above. That
+ * channel is closed elsewhere, in layers: the stamp's /workspace spelling is
+ * itself nested-RO-mounted (managedSettingsMounts below — a review
+ * demonstrated a plain `echo > /workspace/code-mode-managed-settings.json`
+ * rewriting the admin tier through the shared inode), the manual's mount is
+ * already RO (compose.ts), and the boundary hook substring-classifies Bash
+ * commands that name any custody path (code-runner/boundary.ts
+ * CUSTODY_COMMAND_MARKERS — a tripwire for the one custody file that must
+ * stay writable in-container, settings.json).
+ */
+export const BOUNDARY_ASK_RULES: readonly string[] = [
+  `Edit(//workspace/${MANAGED_SETTINGS_FILE})`,
+  `Write(//workspace/${MANAGED_SETTINGS_FILE})`,
+  'Edit(//home/node/.claude/settings.json)',
+  'Write(//home/node/.claude/settings.json)',
+  'Edit(//workspace/group/CLAUDE.md)',
+  'Write(//workspace/group/CLAUDE.md)',
+];
+
+/**
+ * The policy file's content, pure so tests pin both postures byte-for-byte.
+ *
+ * Bypass is the full dangerouslyBypassPermissions posture — the FULL escape hatch, not a
+ * softer ask-list: the runner already passes --dangerously-skip-permissions,
+ * and the managed file deliberately carries no ask rules that would resurrect
+ * prompting for a group where the gateway is configured as the approver.
+ * Auto keeps the CLI's prompting AND pins it: the agent cannot flip
+ * --dangerously-skip-permissions on a nested invocation
+ * (disableBypassPermissionsMode), and cannot out-write the boundary ask rules
+ * from any tier it can reach.
+ */
+export function composeManagedSettings(mode: CodePermissionMode): Record<string, unknown> {
+  if (mode === 'bypass') {
+    return { permissions: { defaultMode: 'bypassPermissions' } };
+  }
+  return {
+    permissions: {
+      defaultMode: 'default',
+      disableBypassPermissionsMode: 'disable',
+      allow: [...SANDBOX_ALLOW_RULES],
+      ask: [...BOUNDARY_ASK_RULES],
+    },
+  };
+}
+
+/**
+ * Stamp the policy for a code-mode session and return its mounts: host-side in
+ * `<sessDir>` (the container.json pattern — 'group-state' pins hostPath +
+ * scope only, never containerPath, so the /etc target passes both drivers),
+ * mounted read-only at the CLI's admin tier.
+ *
+ * TWO mounts of the one stamped file, because it has two in-container
+ * spellings: the /etc admin tier the CLI reads, and the /workspace path the
+ * RW session mount would otherwise expose. Both spellings serve the same
+ * inode, so before the second mount an in-place Bash redirect at the
+ * /workspace path rewrote the policy the /etc mount exists to pin (found in
+ * review). The nested RO file mount makes the /workspace spelling
+ * kernel-refused, and because the RO bind is its own mount the inode cannot
+ * be hardlinked out into the RW side either (link(2) across mounts is EXDEV).
+ *
+ * Failure costs the file, never the session — and losing it fails SAFE in
+ * both postures: an 'auto' session without the policy has no allow rules, so
+ * it asks MORE, not less; a 'bypass' session already rides the runner's
+ * --dangerously-skip-permissions flag and merely loses a redundant statement.
+ */
+export function managedSettingsMounts(sessDir: string, scope: string, mode: CodePermissionMode): VolumeMount[] {
+  const stamped = path.join(sessDir, MANAGED_SETTINGS_FILE);
+  try {
+    fs.writeFileSync(stamped, JSON.stringify(composeManagedSettings(mode), null, 2) + '\n');
+  } catch (error) {
+    log.warn('Code mode: managed permission settings not stamped — the CLI runs without the policy file', {
+      sessDir,
+      mode,
+      error: String(error),
+    });
+    return [];
+  }
+  return [
+    {
+      hostPath: stamped,
+      containerPath: MANAGED_SETTINGS_CONTAINER_PATH,
+      readonly: true,
+      mountClass: 'group-state',
+      scope,
+    },
+    {
+      hostPath: stamped,
+      containerPath: `/workspace/${MANAGED_SETTINGS_FILE}`,
+      readonly: true,
+      mountClass: 'group-state',
+      scope,
+    },
+  ];
+}
+
+/** Host-side name of the decisions dir; the container half cites it as
+ *  BOUNDARY_DECISIONS_DIR (code-runner/boundary.ts). */
+export const BOUNDARY_DECISIONS_SUBDIR = 'code-boundary-decisions';
+
+/**
+ * The decision channel: host-owned, agent-read-only. Requests may ride
+ * the RW workspace (a forged request only over-asks), but a decision the
+ * agent can write is a boundary the agent can approve — a review's
+ * one-Bash-loop self-approval. So the decision dir is a nested RO mount of
+ * its own, and the hook refuses to poll a dir the kernel will not vouch for
+ * (boundary.ts decisionsDirTrusted). That refusal is also why preparation
+ * failure here may return [] like every compose helper: a session without
+ * the mount loses the detached confirm to an explicit deny, never to an
+ * open channel.
+ */
+export function boundaryDecisionMounts(sessDir: string, scope: string): VolumeMount[] {
+  const dir = path.join(sessDir, BOUNDARY_DECISIONS_SUBDIR);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch (error) {
+    log.warn('Code mode: boundary decision dir not prepared — detached boundary confirms will deny', {
+      sessDir,
+      error: String(error),
+    });
+    return [];
+  }
+  return [
+    {
+      hostPath: dir,
+      containerPath: `/workspace/${BOUNDARY_DECISIONS_SUBDIR}`,
+      readonly: true,
+      mountClass: 'group-state',
+      scope,
+    },
+  ];
+}

--- a/src/code-mode/sandboxes.ts
+++ b/src/code-mode/sandboxes.ts
@@ -32,6 +32,7 @@ import { groupFolderExistsOnDisk, isValidGroupFolder } from '../group-folder.js'
 import { initGroupFilesystem } from '../group-init.js';
 import { getInstallSlug } from '../install-slug.js';
 import { log } from '../log.js';
+import { fireSandboxCreated } from './hooks.js';
 import { resolveSandboxSession } from '../session-manager.js';
 import { isValidTimezone } from '../timezone.js';
 import type { AgentGroup, Session } from '../types.js';
@@ -222,6 +223,9 @@ export async function createSandbox(input: CreateSandboxInput = {}): Promise<Cre
     throw error;
   }
   log.info('Sandbox created', { sandbox: folder, agentGroupId: id, sessionId: session.id });
+  // Modules learn of the new sandbox here — after the rows exist and before
+  // the first wake. A listener that throws is logged, never the verb's problem.
+  await fireSandboxCreated(group);
   return { group, session };
 }
 

--- a/src/code-mode/sandboxes.ts
+++ b/src/code-mode/sandboxes.ts
@@ -59,7 +59,12 @@ export const TMUX_SESSION_NAME = 'agent';
 
 const GENERATED_NAME_BASE = 'sandbox';
 
-/** The live handle and the command behind an attach — for a caller that holds the bytes itself. */
+/**
+ * The live handle and the command behind an attach — for a caller that holds
+ * the bytes itself. `handle.execSpec(command)` is the argv a client program
+ * runs; `handle.execStream?.(command, …)` is the same exec held in-process,
+ * when the driver offers it (drivers/types.ts SessionExecStream).
+ */
 export interface AttachTarget {
   handle: SessionHandle;
   /** The argv to run inside the session: the attach-activity stamp, then the tmux client. */

--- a/src/code-mode/sandboxes.ts
+++ b/src/code-mode/sandboxes.ts
@@ -1,0 +1,386 @@
+/**
+ * Sandboxes — the in-process API behind `ncl sandboxes new | list | attach`
+ * and `ncl groups attach`.
+ *
+ * A sandbox IS a code-mode agent group. The verbs here are the one place the
+ * lifecycle is decided: `create` composes the existing group-creation
+ * machinery with code_mode written before the first spawn (runner selection
+ * happens only at spawn, so a creation-time config write needs no restart)
+ * and creates the group's sandbox session; `list` is the reap-visibility
+ * surface (containers reap on the in-container idle lease, the group and
+ * workspace stay durable); `attach` resolves — lazily waking — the live
+ * session runtime and returns the handle and the command an attaching
+ * client runs inside it. The CLI resource renders and execs; anything else
+ * on the host that needs to land a terminal in a sandbox calls the same
+ * functions and holds the bytes itself.
+ *
+ * Authority is the caller's: the ncl socket admits only host operators to
+ * these verbs, and nothing here re-checks it.
+ */
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { GROUPS_DIR } from '../config.js';
+import { wakeContainer } from '../container-runner.js';
+import { createAgentGroup, getAgentGroup, getAgentGroupByFolder } from '../db/agent-groups.js';
+import { getDb } from '../db/connection.js';
+import { getContainerConfig, updateContainerConfigScalars } from '../db/container-configs.js';
+import { findAttachableSessions } from '../db/sessions.js';
+import { getSessionDriver, labelValueLegal, type SessionHandle } from '../drivers/index.js';
+import { groupFolderExistsOnDisk, isValidGroupFolder } from '../group-folder.js';
+import { initGroupFilesystem } from '../group-init.js';
+import { getInstallSlug } from '../install-slug.js';
+import { log } from '../log.js';
+import { resolveSandboxSession } from '../session-manager.js';
+import { isValidTimezone } from '../timezone.js';
+import type { AgentGroup, Session } from '../types.js';
+
+/** How long attach waits for a lazily-woken session's runtime to report running. */
+export const ATTACH_WAKE_WAIT_MS = 90_000;
+
+/**
+ * The first-ever spawn of a brand-new group is the slow path — a cold session
+ * runtime can take ~10s to come up and an image pull blows a short attach
+ * wait — so `create` waits longer than plain attach when it lands attached.
+ */
+export const NEW_SANDBOX_WAKE_WAIT_MS = 30_000;
+
+/**
+ * Attach-exec evidence (liveness). Hand-synced with the runner's
+ * ATTACH_ACTIVITY_PATH (code-runner/agent-state.ts) — the same lockstep
+ * discipline as the tmux-socket literal below.
+ */
+const ATTACH_ACTIVITY_PATH = '/tmp/code-runner/attach-activity';
+
+/** The runner's tmux socket and session name (code-runner/tmux-session.ts). */
+export const TMUX_SOCKET_PATH = '/tmp/code-runner/tmux.sock';
+export const TMUX_SESSION_NAME = 'agent';
+
+const GENERATED_NAME_BASE = 'sandbox';
+
+/** The live handle and the command behind an attach — for a caller that holds the bytes itself. */
+export interface AttachTarget {
+  handle: SessionHandle;
+  /** The argv to run inside the session: the attach-activity stamp, then the tmux client. */
+  command: string[];
+  /** The group's display name. */
+  group: string;
+  /** The session runtime's own name (the driver's, not the host's lineage label). */
+  containerName: string;
+}
+
+export interface CreateSandboxInput {
+  /** The sandbox name (the group folder); generated when omitted. */
+  name?: string;
+  provider?: string;
+  permissionMode?: string;
+  timezone?: string;
+}
+
+export interface CreatedSandbox {
+  group: AgentGroup;
+  session: Session;
+}
+
+export interface SandboxListRow {
+  sandbox: string;
+  id: string;
+  status: 'running' | 'cold';
+  sessions: number;
+  container_status: string | null;
+  last_active: string | null;
+  created_at: string;
+}
+
+/**
+ * A sandbox name is the group folder AND rides the session driver's
+ * group-folder label VERBATIM (SessionSpec label `nanoclaw-group-folder`,
+ * refused at composition when label-illegal) — so both grammars must hold at
+ * creation, not at first spawn. isValidGroupFolder alone would admit 64 chars
+ * and a trailing underscore, both label-illegal.
+ */
+export function validateSandboxName(name: string): void {
+  if (!isValidGroupFolder(name) || !labelValueLegal(name)) {
+    throw new Error(
+      `invalid sandbox name "${name}" — up to 63 chars of [A-Za-z0-9_-], starting and ending ` +
+        `alphanumeric ('global' is reserved; the name is the group folder and rides the session ` +
+        `driver's group-folder label verbatim)`,
+    );
+  }
+}
+
+/**
+ * Suffix-dedupe name generation (create-agent.ts precedent), globally across
+ * agent_groups.folder AND the on-disk groups/ dir: a folder on disk with no
+ * claiming DB row is deleted-group residue and must never be adopted.
+ */
+export async function generateSandboxName(): Promise<string> {
+  let folder = GENERATED_NAME_BASE;
+  let suffix = 2;
+  while ((await getAgentGroupByFolder(folder)) || groupFolderExistsOnDisk(folder)) {
+    folder = `${GENERATED_NAME_BASE}-${suffix}`;
+    suffix++;
+  }
+  return folder;
+}
+
+/** id-first, then folder — the attach resolution order. Undefined when neither matches. */
+export async function findSandboxGroup(nameOrId: string): Promise<AgentGroup | undefined> {
+  return (await getAgentGroup(nameOrId)) ?? (await getAgentGroupByFolder(nameOrId));
+}
+
+/** Every code-mode group, oldest first. */
+export async function listSandboxGroups(): Promise<Pick<AgentGroup, 'id' | 'folder' | 'created_at'>[]> {
+  return getDb().all<Pick<AgentGroup, 'id' | 'folder' | 'created_at'>>(
+    `SELECT g.id, g.folder, g.created_at
+       FROM agent_groups g
+       JOIN container_configs c ON c.agent_group_id = g.id
+      WHERE c.code_mode = 1
+      ORDER BY g.created_at`,
+  );
+}
+
+/**
+ * Create a sandbox: the exact creation machinery of `groups create` (fresh
+ * branch) — agent_groups row, workspace folder, container_configs row — with
+ * code mode written before any spawn, then the group's sandbox session.
+ *
+ * Collision is a refusal, deliberately NOT groups-create's idempotent
+ * return: `new` promises a FRESH box, and silently landing someone in an
+ * existing agent's workspace would hand over that agent's memory and
+ * materials.
+ */
+export async function createSandbox(input: CreateSandboxInput = {}): Promise<CreatedSandbox> {
+  const requested = input.name;
+  if (requested !== undefined) validateSandboxName(requested);
+
+  const provider = input.provider ?? 'claude';
+  if (provider !== 'claude') {
+    throw new Error('code mode currently supports only Claude Code');
+  }
+
+  const permissionMode = input.permissionMode;
+  if (permissionMode !== undefined && permissionMode !== 'auto' && permissionMode !== 'bypass') {
+    throw new Error('--permission-mode must be auto or bypass');
+  }
+
+  const timezone = input.timezone;
+  if (timezone !== undefined && !isValidTimezone(timezone)) {
+    throw new Error(`invalid --timezone: "${timezone}" is not an IANA timezone id (e.g. "Europe/Lisbon")`);
+  }
+
+  if (requested !== undefined) {
+    if (await getAgentGroupByFolder(requested)) {
+      throw new Error(`sandbox '${requested}' already exists — attach to it: ncl sandboxes attach ${requested}`);
+    }
+    if (groupFolderExistsOnDisk(requested)) {
+      throw new Error(
+        `group folder 'groups/${requested}' already exists on disk but no sandbox claims it — ` +
+          `deleted-group residue is never adopted under a new identity. Move or remove the folder, ` +
+          `or pick a different --name.`,
+      );
+    }
+  }
+  const folder = requested ?? (await generateSandboxName());
+
+  const id = `ag-${randomUUID()}`;
+  const group: AgentGroup = {
+    id,
+    name: folder,
+    folder,
+    agent_provider: null,
+    created_at: new Date().toISOString(),
+  };
+  await createAgentGroup(group);
+  let session: Session;
+  try {
+    await initGroupFilesystem(group, { provider });
+
+    // Creation-time code mode — written BEFORE the first spawn, so no restart
+    // is needed: spawn reads the flag for entrypoint selection, code-mode
+    // mounts and code env. No other creation path sets it.
+    await updateContainerConfigScalars(id, {
+      code_mode: 1,
+      ...(permissionMode !== undefined ? { permission_mode: permissionMode } : {}),
+      ...(timezone !== undefined ? { timezone } : {}),
+    });
+
+    session = (await resolveSandboxSession(id)).session;
+  } catch (error) {
+    // All or nothing: a half-made sandbox (a row without its workspace, a
+    // folder without its config) would be refused as residue by the next
+    // `new` and adopted by nothing. Undo what this call created, then say why.
+    await getDb().run('DELETE FROM agent_groups WHERE id = ?', id); // container_configs and sessions cascade
+    fs.rmSync(path.join(GROUPS_DIR, folder), { recursive: true, force: true });
+    log.warn('Sandbox not created — rolled back', { sandbox: folder, agentGroupId: id, error: String(error) });
+    throw error;
+  }
+  log.info('Sandbox created', { sandbox: folder, agentGroupId: id, sessionId: session.id });
+  return { group, session };
+}
+
+function newestActivity(sessions: Session[]): { container_status: string | null; last_active: string | null } {
+  let best: Session | undefined;
+  for (const s of sessions) {
+    const stamp = s.last_active ?? s.created_at;
+    if (!best || stamp > (best.last_active ?? best.created_at)) best = s;
+  }
+  return { container_status: best?.container_status ?? null, last_active: best?.last_active ?? null };
+}
+
+/**
+ * Every sandbox with its live runtime status. Live phase comes through the
+ * driver's own discovery (the adoption contract — lineage names lie): one
+ * listSessions sweep, where each snapshot carries the phase the listing
+ * itself observed, grouped by owning agent group. No reaper runs here: TTL
+ * posture is the in-container lease, list only shows the result.
+ */
+export async function listSandboxes(): Promise<SandboxListRow[]> {
+  const groups = await listSandboxGroups();
+  const running = new Set<string>();
+  for (const snapshot of await getSessionDriver().listSessions(getInstallSlug())) {
+    if (snapshot.phase === 'running') running.add(snapshot.handle.key.agentGroupId);
+  }
+  return Promise.all(
+    groups.map(async (g): Promise<SandboxListRow> => {
+      const sessions = await findAttachableSessions(g.id);
+      const { container_status, last_active } = newestActivity(sessions);
+      return {
+        sandbox: g.folder,
+        id: g.id,
+        status: running.has(g.id) ? 'running' : 'cold',
+        sessions: sessions.length,
+        container_status,
+        last_active,
+        created_at: g.created_at,
+      };
+    }),
+  );
+}
+
+/**
+ * Wrap an exec the attach path routes into the container so it stamps the
+ * attach-activity file on the way in; the runner reads the stamp's mtime as
+ * liveness activity (the reaper case closed at the one choke point every
+ * attach-routed exec passes through, so any future sandbox verb inherits the
+ * evidence for free). The stamp is best-effort by construction: a failed
+ * mkdir/write still execs the client — evidence is never worth the attach.
+ * Stamped content is a UTC second for debuggability; only the mtime is read.
+ */
+function withAttachActivityStamp(command: string[]): string[] {
+  // Runtime readiness can precede the runner's terminal. Wait for the actual
+  // tmux session on the same path every attachment takes.
+  const wait =
+    `n=0; until tmux -S ${TMUX_SOCKET_PATH} has-session -t ${TMUX_SESSION_NAME} 2>/dev/null; do ` +
+    'n=$((n+1)); if [ "$n" -ge 90 ]; then echo "code mode: terminal did not become ready within 90s; check the Host logs" >&2; exit 1; fi; sleep 1; done; ';
+  return [
+    'sh',
+    '-c',
+    `{ mkdir -p /tmp/code-runner && date -u +%Y-%m-%dT%H:%M:%SZ > ${ATTACH_ACTIVITY_PATH}; } 2>/dev/null; ${wait}exec "$@"`,
+    'attach',
+    ...command,
+  ];
+}
+
+/**
+ * The tmux client command an attachment runs inside the session. The
+ * client's own environment is the exec transport's, not the operator's: an
+ * exec transport may forward neither TERM nor the locale, so a bare
+ * `tmux attach` announces TERM=xterm (no 256-color/truecolor output) and
+ * runs non-UTF-8 (filled blocks and box drawing render as junk).
+ * `env TERM=…` restores the color floor and `-u` forces UTF-8 regardless
+ * of what the transport dropped. Both were measured on a prototype.
+ */
+export function attachClientCommand(): string[] {
+  return withAttachActivityStamp([
+    'env',
+    'TERM=xterm-256color',
+    'tmux',
+    '-u',
+    '-S',
+    TMUX_SOCKET_PATH,
+    'attach-session',
+    '-t',
+    TMUX_SESSION_NAME,
+  ]);
+}
+
+/**
+ * Resolve the live runtime handle for the first of `sessions` that has one.
+ * Resolution goes through the session driver's own discovery (the adoption
+ * contract): the host's in-memory container name is a lineage label, not the
+ * runtime name — under some drivers the two never match, and even under
+ * docker the real name is key-derived (`ncl-<session>`), not the label.
+ */
+export async function findLiveSessionHandle(sessions: Session[]): Promise<SessionHandle | undefined> {
+  if (sessions.length === 0) return undefined;
+  const snapshots = await getSessionDriver().listSessions(getInstallSlug());
+  const bySession = new Map(snapshots.map((s) => [s.handle.key.sessionId, s]));
+  for (const session of sessions) {
+    const snapshot = bySession.get(session.id);
+    if (!snapshot) continue;
+    // The snapshot's phase is the listing's own truth (corpse-honest): no
+    // per-handle status() round trip, and a self-exited runtime never
+    // resolves as attachable.
+    if (snapshot.phase === 'running') return snapshot.handle;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve an attach for `group`: gate on code mode, find (or lazily wake)
+ * a live session runtime, and return its handle with the command to run in
+ * it. Group lookup stays with the callers — verbs differ in how they name a
+ * group (id-or-folder) and in their not-found texts.
+ */
+export async function attachSandbox(group: AgentGroup, opts?: { wakeWaitMs?: number }): Promise<AttachTarget> {
+  const cfg = await getContainerConfig(group.id);
+  if (cfg?.code_mode !== 1) {
+    throw new Error(
+      `${group.name} is not a code-mode group — flip it with: ` +
+        `ncl groups config update --id ${group.id} --code-mode true (takes effect on respawn)`,
+    );
+  }
+  // A group can hold several active sessions (one per wired messaging
+  // group/thread, plus system task and sandbox sessions — a schedule-driven
+  // box may hold ONLY those); attach to the one that actually has a live
+  // runtime, not merely the newest row.
+  const sessions = await findAttachableSessions(group.id);
+  let live = await findLiveSessionHandle(sessions);
+  if (!live && sessions.length > 0) {
+    // A cold sandbox wakes on attach: wake the preferred session
+    // (channel-wired first, else the newest task session, else the sandbox
+    // session) instead of refusing, then wait for the runtime to come up (a
+    // container needs a few seconds; the attach client separately retries
+    // the socket).
+    if (await wakeContainer(sessions[0])) {
+      const deadline = Date.now() + (opts?.wakeWaitMs ?? ATTACH_WAKE_WAIT_MS);
+      live = await findLiveSessionHandle(sessions);
+      while (!live && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        live = await findLiveSessionHandle(sessions);
+      }
+    }
+  }
+  if (!live) {
+    throw new Error(
+      sessions.length === 0
+        ? `${group.name} has no session yet — message the agent once to create one, then re-attach`
+        : `${group.name}'s session container did not come up — check the host logs, then re-attach`,
+    );
+  }
+  return { handle: live, command: attachClientCommand(), group: group.name, containerName: live.name };
+}
+
+/** The verbs as one object, for a caller that wants to hold them (or a test that swaps them). */
+export interface SandboxVerbs {
+  list(): Promise<SandboxListRow[]>;
+  create(input?: CreateSandboxInput): Promise<CreatedSandbox>;
+  attach(group: AgentGroup, opts?: { wakeWaitMs?: number }): Promise<AttachTarget>;
+  find(nameOrId: string): Promise<AgentGroup | undefined>;
+}
+
+export function sandboxVerbs(): SandboxVerbs {
+  return { list: listSandboxes, create: createSandbox, attach: attachSandbox, find: findSandboxGroup };
+}

--- a/src/code-mode/sandboxes.ts
+++ b/src/code-mode/sandboxes.ts
@@ -32,6 +32,7 @@ import { groupFolderExistsOnDisk, isValidGroupFolder } from '../group-folder.js'
 import { initGroupFilesystem } from '../group-init.js';
 import { getInstallSlug } from '../install-slug.js';
 import { log } from '../log.js';
+import { codeModeBundleWarnings } from './compose.js';
 import { fireSandboxCreated } from './hooks.js';
 import { resolveSandboxSession } from '../session-manager.js';
 import { isValidTimezone } from '../timezone.js';
@@ -87,6 +88,8 @@ export interface CreateSandboxInput {
 export interface CreatedSandbox {
   group: AgentGroup;
   session: Session;
+  /** What the operator should hear before the terminal is handed over (a degraded install tree). */
+  warnings: string[];
 }
 
 export interface SandboxListRow {
@@ -223,10 +226,14 @@ export async function createSandbox(input: CreateSandboxInput = {}): Promise<Cre
     throw error;
   }
   log.info('Sandbox created', { sandbox: folder, agentGroupId: id, sessionId: session.id });
+  // The instruction surface is stamped fail-open at spawn; a checkout
+  // without it must be loud HERE, where the operator is looking.
+  const warnings = codeModeBundleWarnings();
+  for (const warning of warnings) log.warn(warning, { sandbox: folder });
   // Modules learn of the new sandbox here — after the rows exist and before
   // the first wake. A listener that throws is logged, never the verb's problem.
   await fireSandboxCreated(group);
-  return { group, session };
+  return { group, session, warnings };
 }
 
 function newestActivity(sessions: Session[]): { container_status: string | null; last_active: string | null } {

--- a/src/code-mode/surface/binding.test.ts
+++ b/src/code-mode/surface/binding.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Binding a sandbox to its surface: one provider open per group, the
+ * binding row, the messaging group in the PROVIDER'S spelling of the surface
+ * + the wiring in session mode 'sandbox', adoption of a row the adapter
+ * created first (its pending registration retired, no duplicate), the
+ * coding session's default outbound route, what a repeat and a re-bind
+ * after an archive do, a provider that has nothing to give, and the
+ * onSandboxBound hook.
+ */
+import fs from 'node:fs';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../cli/resources/destinations.js', () => ({
+  projectDestinationsToSessions: vi.fn(async () => {}),
+}));
+vi.mock('../../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../config.js')>();
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-session-surface-binding/data' };
+});
+
+import { projectDestinationsToSessions } from '../../cli/resources/destinations.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { getDb } from '../../db/connection.js';
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import {
+  createMessagingGroup,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+  getMessagingGroupsByChannel,
+} from '../../db/messaging-groups.js';
+import { SANDBOX_SYSTEM_THREAD_ID } from '../../db/sessions.js';
+import { inboundDbPath } from '../../mailbox/sqlite/paths.js';
+import { resolveSandboxSession, resolveSession } from '../../session-manager.js';
+import { SANDBOX_HOOKS_SEAM, onSandboxBound, resetSandboxHooksForTesting, type BoundSurface } from '../hooks.js';
+import { bindSessionSurface } from './binding.js';
+import { getSessionSurfaceByGroup, updateSessionSurface } from './db.js';
+import type { SessionSurfaceProvider, SurfaceHandle, SurfaceSpelling } from './types.js';
+import '../index.js';
+
+const TEST_ROOT = '/tmp/nanoclaw-test-session-surface-binding';
+const GROUP = { id: 'ag-bind-1', name: 'box', folder: 'box' };
+
+/** The adapter's spelling, as a chat adapter encodes a conversation: `<adapter>:<conversation>`. */
+const spell = async (surfaceId: string): Promise<SurfaceSpelling> => ({
+  platformId: `chat:${surfaceId}`,
+  instance: 'chat',
+});
+
+type OpenCall = { sandbox: string; title?: string; terminalAddress?: string };
+
+function fakeProvider(over: Partial<Pick<SessionSurfaceProvider, 'open' | 'spell'>> = {}) {
+  const opens: OpenCall[] = [];
+  let n = 0;
+  const provider = {
+    spell,
+    open: vi.fn(async (sandbox: { id: string }, options: { title?: string; terminalAddress?: string }) => {
+      opens.push({ sandbox: sandbox.id, ...options });
+      n += 1;
+      return { surfaceId: `S${n}`, sessionId: sandbox.id } as SurfaceHandle;
+    }),
+    ...over,
+  };
+  return { provider, opens };
+}
+
+function bind(extra: Partial<Parameters<typeof bindSessionSurface>[0]> = {}, over = {}) {
+  const { provider, opens } = fakeProvider(over);
+  return {
+    opens,
+    provider,
+    run: () => bindSessionSurface({ group: GROUP, channelType: 'chat', provider, ...extra }),
+  };
+}
+
+/** The default outbound route the host wrote into a session's mailbox (the row the runner's `outbox send` reads). */
+function routingOf(sessionId: string): unknown {
+  const db = new Database(inboundDbPath(GROUP.id, sessionId), { readonly: true });
+  try {
+    return db.prepare('SELECT channel_type, platform_id, thread_id FROM session_routing').get();
+  } finally {
+    db.close();
+  }
+}
+
+async function sandboxRouting(): Promise<unknown> {
+  const { session } = await resolveSandboxSession(GROUP.id);
+  return routingOf(session.id);
+}
+
+beforeEach(async () => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(TEST_ROOT, { recursive: true });
+  await runMigrations(await initTestDb());
+  await createAgentGroup({ ...GROUP, agent_provider: null, created_at: new Date().toISOString() });
+  vi.mocked(projectDestinationsToSessions).mockClear();
+});
+
+afterEach(async () => {
+  resetSandboxHooksForTesting();
+  await closeDb();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('bindSessionSurface', () => {
+  it("opens the surface once, stores the row, and wires the group under the provider's spelling", async () => {
+    const { run, opens } = bind();
+    const bound = await run();
+    expect(bound?.created).toBe(true);
+    expect(opens).toEqual([{ sandbox: 'ag-bind-1', title: 'box' }]);
+
+    const row = await getSessionSurfaceByGroup(GROUP.id);
+    expect(row).toMatchObject({
+      provider: 'chat',
+      surface_id: 'S1',
+      session_id: 'ag-bind-1',
+      title: 'box',
+      last_status: null,
+      stopped_at: null,
+      last_turn_seq: 0,
+      archived_at: null,
+    });
+
+    // Exactly one messaging group, in the adapter's form — never a bare id.
+    const rows = await getMessagingGroupsByChannel('chat');
+    expect(rows.map((r) => r.platform_id)).toEqual(['chat:S1']);
+    const mg = rows[0];
+    expect(mg).toMatchObject({ instance: 'chat', is_group: 1, unknown_sender_policy: 'public', name: 'box' });
+    expect(row!.messaging_group_id).toBe(mg.id);
+    const wirings = await getMessagingGroupAgents(mg.id);
+    expect(wirings).toHaveLength(1);
+    expect(wirings[0]).toMatchObject({
+      agent_group_id: GROUP.id,
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      session_mode: 'sandbox',
+      threads: 0,
+    });
+    expect(projectDestinationsToSessions).toHaveBeenCalledWith(GROUP.id);
+  });
+
+  it('uses the instance the adapter runs under, not the platform name', async () => {
+    const { run } = bind({}, { spell: async (id: string) => ({ platformId: `chat:${id}`, instance: 'chat-second' }) });
+    await run();
+    expect(await getMessagingGroupByPlatform('chat', 'chat:S1', 'chat-second')).toBeTruthy();
+    expect(await getMessagingGroupByPlatform('chat', 'chat:S1', 'chat')).toBeUndefined();
+  });
+
+  it('is idempotent: a second bind returns the same row without a second open or wiring', async () => {
+    const { run, opens } = bind();
+    const first = await run();
+    const second = await run();
+    expect(second?.created).toBe(false);
+    expect(second?.row.surface_id).toBe(first?.row.surface_id);
+    expect(opens).toHaveLength(1);
+    expect(await getMessagingGroupsByChannel('chat')).toHaveLength(1);
+    expect(await getMessagingGroupAgents(first!.row.messaging_group_id!)).toHaveLength(1);
+    expect(projectDestinationsToSessions).toHaveBeenCalledTimes(1);
+  });
+
+  it("a message on the wired surface resolves to the group's coding session, not a chat session", async () => {
+    const { run } = bind();
+    const bound = await run();
+    const { session } = await resolveSession(GROUP.id, bound!.row.messaging_group_id, null, 'sandbox');
+    expect(session.thread_id).toBe(SANDBOX_SYSTEM_THREAD_ID);
+    expect(session.messaging_group_id).toBeNull();
+    const again = await resolveSession(GROUP.id, bound!.row.messaging_group_id, 'some-thread', 'sandbox');
+    expect(again.session.id).toBe(session.id);
+  });
+
+  it('after an archive a new bind opens a fresh surface', async () => {
+    const { run, opens } = bind();
+    await run();
+    await updateSessionSurface(GROUP.id, { archived_at: '2026-09-11T12:00:00.000Z' });
+
+    const rebound = await run();
+    expect(rebound?.created).toBe(true);
+    expect(opens).toHaveLength(2);
+    const row = await getSessionSurfaceByGroup(GROUP.id);
+    expect(row).toMatchObject({ surface_id: 'S2', archived_at: null });
+    const mg2 = await getMessagingGroupByPlatform('chat', 'chat:S2', 'chat');
+    expect(await getMessagingGroupAgents(mg2!.id)).toHaveLength(1);
+  });
+
+  it('a title override and a terminal address ride the open; the sandbox name is the default title', async () => {
+    const { run, opens } = bind({ title: 'Status page', terminalAddress: 'box.example.test' });
+    await run();
+    expect(opens[0]).toEqual({ sandbox: 'ag-bind-1', title: 'Status page', terminalAddress: 'box.example.test' });
+    expect((await getSessionSurfaceByGroup(GROUP.id))!.title).toBe('Status page');
+  });
+
+  it('a provider with nothing to give (null, or a throw) leaves a plain sandbox: no row, no wiring', async () => {
+    const { run } = bind({}, { open: async () => null });
+    expect(await run()).toBeNull();
+    const { run: failing } = bind(
+      {},
+      {
+        open: async () => {
+          throw new Error('platform down');
+        },
+      },
+    );
+    expect(await failing()).toBeNull();
+    expect(await getSessionSurfaceByGroup(GROUP.id)).toBeUndefined();
+    expect(await getMessagingGroupsByChannel('chat')).toHaveLength(0);
+  });
+
+  it('a sandbox already bound on another platform refuses a second surface — the first binding stays', async () => {
+    const { run } = bind();
+    const first = await run();
+    const other = fakeProvider();
+    const second = await bindSessionSurface({ group: GROUP, channelType: 'other-chat', provider: other.provider });
+    expect(second).toBeNull();
+    expect(other.provider.open).not.toHaveBeenCalled();
+    expect(await getSessionSurfaceByGroup(GROUP.id)).toMatchObject({
+      provider: 'chat',
+      surface_id: first!.row.surface_id,
+    });
+    expect(await getMessagingGroupsByChannel('other-chat')).toHaveLength(0);
+  });
+
+  it('fires onSandboxBound once the row and the wiring exist', async () => {
+    const seen: BoundSurface[] = [];
+    onSandboxBound('t', (_group, surface) => void seen.push(surface), { seam: SANDBOX_HOOKS_SEAM });
+    const { run } = bind();
+    const bound = await run();
+    expect(seen).toEqual([
+      { channelType: 'chat', surfaceId: 'S1', sessionId: 'ag-bind-1', messagingGroupId: bound!.row.messaging_group_id },
+    ]);
+    await run();
+    expect(seen).toHaveLength(1); // a repeat bind is not a new binding
+  });
+});
+
+describe('bindSessionSurface — adopting the adapter-created conversation', () => {
+  it('a row the adapter already wrote for the surface is wired, not duplicated, and its registration card retired', async () => {
+    // The bot was invited and spoke before the host bound: the router
+    // auto-created the row (name null, request_approval) and raised a card.
+    await createMessagingGroup({
+      id: 'mg-adapter',
+      channel_type: 'chat',
+      platform_id: 'chat:S1',
+      instance: 'chat',
+      name: null,
+      is_group: 1,
+      unknown_sender_policy: 'request_approval',
+      created_at: new Date().toISOString(),
+    });
+    await getDb().run(
+      `INSERT INTO pending_channel_approvals (messaging_group_id, agent_group_id, original_message, approver_user_id, created_at, title, question, options_json)
+       VALUES ('mg-adapter', 'ag-bind-1', '{}', 'chat:U1', '2026-09-12T00:00:00.000Z', 'New channel', 'Connect?', '[]')`,
+    );
+
+    const { run } = bind();
+    const bound = await run();
+    expect(bound?.row.messaging_group_id).toBe('mg-adapter');
+    expect(await getMessagingGroupsByChannel('chat')).toHaveLength(1);
+    const wirings = await getMessagingGroupAgents('mg-adapter');
+    expect(wirings).toHaveLength(1);
+    expect(wirings[0]).toMatchObject({ agent_group_id: GROUP.id, session_mode: 'sandbox' });
+    const pending = await getDb().get(
+      'SELECT 1 AS x FROM pending_channel_approvals WHERE messaging_group_id = ?',
+      'mg-adapter',
+    );
+    expect(pending).toBeUndefined();
+  });
+
+  it('re-binding once the row exists adopts it again: still one row, one wiring', async () => {
+    const { run } = bind();
+    const first = await run();
+    const second = await run();
+    expect(second?.row.messaging_group_id).toBe(first?.row.messaging_group_id);
+    expect(await getMessagingGroupsByChannel('chat')).toHaveLength(1);
+    expect(await getMessagingGroupAgents(first!.row.messaging_group_id!)).toHaveLength(1);
+  });
+});
+
+describe('bindSessionSurface — the default outbound route', () => {
+  const SURFACE_ROUTE = { channel_type: 'chat', platform_id: 'chat:S1', thread_id: null };
+
+  it("points the coding session's routing at the surface, thread null (top level)", async () => {
+    // As `sandboxes new` does: the coding session exists before the bind.
+    await resolveSandboxSession(GROUP.id);
+    const { run } = bind();
+    await run();
+    expect(await sandboxRouting()).toEqual(SURFACE_ROUTE);
+  });
+
+  it('an existing sandbox session gets the route too, and a repeat bind keeps it', async () => {
+    const { session } = await resolveSandboxSession(GROUP.id);
+    expect(routingOf(session.id)).toBeUndefined(); // no chat of its own yet
+    const { run } = bind();
+    await run();
+    expect(routingOf(session.id)).toEqual(SURFACE_ROUTE);
+    await run();
+    expect(await sandboxRouting()).toEqual(SURFACE_ROUTE);
+  });
+});

--- a/src/code-mode/surface/binding.ts
+++ b/src/code-mode/surface/binding.ts
@@ -1,0 +1,248 @@
+/**
+ * Bind a sandbox to a chat surface.
+ *
+ * Three idempotent steps, each safe to repeat after a crash between them:
+ *   1. open (or find) the surface through the platform's provider
+ *      (types.ts `open`; the provider keys idempotency on the sandbox's
+ *      group id, which is the session id it is given);
+ *   2. remember `{ agent group, provider, surface, session }` in
+ *      code_session_surfaces (db.ts) so the runtime finds it after a
+ *      restart;
+ *   3. wire the group to the surface through the ordinary group ↔ chat
+ *      mechanism — a messaging_groups row for the surface and a
+ *      messaging_group_agents row in session mode 'sandbox' (session-manager
+ *      resolveSession routes it into the coding session), engaging on every
+ *      message with threads off — then point the coding session's default
+ *      outbound route at it (writeSessionRouting), so a reply AND a
+ *      standalone `ncl outbox send` both land on the surface. From there
+ *      inbound delivery and outbox replies are the existing paths; nothing
+ *      here carries a message.
+ *
+ * The messaging_groups row must be the one the adapter's inbound path
+ * resolves, so its platform id is the PROVIDER'S spelling of the surface
+ * (`spell`, today `ChannelAdapter.conversationPlatformId`) on the adapter's
+ * instance, never a bare id. When the adapter got there first — the bot was
+ * invited and a message arrived before this ran, so the router auto-created
+ * the row and may have raised a registration card — that row is ADOPTED:
+ * wired to the sandbox, its pending registration retired, no second row.
+ *
+ * Only the binding row and the wiring are ours to remove (the archive is
+ * the explicit wrap-up); a deleted group takes the row with it (FK cascade).
+ */
+import { randomUUID } from 'node:crypto';
+
+import { projectDestinationsToSessions } from '../../cli/resources/destinations.js';
+import { getDb, hasTable } from '../../db/connection.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+} from '../../db/messaging-groups.js';
+import { findSandboxSessions } from '../../db/sessions.js';
+import { log } from '../../log.js';
+import { writeSessionRouting } from '../../session-manager.js';
+import type { MessagingGroup } from '../../types.js';
+import { fireSandboxBound, type SandboxGroup } from '../hooks.js';
+import {
+  deleteSessionSurface,
+  getSessionSurfaceByGroup,
+  insertSessionSurface,
+  updateSessionSurface,
+  type SessionSurfaceRow,
+} from './db.js';
+import type { SessionSurfaceProvider, SurfaceSpelling } from './types.js';
+
+export interface BindSessionSurfaceInput {
+  group: SandboxGroup;
+  /** The chat platform (the channel type the provider registered under). */
+  channelType: string;
+  provider: Pick<SessionSurfaceProvider, 'open' | 'spell'>;
+  /** Surface title; defaults to the sandbox name. */
+  title?: string;
+  /** The address a terminal reaches this sandbox at, when the host has one. Never a gate. */
+  terminalAddress?: string;
+}
+
+export interface BoundSessionSurface {
+  row: SessionSurfaceRow;
+  /** True when this call opened the surface (false: found an existing binding). */
+  created: boolean;
+}
+
+/**
+ * A registration card the router raised for an adapter-created row is moot
+ * once the row is wired to its sandbox: retire the pending row so the card's
+ * in-flight dedupe clears and a later click finds nothing to approve.
+ */
+async function retirePendingRegistration(messagingGroupId: string): Promise<boolean> {
+  const db = getDb();
+  if (!(await hasTable(db, 'pending_channel_approvals'))) return false;
+  const result = await db.run('DELETE FROM pending_channel_approvals WHERE messaging_group_id = ?', messagingGroupId);
+  return result.changes > 0;
+}
+
+/**
+ * Ensure the group is wired to the surface: messaging group (adopted when
+ * the adapter created it first, else created in the provider's spelling) +
+ * wiring row, both create-if-absent; then the coding session's default
+ * route. Returns the messaging group the surface maps to.
+ */
+export async function ensureSessionSurfaceWiring(
+  agentGroupId: string,
+  channelType: string,
+  title: string,
+  spelling: SurfaceSpelling,
+): Promise<MessagingGroup> {
+  const at = new Date().toISOString();
+  let mg = await getMessagingGroupByPlatform(channelType, spelling.platformId, spelling.instance);
+  let adopted = false;
+  if (!mg) {
+    mg = {
+      id: `mg-${randomUUID()}`,
+      channel_type: channelType,
+      platform_id: spelling.platformId,
+      instance: spelling.instance,
+      name: title,
+      is_group: 1,
+      // Everyone on the surface was invited there for this session; the
+      // provider admits members, not the sender gate.
+      unknown_sender_policy: 'public',
+      created_at: at,
+    };
+    await createMessagingGroup(mg);
+  } else {
+    adopted = true;
+  }
+  const wiring = await getMessagingGroupAgentByPair(mg.id, agentGroupId);
+  if (!wiring) {
+    await createMessagingGroupAgent({
+      id: randomUUID(),
+      messaging_group_id: mg.id,
+      agent_group_id: agentGroupId,
+      // Every message is for the session, no mention needed; one session,
+      // never one per thread.
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'sandbox',
+      priority: 0,
+      threads: 0,
+      created_at: at,
+    });
+    // A container already running for the group keeps serving its stale
+    // destination projection until its next spawn — refresh it now so the
+    // first reply from the session is not dropped as an unknown destination.
+    await projectDestinationsToSessions(agentGroupId);
+    if (adopted) {
+      const retired = await retirePendingRegistration(mg.id);
+      log.info('Session surface adopted the adapter-created conversation', {
+        agentGroupId,
+        channelType,
+        messagingGroupId: mg.id,
+        platformId: spelling.platformId,
+        registrationRetired: retired,
+      });
+    }
+  }
+  return mg;
+}
+
+/**
+ * Point the coding session's default outbound route at its surface: the
+ * resolver index.ts registers answers writeSessionRouting from the binding
+ * row, so this runs once the row names its messaging group. A running
+ * container picks the new route up on its next send.
+ */
+export async function refreshSandboxRouting(agentGroupId: string): Promise<void> {
+  for (const session of await findSandboxSessions(agentGroupId)) {
+    await writeSessionRouting(agentGroupId, session.id);
+  }
+}
+
+/**
+ * Open-or-find the surface for a sandbox and wire the group to it. Null
+ * when the provider has no surface to give (its `open` answered null or
+ * threw): the sandbox goes on without one, and the reason is a log line.
+ */
+export async function bindSessionSurface(input: BindSessionSurfaceInput): Promise<BoundSessionSurface | null> {
+  const { group, channelType, provider } = input;
+  const title = input.title ?? group.folder;
+
+  const existing = await getSessionSurfaceByGroup(group.id);
+  if (existing && !existing.archived_at && existing.provider !== channelType) {
+    // One surface per coding session: the table holds one row per group, so
+    // a second platform cannot bind without repointing the first's binding.
+    // The first stays; this platform is told no.
+    log.info('Session surface not opened — the sandbox already has one on another platform', {
+      agentGroupId: group.id,
+      channelType,
+      bound: existing.provider,
+    });
+    return null;
+  }
+  if (existing && !existing.archived_at) {
+    const mg = await ensureSessionSurfaceWiring(
+      group.id,
+      existing.provider,
+      existing.title,
+      await provider.spell(existing.surface_id),
+    );
+    if (existing.messaging_group_id !== mg.id) {
+      await updateSessionSurface(group.id, { messaging_group_id: mg.id });
+      existing.messaging_group_id = mg.id;
+    }
+    await refreshSandboxRouting(group.id);
+    return { row: existing, created: false };
+  }
+
+  let handle;
+  try {
+    handle = await provider.open(group, {
+      title,
+      ...(input.terminalAddress ? { terminalAddress: input.terminalAddress } : {}),
+    });
+  } catch (err) {
+    log.warn('Session surface not opened — sandbox continues without one', {
+      agentGroupId: group.id,
+      channelType,
+      err,
+    });
+    return null;
+  }
+  if (!handle) {
+    log.info('Session surface not available — sandbox continues without one', { agentGroupId: group.id, channelType });
+    return null;
+  }
+
+  // The binding row before the wiring: a crash between the two leaves a row
+  // the next bind completes, never a surface nothing remembers.
+  if (existing) await deleteSessionSurface(group.id);
+  const row = await insertSessionSurface({
+    agent_group_id: group.id,
+    provider: channelType,
+    surface_id: handle.surfaceId,
+    session_id: handle.sessionId,
+    messaging_group_id: null,
+    title,
+    last_status: null,
+    last_status_at: null,
+    stopped_at: null,
+    last_turn_seq: 0,
+    events_cursor: null,
+    archived_at: null,
+  });
+  const mg = await ensureSessionSurfaceWiring(group.id, channelType, title, await provider.spell(handle.surfaceId));
+  await updateSessionSurface(group.id, { messaging_group_id: mg.id });
+  row.messaging_group_id = mg.id;
+  await refreshSandboxRouting(group.id);
+  log.info('Session surface bound', { agentGroupId: group.id, channelType, surfaceId: handle.surfaceId });
+  await fireSandboxBound(group, {
+    channelType,
+    surfaceId: handle.surfaceId,
+    sessionId: handle.sessionId,
+    messagingGroupId: mg.id,
+  });
+  return { row, created: true };
+}

--- a/src/code-mode/surface/contract.ts
+++ b/src/code-mode/surface/contract.ts
@@ -1,0 +1,20 @@
+/**
+ * Contract-test helper for the session-surface seam: a module's test
+ * imports the real barrels and asserts its provider is registered, with the
+ * refusal's reason when it is not.
+ */
+import { seamRefusals } from '../../seams.js';
+import { getSessionSurface } from './registry.js';
+
+export { assertSandboxHook, assertSandboxVerb } from '../contract.js';
+
+export function assertSurfaceRegistered(channelType: string): void {
+  if (getSessionSurface(channelType)) return;
+  const refused = seamRefusals().find((r) => r.registry === 'session-surface' && r.registrant === channelType);
+  throw new Error(
+    `no session surface is registered for '${channelType}'` +
+      (refused
+        ? ` (refused: seam ${refused.wanted} expected, ${refused.got === undefined ? 'none' : refused.got} given)`
+        : ''),
+  );
+}

--- a/src/code-mode/surface/db.ts
+++ b/src/code-mode/surface/db.ts
@@ -1,0 +1,138 @@
+/**
+ * The binding table — one row per coding session that has a chat surface.
+ *
+ * `agent_group_id` is the primary key because a sandbox IS a code-mode agent
+ * group and holds one coding session (`system:sandbox`, session-manager.ts
+ * resolveSandboxSession). `provider` is the chat platform (the channel type
+ * the surface provider registered under), `surface_id` the provider's id
+ * for the surface, `messaging_group_id` the messaging_groups row the surface
+ * is wired through (the ordinary group ↔ chat mechanism — nothing here
+ * delivers a message itself).
+ *
+ * Mirror bookkeeping lives beside the ids so a host restart resumes where it
+ * left off: the last status sent, the last turn the diff view rendered, the
+ * stop mark, and the event cursor of the long-poll.
+ */
+import { getDb } from '../../db/connection.js';
+import type { DbDriver } from '../../db/driver.js';
+import { registerMigration } from '../../db/migrations/index.js';
+
+export const SESSION_SURFACES_TABLE = 'code_session_surfaces';
+
+registerMigration({
+  version: 3,
+  name: 'module:code-mode:session-surfaces',
+  async up(db: DbDriver) {
+    await db.exec(`CREATE TABLE IF NOT EXISTS ${SESSION_SURFACES_TABLE} (
+      agent_group_id     TEXT PRIMARY KEY REFERENCES agent_groups(id) ON DELETE CASCADE,
+      provider           TEXT NOT NULL,
+      surface_id         TEXT NOT NULL,
+      session_id         TEXT NOT NULL,
+      messaging_group_id TEXT,
+      title              TEXT NOT NULL,
+      last_status        TEXT,
+      last_status_at     TEXT,
+      stopped_at         TEXT,
+      last_turn_seq      BIGINT NOT NULL DEFAULT 0,
+      events_cursor      TEXT,
+      archived_at        TEXT,
+      created_at         TEXT NOT NULL,
+      updated_at         TEXT NOT NULL,
+      UNIQUE (provider, surface_id)
+    )`);
+  },
+});
+
+export interface SessionSurfaceRow {
+  agent_group_id: string;
+  provider: string;
+  surface_id: string;
+  session_id: string;
+  messaging_group_id: string | null;
+  title: string;
+  last_status: string | null;
+  last_status_at: string | null;
+  stopped_at: string | null;
+  last_turn_seq: number;
+  events_cursor: string | null;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type SessionSurfacePatch = Partial<
+  Pick<
+    SessionSurfaceRow,
+    | 'messaging_group_id'
+    | 'title'
+    | 'last_status'
+    | 'last_status_at'
+    | 'stopped_at'
+    | 'last_turn_seq'
+    | 'events_cursor'
+    | 'archived_at'
+  >
+>;
+
+export async function insertSessionSurface(
+  row: Omit<SessionSurfaceRow, 'created_at' | 'updated_at'> & Partial<Pick<SessionSurfaceRow, 'created_at'>>,
+): Promise<SessionSurfaceRow> {
+  const at = new Date().toISOString();
+  const full: SessionSurfaceRow = { ...row, created_at: row.created_at ?? at, updated_at: at };
+  await getDb().run(
+    `INSERT INTO ${SESSION_SURFACES_TABLE} (
+       agent_group_id, provider, surface_id, session_id, messaging_group_id, title,
+       last_status, last_status_at, stopped_at, last_turn_seq, events_cursor, archived_at, created_at, updated_at
+     ) VALUES (
+       @agent_group_id, @provider, @surface_id, @session_id, @messaging_group_id, @title,
+       @last_status, @last_status_at, @stopped_at, @last_turn_seq, @events_cursor, @archived_at, @created_at, @updated_at
+     )`,
+    full,
+  );
+  return full;
+}
+
+export async function getSessionSurfaceByGroup(agentGroupId: string): Promise<SessionSurfaceRow | undefined> {
+  return getDb().get<SessionSurfaceRow>(
+    `SELECT * FROM ${SESSION_SURFACES_TABLE} WHERE agent_group_id = ?`,
+    agentGroupId,
+  );
+}
+
+export async function getSessionSurfaceBySurface(
+  provider: string,
+  surfaceId: string,
+): Promise<SessionSurfaceRow | undefined> {
+  return getDb().get<SessionSurfaceRow>(
+    `SELECT * FROM ${SESSION_SURFACES_TABLE} WHERE provider = ? AND surface_id = ?`,
+    provider,
+    surfaceId,
+  );
+}
+
+/** Every binding that still has a live surface (archived rows are history). */
+export async function listOpenSessionSurfaces(): Promise<SessionSurfaceRow[]> {
+  return getDb().all<SessionSurfaceRow>(
+    `SELECT * FROM ${SESSION_SURFACES_TABLE} WHERE archived_at IS NULL ORDER BY created_at`,
+  );
+}
+
+export async function updateSessionSurface(agentGroupId: string, patch: SessionSurfacePatch): Promise<void> {
+  const fields: string[] = [];
+  const values: Record<string, unknown> = { agent_group_id: agentGroupId, updated_at: new Date().toISOString() };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) continue;
+    fields.push(`${key} = @${key}`);
+    values[key] = value;
+  }
+  if (fields.length === 0) return;
+  fields.push('updated_at = @updated_at');
+  await getDb().run(
+    `UPDATE ${SESSION_SURFACES_TABLE} SET ${fields.join(', ')} WHERE agent_group_id = @agent_group_id`,
+    values,
+  );
+}
+
+export async function deleteSessionSurface(agentGroupId: string): Promise<void> {
+  await getDb().run(`DELETE FROM ${SESSION_SURFACES_TABLE} WHERE agent_group_id = ?`, agentGroupId);
+}

--- a/src/code-mode/surface/diff-view.test.ts
+++ b/src/code-mode/surface/diff-view.test.ts
@@ -1,0 +1,300 @@
+/**
+ * The diff view, read through the session's exec: the argv git gets inside
+ * the container (no external diff, no textconv, no fsmonitor), a real
+ * temporary repository standing in for the session (tracked change and
+ * untracked file both appear, nothing written to the repo, a repository
+ * that names an external diff helper never runs it), the byte bounds and
+ * their markers, the not-a-repo answer, the no-HEAD fallback, and the cold
+ * session that yields no diff at all.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { SessionExecSpec, SessionHandle } from '../../drivers/types.js';
+import {
+  boundDiff,
+  collectDiff,
+  collectSandboxDiff,
+  DiffCollectError,
+  DIFF_OUTPUT_CUT_MARKER,
+  DIFF_TRUNCATED_TRAILER,
+  gitReadArgv,
+  parseStatus,
+  type DiffExec,
+} from './diff-view.js';
+
+let dir: string;
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: 't',
+  GIT_AUTHOR_EMAIL: 't@t',
+  GIT_COMMITTER_NAME: 't',
+  GIT_COMMITTER_EMAIL: 't@t',
+};
+
+function git(...args: string[]): string {
+  return execFileSync('git', ['-C', dir, ...args], {
+    stdio: ['ignore', 'pipe', 'ignore'],
+    env: { ...process.env, ...GIT_ENV, HOME: dir },
+  }).toString();
+}
+
+/** A handle whose exec runs the command on this machine: the temp repo stands in for the session's tree. */
+function localHandle(): SessionHandle {
+  return {
+    key: { installSlug: 'i', agentGroupId: 'ag-1', sessionId: 's-1' },
+    name: 'ncl-s-1',
+    start: async () => {},
+    status: async () => ({ phase: 'running' }),
+    stop: async () => {},
+    execSpec: (command) => ({ bin: command[0], argsTty: command.slice(1), argsPlain: command.slice(1) }),
+  };
+}
+
+/** A handle that only describes the exec, for the scripted `run` seam. */
+function describedHandle(): SessionHandle {
+  return {
+    ...localHandle(),
+    execSpec: (command) => ({
+      bin: 'fake-runtime',
+      argsTty: ['exec', '-it', 'ncl-s-1', ...command],
+      argsPlain: ['exec', '-i', 'ncl-s-1', ...command],
+    }),
+  };
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-diff-'));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('collectDiff through a real repository', () => {
+  it('shows tracked changes and untracked files as unified diffs, without touching the index', async () => {
+    git('init', '-q', '-b', 'work');
+    fs.writeFileSync(path.join(dir, 'app.ts'), 'const a = 1;\n');
+    git('add', 'app.ts');
+    git('commit', '-q', '-m', 'init');
+    fs.writeFileSync(path.join(dir, 'app.ts'), 'const a = 2;\n');
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', "it's new.ts"), 'export const fresh = true;\n');
+
+    const view = await collectDiff(localHandle(), { workspaceDir: dir });
+    expect(view).not.toBeNull();
+    expect(view!.truncated).toBe(false);
+    expect(view!.headBranch).toBe('work');
+    expect(view!.content).toContain('-const a = 1;');
+    expect(view!.content).toContain('+const a = 2;');
+    expect(view!.content).toContain('new file mode');
+    expect(view!.content).toContain('+export const fresh = true;');
+    // The view is a read: the new file stays untracked, the change stays unstaged.
+    expect(git('status', '--porcelain', '--untracked-files=all')).toBe(' M app.ts\n?? "src/it\'s new.ts"\n');
+  });
+
+  it("a repository's external diff driver and textconv are never run", async () => {
+    git('init', '-q');
+    fs.writeFileSync(path.join(dir, 'app.ts'), 'const a = 1;\n');
+    git('add', 'app.ts');
+    git('commit', '-q', '-m', 'init');
+    // The helper lives outside the tree so it is the config, not an untracked file, that names it.
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-diff-helper-'));
+    const marker = path.join(outside, 'helper-ran');
+    const helper = path.join(outside, 'helper.sh');
+    fs.writeFileSync(helper, `#!/bin/sh\nprintf ran > '${marker}'\nprintf 'helper output\\n'\n`, { mode: 0o755 });
+    git('config', 'diff.external', helper);
+    git('config', 'diff.ts.textconv', helper);
+    fs.writeFileSync(path.join(dir, '.gitattributes'), '*.ts diff=ts\n');
+    fs.writeFileSync(path.join(dir, 'app.ts'), 'const a = 2;\n');
+
+    const view = await collectDiff(localHandle(), { workspaceDir: dir });
+    expect(fs.existsSync(marker)).toBe(false);
+    expect(view!.content).not.toContain('helper output');
+    expect(view!.content).toContain('+const a = 2;');
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  it('a clean tree yields empty content; a repository with no commit yet still works', async () => {
+    git('init', '-q');
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'hello\n');
+    const view = await collectDiff(localHandle(), { workspaceDir: dir });
+    expect(view).not.toBeNull();
+    expect(view!.content).toContain('+hello');
+    git('add', 'a.txt');
+    git('commit', '-q', '-m', 'init');
+    expect((await collectDiff(localHandle(), { workspaceDir: dir }))!.content).toBe('');
+  });
+
+  it('not a repository → null', async () => {
+    expect(await collectDiff(localHandle(), { workspaceDir: dir })).toBeNull();
+  });
+});
+
+describe('the exec argv', () => {
+  function scripted(answers: (sub: string[]) => { stdout: string; code: number; truncated?: boolean }) {
+    const specs: SessionExecSpec[] = [];
+    const run: DiffExec = async (spec) => {
+      specs.push(spec);
+      // argsPlain = ['exec', '-i', 'ncl-s-1', 'git', '-C', ws, '-c', 'core.fsmonitor=', '--no-pager', ...sub]
+      const command = spec.argsPlain.slice(3);
+      return answers(command[0] === 'git' ? command.slice(6) : command);
+    };
+    return { specs, run };
+  }
+
+  it('every git read runs in the session as the plain exec, with the helpers switched off', async () => {
+    const { specs, run } = scripted((sub) => {
+      if (sub[0] === 'status') return { stdout: '# branch.head main\0? new.txt\0', code: 0 };
+      if (sub[0] === 'diff' && sub.includes('HEAD')) return { stdout: 'diff --git a/x b/x\n', code: 0 };
+      if (sub[0] === 'sh') return { stdout: 'diff --git a/new.txt b/new.txt\n', code: 0 };
+      return { stdout: '', code: 1 };
+    });
+    const view = await collectDiff(describedHandle(), { run });
+    expect(view).toEqual({
+      content: 'diff --git a/x b/x\ndiff --git a/new.txt b/new.txt\n',
+      truncated: false,
+      headBranch: 'main',
+    });
+    expect(
+      specs.every((s) => s.bin === 'fake-runtime' && s.argsPlain.slice(0, 3).join(' ') === 'exec -i ncl-s-1'),
+    ).toBe(true);
+    const commands = specs.map((s) => s.argsPlain.slice(3));
+    expect(commands[0]).toEqual(
+      gitReadArgv('/workspace/group', 'status', '--porcelain=v2', '--branch', '-z', '--untracked-files=all'),
+    );
+    expect(commands[0].slice(0, 6)).toEqual(['git', '-C', '/workspace/group', '-c', 'core.fsmonitor=', '--no-pager']);
+    expect(commands[1]).toEqual(
+      gitReadArgv('/workspace/group', 'diff', '--no-color', '--no-ext-diff', '--no-textconv', 'HEAD', '--'),
+    );
+    // The untracked loop: one sh, the paths as positional arguments, the same flags inside.
+    expect(commands[2].slice(0, 2)).toEqual(['sh', '-c']);
+    expect(commands[2][2]).toContain("'--no-ext-diff' '--no-textconv' '--no-index' '--' '/dev/null' \"$f\"");
+    expect(commands[2].slice(3)).toEqual(['sh', 'new.txt']);
+  });
+
+  it('not a repository (status exits 128) → null and nothing else is run; any other failure throws', async () => {
+    const { specs, run } = scripted(() => ({ stdout: 'fatal: not a git repository', code: 128 }));
+    expect(await collectDiff(describedHandle(), { run })).toBeNull();
+    expect(specs).toHaveLength(1);
+    const broken = scripted(() => ({ stdout: '', code: 1 }));
+    await expect(collectDiff(describedHandle(), { run: broken.run })).rejects.toBeInstanceOf(DiffCollectError);
+    const diffBroken = scripted((sub) =>
+      sub[0] === 'status' ? { stdout: '# branch.head main\0', code: 0 } : { stdout: '', code: 129 },
+    );
+    await expect(collectDiff(describedHandle(), { run: diffBroken.run })).rejects.toThrow('git diff exited 129');
+  });
+
+  it('falls back to the plain diff when HEAD does not exist, and a detached head names no branch', async () => {
+    const { run } = scripted((sub) => {
+      if (sub[0] === 'status') return { stdout: '# branch.oid (initial)\0# branch.head (detached)\0', code: 0 };
+      if (sub[0] === 'diff' && sub.includes('HEAD')) return { stdout: '', code: 128 };
+      if (sub[0] === 'diff') return { stdout: 'diff --git a/x b/x\n', code: 0 };
+      return { stdout: '', code: 1 };
+    });
+    expect(await collectDiff(describedHandle(), { run })).toEqual({
+      content: 'diff --git a/x b/x\n',
+      truncated: false,
+    });
+  });
+
+  it('honours maxBytes and the untracked-file cap', async () => {
+    const { specs, run } = scripted((sub) => {
+      if (sub[0] === 'status') return { stdout: '# branch.head main\0? a\0? b\0? c\0? d\0', code: 0 };
+      if (sub[0] === 'diff') return { stdout: '', code: 0 };
+      if (sub[0] === 'sh') {
+        const files = sub.slice(3);
+        return { stdout: files.map((f) => `diff --git a/${f} b/${f}\n${'+'.repeat(300)}\n`).join(''), code: 0 };
+      }
+      return { stdout: '', code: 1 };
+    });
+    const view = await collectDiff(describedHandle(), { run, maxBytes: 500, maxUntrackedFiles: 2 });
+    expect(view!.truncated).toBe(true);
+    expect(Buffer.byteLength(view!.content, 'utf8')).toBeLessThanOrEqual(500);
+    expect(view!.content.endsWith(DIFF_TRUNCATED_TRAILER)).toBe(true);
+    // Only the first two untracked files were even asked for.
+    expect(specs.at(-1)!.argsPlain.slice(-2)).toEqual(['a', 'b']);
+  });
+
+  it('an exec that hit its byte cap is marked cut, and the untracked read is skipped', async () => {
+    const { specs, run } = scripted((sub) => {
+      if (sub[0] === 'status') return { stdout: '# branch.head main\0? new.txt\0', code: 0 };
+      if (sub[0] === 'diff') return { stdout: 'diff --git a/x b/x\n+huge', code: 0, truncated: true };
+      return { stdout: '', code: 1 };
+    });
+    const view = await collectDiff(describedHandle(), { run });
+    expect(view!.truncated).toBe(true);
+    expect(view!.content).toBe('diff --git a/x b/x\n+huge' + DIFF_OUTPUT_CUT_MARKER);
+    expect(specs).toHaveLength(2);
+  });
+});
+
+describe('collectSandboxDiff', () => {
+  it('a cold session yields no diff: the host does not read the tree itself', async () => {
+    const run: DiffExec = async () => {
+      throw new Error('must not run');
+    };
+    expect(await collectSandboxDiff('ag-1', { findLiveHandle: async () => undefined, run })).toEqual({ live: false });
+  });
+
+  it('a live session is read through its handle', async () => {
+    const run: DiffExec = async (spec) =>
+      spec.argsPlain.includes('status') ? { stdout: '# branch.head main\0', code: 0 } : { stdout: '', code: 0 };
+    expect(await collectSandboxDiff('ag-1', { findLiveHandle: async () => describedHandle(), run })).toEqual({
+      live: true,
+      ok: true,
+      view: { content: '', truncated: false, headBranch: 'main' },
+    });
+  });
+
+  it('a read that failed is reported as such, never as a clean tree', async () => {
+    const threw: DiffExec = async () => {
+      throw new Error('exec failed');
+    };
+    const failed = await collectSandboxDiff('ag-1', { findLiveHandle: async () => describedHandle(), run: threw });
+    expect(failed).toMatchObject({ live: true, ok: false });
+    expect((failed as { error: unknown }).error).toBeInstanceOf(DiffCollectError);
+    const exited: DiffExec = async () => ({ stdout: '', code: 1 });
+    expect(
+      await collectSandboxDiff('ag-1', { findLiveHandle: async () => describedHandle(), run: exited }),
+    ).toMatchObject({ live: true, ok: false });
+  });
+});
+
+describe('parseStatus', () => {
+  it('reads the head, the untracked paths, and steps over a rename entry', () => {
+    const out = [
+      '# branch.oid abc',
+      '# branch.head feature/x',
+      '1 .M N... 100644 100644 100644 abc abc app.ts',
+      '2 R. N... 100644 100644 100644 abc abc R100 new-name.ts',
+      'old-name.ts',
+      '? untracked one.txt',
+      '? dir/two.txt',
+      '',
+    ].join('\0');
+    expect(parseStatus(out)).toEqual({ untracked: ['untracked one.txt', 'dir/two.txt'], headBranch: 'feature/x' });
+    expect(parseStatus('# branch.head (detached)\0')).toEqual({ untracked: [] });
+  });
+});
+
+describe('bounds', () => {
+  it('cuts on a line boundary and appends the trailer', () => {
+    const line = 'x'.repeat(50) + '\n';
+    const content = line.repeat(100);
+    const bounded = boundDiff(content, 1_000);
+    expect(bounded.truncated).toBe(true);
+    expect(Buffer.byteLength(bounded.content, 'utf8')).toBeLessThanOrEqual(1_000);
+    expect(bounded.content.endsWith(DIFF_TRUNCATED_TRAILER)).toBe(true);
+    const body = bounded.content.slice(0, -DIFF_TRUNCATED_TRAILER.length);
+    expect(body.endsWith('\n')).toBe(true);
+    expect(body.split('\n').every((l) => l === '' || l.length === 50)).toBe(true);
+  });
+
+  it('leaves small content alone', () => {
+    expect(boundDiff('abc\n', 100)).toEqual({ content: 'abc\n', truncated: false });
+  });
+});

--- a/src/code-mode/surface/diff-view.ts
+++ b/src/code-mode/surface/diff-view.ts
@@ -1,0 +1,249 @@
+/**
+ * The diff view — what changed in the coding session's working tree.
+ *
+ * Collected INSIDE the session container, through the driver's exec
+ * (SessionHandle.execSpec, the same path attach and the interrupt use), as
+ * the container's own user. The working tree is the agent's: a repository
+ * it controls can name an external diff driver, a textconv filter, a
+ * fsmonitor hook — programs git runs on the tree's behalf. Host git never
+ * touches that tree; git runs where the agent already runs, with the
+ * repository's helpers switched off (`--no-ext-diff --no-textconv`, an
+ * empty `core.fsmonitor`) so the view is a read of the files, and its
+ * output crosses to the host as bounded bytes. A session whose container
+ * is not running has no diff: nothing on the host stands in for it.
+ *
+ * What the view shows: `git diff HEAD` for tracked changes (staged and
+ * unstaged together), plus a `--no-index` diff against /dev/null for each
+ * untracked file so a brand-new file shows up as the "new file" hunk it is,
+ * instead of vanishing from a view whose whole point is to show new work. A
+ * repository with no commit yet falls back to the index diff. Not a git
+ * repository → null, and the caller sends nothing. Three outcomes are kept
+ * apart for the caller (DiffCollection): a cold session (nothing to read),
+ * a read that answered (hunks, a clean tree, or no repository), and a read
+ * that FAILED (the exec threw, git exited with an error) — the last one is
+ * retried by the runtime, never mistaken for a clean tree.
+ *
+ * Bounded three times: the exec's output at `execMaxBytes` (cut, marked),
+ * at most `maxUntrackedFiles` new files, and `maxBytes` of view in total
+ * (cut at a line boundary with a trailer that says so). Every exec has a
+ * timeout.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import type { SessionExecSpec, SessionHandle } from '../../drivers/types.js';
+import { CODE_WORKSPACE_DIR } from '../compose.js';
+import { findLiveSandboxHandle } from './stop.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface DiffView {
+  content: string;
+  truncated: boolean;
+  headBranch?: string;
+}
+
+/** A read of the tree that did not answer: the exec failed or git exited with an error. */
+export class DiffCollectError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'DiffCollectError';
+  }
+}
+
+export interface DiffExecResult {
+  stdout: string;
+  code: number;
+  /** The output hit the exec's byte cap and was cut. */
+  truncated?: boolean;
+}
+
+/** Run one command in the session; resolves stdout with the exit code, never rejects for a non-zero exit. */
+export type DiffExec = (spec: SessionExecSpec) => Promise<DiffExecResult>;
+
+export interface CollectDiffOptions {
+  maxBytes?: number;
+  maxUntrackedFiles?: number;
+  /** Byte cap on one exec's stdout. */
+  execMaxBytes?: number;
+  /** Time cap on one exec. */
+  execTimeoutMs?: number;
+  /** The working tree inside the session. */
+  workspaceDir?: string;
+  /** Test seam: run one exec spec. */
+  run?: DiffExec;
+}
+
+export const DEFAULT_DIFF_MAX_BYTES = 200 * 1024;
+export const DEFAULT_MAX_UNTRACKED_FILES = 40;
+export const DEFAULT_DIFF_EXEC_MAX_BYTES = 16 * 1024 * 1024;
+export const DEFAULT_DIFF_EXEC_TIMEOUT_MS = 30_000;
+export const DIFF_TRUNCATED_TRAILER = '\n... (diff truncated)\n';
+export const DIFF_OUTPUT_CUT_MARKER = '\n... (output cut at the exec byte cap)\n';
+
+/**
+ * The git invocation prefix for every read of the tree: run in the
+ * workspace, no pager, no fsmonitor hook. The diff flags below keep the
+ * repository's external diff driver and textconv filters out of it.
+ */
+export function gitReadArgv(workspaceDir: string, ...args: string[]): string[] {
+  return ['git', '-C', workspaceDir, '-c', 'core.fsmonitor=', '--no-pager', ...args];
+}
+
+const DIFF_FLAGS = ['--no-color', '--no-ext-diff', '--no-textconv'];
+
+/**
+ * The default exec: the driver's plain argv, its stdout captured up to the
+ * byte cap. Node's execFile fails the call at maxBuffer with the bytes it
+ * has; that is the cut, reported as such rather than as a failure.
+ */
+export function defaultDiffExec(options: { maxBytes: number; timeoutMs: number }): DiffExec {
+  return async (spec) => {
+    try {
+      const { stdout } = await execFileAsync(spec.bin, spec.argsPlain, {
+        maxBuffer: options.maxBytes,
+        timeout: options.timeoutMs,
+        encoding: 'utf8',
+      });
+      return { stdout, code: 0 };
+    } catch (error) {
+      const failed = error as { stdout?: string; code?: number | string; killed?: boolean };
+      const stdout = typeof failed.stdout === 'string' ? failed.stdout : '';
+      if (failed.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') return { stdout, code: 0, truncated: true };
+      if (failed.killed) throw new Error(`diff exec timed out after ${options.timeoutMs} ms`, { cause: error });
+      return { stdout, code: typeof failed.code === 'number' ? failed.code : 1 };
+    }
+  };
+}
+
+/** Cut at `maxBytes` on a line boundary and say so. */
+export function boundDiff(content: string, maxBytes: number): { content: string; truncated: boolean } {
+  if (Buffer.byteLength(content, 'utf8') <= maxBytes) return { content, truncated: false };
+  const budget = Math.max(0, maxBytes - Buffer.byteLength(DIFF_TRUNCATED_TRAILER, 'utf8'));
+  let cut = Buffer.from(content, 'utf8').subarray(0, budget).toString('utf8');
+  // Drop a partially decoded last character and end on a whole line.
+  cut = cut.replace(/�$/, '');
+  const lastNewline = cut.lastIndexOf('\n');
+  if (lastNewline > 0) cut = cut.slice(0, lastNewline + 1);
+  return { content: cut + DIFF_TRUNCATED_TRAILER, truncated: true };
+}
+
+/** Untracked paths and the branch head out of `status --porcelain=v2 --branch -z`. */
+export function parseStatus(stdout: string): { untracked: string[]; headBranch?: string } {
+  const untracked: string[] = [];
+  let headBranch: string | undefined;
+  const fields = stdout.split('\0');
+  for (let i = 0; i < fields.length; i++) {
+    const entry = fields[i];
+    if (!entry) continue;
+    if (entry.startsWith('# branch.head ')) {
+      const head = entry.slice('# branch.head '.length);
+      if (head && head !== '(detached)') headBranch = head;
+    } else if (entry.startsWith('? ')) {
+      untracked.push(entry.slice(2));
+    } else if (entry.startsWith('2 ')) {
+      i++; // a rename carries its original path as the next field
+    }
+  }
+  return { untracked, headBranch };
+}
+
+/**
+ * Collect the view through the live session `handle`. The exec runs the
+ * driver's plain (non-tty) argv for each git read. Resolves null for a
+ * workspace that is not a repository; throws DiffCollectError when a read
+ * failed (an exec that threw, or git exiting with an error that is not
+ * "not a repository").
+ */
+export async function collectDiff(handle: SessionHandle, options: CollectDiffOptions = {}): Promise<DiffView | null> {
+  const maxBytes = options.maxBytes ?? DEFAULT_DIFF_MAX_BYTES;
+  const maxUntracked = options.maxUntrackedFiles ?? DEFAULT_MAX_UNTRACKED_FILES;
+  const workspaceDir = options.workspaceDir ?? CODE_WORKSPACE_DIR;
+  const run =
+    options.run ??
+    defaultDiffExec({
+      maxBytes: options.execMaxBytes ?? DEFAULT_DIFF_EXEC_MAX_BYTES,
+      timeoutMs: options.execTimeoutMs ?? DEFAULT_DIFF_EXEC_TIMEOUT_MS,
+    });
+  const exec = async (command: string[]): Promise<DiffExecResult> => {
+    try {
+      return await run(handle.execSpec(command));
+    } catch (error) {
+      throw new DiffCollectError(`diff exec failed: ${command.slice(0, 2).join(' ')}`, { cause: error });
+    }
+  };
+  const git = (...args: string[]) => exec(gitReadArgv(workspaceDir, ...args));
+  let cut = false;
+  const take = (result: DiffExecResult): string => {
+    if (result.truncated) cut = true;
+    return result.truncated ? result.stdout + DIFF_OUTPUT_CUT_MARKER : result.stdout;
+  };
+
+  // One read answers three questions: is this a repository (git's exit 128
+  // says no), which files are untracked, and what the head branch is. Any
+  // other failure is a read that did not answer.
+  const status = await git('status', '--porcelain=v2', '--branch', '-z', '--untracked-files=all');
+  if (status.code === 128) return null;
+  if (status.code !== 0) throw new DiffCollectError(`git status exited ${status.code}`);
+  const { untracked, headBranch } = parseStatus(status.stdout);
+
+  let tracked = await git('diff', ...DIFF_FLAGS, 'HEAD', '--');
+  if (tracked.code !== 0) tracked = await git('diff', ...DIFF_FLAGS, '--'); // no HEAD yet: unstaged only
+  if (tracked.code !== 0) throw new DiffCollectError(`git diff exited ${tracked.code}`);
+  const parts: string[] = tracked.stdout ? [take(tracked)] : [];
+
+  const files = untracked.slice(0, maxUntracked);
+  if (files.length > 0 && !cut && parts.reduce((n, p) => n + Buffer.byteLength(p, 'utf8'), 0) <= maxBytes) {
+    // One exec for every new file: the loop runs in the session, the paths
+    // travel as positional arguments, never through a shell word.
+    const loop = `for f in "$@"; do ${gitReadArgv(workspaceDir, 'diff', ...DIFF_FLAGS, '--no-index', '--', '/dev/null')
+      .map(shQuote)
+      .join(' ')} "$f"; done; exit 0`;
+    const added = await exec(['sh', '-c', loop, 'sh', ...files]);
+    if (added.code === 0 && added.stdout) parts.push(take(added));
+  }
+
+  const bounded = boundDiff(parts.join(''), maxBytes);
+  return {
+    content: bounded.content,
+    truncated: bounded.truncated || cut,
+    ...(headBranch ? { headBranch } : {}),
+  };
+}
+
+function shQuote(token: string): string {
+  return `'${token.replace(/'/g, `'\\''`)}'`;
+}
+
+/** The outcome of one read of the tree, for a running session. */
+export type DiffCollection =
+  /** The read answered: hunks, a clean tree (empty content), or no repository (null). */
+  | { ok: true; view: DiffView | null }
+  /** The read failed — retry later; this is not a clean tree. */
+  | { ok: false; error: unknown };
+
+export type SandboxDiff =
+  /** No running session to read from. */
+  { live: false } | ({ live: true } & DiffCollection);
+
+export interface CollectSandboxDiffDeps extends CollectDiffOptions {
+  findLiveHandle?: (agentGroupId: string) => Promise<SessionHandle | undefined>;
+}
+
+/**
+ * The view for a group's coding session: through its live container, or
+ * nothing when it is cold. The host never reads the tree itself.
+ */
+export async function collectSandboxDiff(
+  agentGroupId: string,
+  deps: CollectSandboxDiffDeps = {},
+): Promise<SandboxDiff> {
+  const { findLiveHandle, ...options } = deps;
+  const handle = await (findLiveHandle ?? findLiveSandboxHandle)(agentGroupId);
+  if (!handle) return { live: false };
+  try {
+    return { live: true, ok: true, view: await collectDiff(handle, options) };
+  } catch (error) {
+    return { live: true, ok: false, error };
+  }
+}

--- a/src/code-mode/surface/index.ts
+++ b/src/code-mode/surface/index.ts
@@ -1,0 +1,259 @@
+/**
+ * A chat surface for each coding session — module wiring.
+ *
+ * When a sandbox is created on a host where a chat platform has registered
+ * a session-surface provider (registry.ts), the host opens a surface for
+ * that session through the provider, binds the sandbox group to it through
+ * the ordinary group ↔ chat wiring (binding.ts), mirrors the session's
+ * state to it (runtime.ts: status and a diff view after each turn) and
+ * honours a Stop from the surface (stop.ts: interrupt the turn, never
+ * archive). The diff is read inside the session container (diff-view.ts). With no provider registered nothing opens, and the terminal
+ * verbs `ncl sandboxes status | diff | stop` are the surface.
+ *
+ * Registered here: the table migration (db.ts), the routing resolver that
+ * makes a bound surface the coding session's default outbound route, the
+ * sandbox-created hook that opens surfaces, and the host lifecycle of the
+ * mirror. The sandbox verbs run in the host process (the ncl socket server
+ * lives there), so a fresh binding joins the running mirror directly.
+ */
+import path from 'node:path';
+
+import { getMessagingGroup } from '../../db/messaging-groups.js';
+import { findSandboxSessions, SANDBOX_SYSTEM_THREAD_ID } from '../../db/sessions.js';
+import { onHostShutdown, onHostStart } from '../../host-lifecycle.js';
+import { log } from '../../log.js';
+import { registerSessionRoutingResolver, sessionDir } from '../../session-manager.js';
+import { onSandboxCreated, SANDBOX_HOOKS_SEAM, type SandboxGroup } from '../hooks.js';
+import { bindSessionSurface, type BoundSessionSurface } from './binding.js';
+import {
+  getSessionSurfaceByGroup,
+  listOpenSessionSurfaces,
+  updateSessionSurface,
+  type SessionSurfacePatch,
+  type SessionSurfaceRow,
+} from './db.js';
+import { collectSandboxDiff } from './diff-view.js';
+import { mapStatus, type MirrorObservation, type MirrorStatus, type TurnStamp } from './mapper.js';
+import { getSessionSurface, listSessionSurfaces, noopSessionSurface, onSessionSurfaceChange } from './registry.js';
+import { SessionSurfaceRuntime, type SessionSurfaceRuntimeDeps } from './runtime.js';
+import { interruptCodingSession } from './stop.js';
+import { readTurnStamp, TURN_STAMP_SUBDIR } from './turn-stamp.js';
+
+export { SESSION_SURFACE_SEAM, registerSessionSurface } from './registry.js';
+export type { SessionSurfaceRow } from './db.js';
+export type * from './types.js';
+
+let runtime: SessionSurfaceRuntime | null = null;
+
+// A coding session has no origin chat of its own; once bound, its surface is
+// its default outbound route: a reply and a standalone `ncl outbox send`
+// both post at the surface's top level (thread null — the adapter posts a
+// null thread at the conversation itself).
+registerSessionRoutingResolver(async (session) => {
+  if (session.thread_id !== SANDBOX_SYSTEM_THREAD_ID) return null;
+  const row = await getSessionSurfaceByGroup(session.agent_group_id);
+  if (!row || row.archived_at || !row.messaging_group_id) return null;
+  const mg = await getMessagingGroup(row.messaging_group_id);
+  if (!mg) return null;
+  return { channelType: mg.channel_type, platformId: mg.platform_id, threadId: null };
+});
+
+/** The mirror this process runs, if the host started one (tests install their own). */
+export function getSessionSurfaceRuntime(): SessionSurfaceRuntime | null {
+  return runtime;
+}
+
+export function setSessionSurfaceRuntime(next: SessionSurfaceRuntime | null): void {
+  runtime = next;
+}
+
+/** The host-side read of the runner's turn stamp for a group's coding session. */
+export async function observeSandbox(agentGroupId: string): Promise<MirrorObservation> {
+  const sessions = await findSandboxSessions(agentGroupId);
+  const session = sessions[0];
+  if (!session) return { running: false, turn: null };
+  const running = session.container_status === 'running' || session.container_status === 'idle';
+  const turn: TurnStamp | null = readTurnStamp(path.join(sessionDir(agentGroupId, session.id), TURN_STAMP_SUBDIR));
+  return { running, turn };
+}
+
+/**
+ * Where the coding session's working tree lives on the host (the
+ * container's /workspace/group). A path, for mounts and tests; the host
+ * never runs git there — the diff is read inside the session (diff-view.ts).
+ */
+export async function sandboxWorkspaceDir(agentGroupId: string): Promise<string | null> {
+  const session = (await findSandboxSessions(agentGroupId))[0];
+  return session ? path.join(sessionDir(agentGroupId, session.id), 'group') : null;
+}
+
+export function createSessionSurfaceRuntime(overrides: Partial<SessionSurfaceRuntimeDeps> = {}): SessionSurfaceRuntime {
+  return new SessionSurfaceRuntime({
+    // A binding whose platform has no provider (yet, or any more) waits in
+    // the runtime — nothing sent, nothing persisted — and goes live when
+    // the provider registers (the change listener below).
+    providerFor: (row) => getSessionSurface(row.provider) ?? null,
+    listBindings: listOpenSessionSurfaces,
+    observe: (row) => observeSandbox(row.agent_group_id),
+    // A cold session has nothing to read and nothing to publish; the runtime
+    // only asks while the session runs, so this answers "clean" for it.
+    collectDiff: async (row) => {
+      const result = await collectSandboxDiff(row.agent_group_id);
+      return result.live ? result : { ok: true, view: null };
+    },
+    interrupt: (agentGroupId) => interruptCodingSession(agentGroupId),
+    persist: (agentGroupId, patch: SessionSurfacePatch) => updateSessionSurface(agentGroupId, patch),
+    ...overrides,
+  });
+}
+
+onHostStart(async () => {
+  runtime = createSessionSurfaceRuntime();
+  await runtime.start();
+});
+
+onHostShutdown(async () => {
+  await runtime?.stop();
+  runtime = null;
+});
+
+// The host restores bindings at start, before every module has activated:
+// a provider registering later takes over the rows of its platform, and one
+// unregistering hands them back to waiting.
+onSessionSurfaceChange((channelType) => {
+  const active = runtime;
+  if (!active) return;
+  active.refresh(channelType).catch((err) => log.warn('Session surface refresh failed', { channelType, err }));
+});
+
+/**
+ * Open (or find) the chat surface for a sandbox on `channelType`. Never
+ * throws: no provider, a provider that answers null, or one that fails all
+ * resolve null and the sandbox goes on without a surface.
+ */
+export async function bindSandboxSurface(
+  group: SandboxGroup,
+  channelType: string,
+  options: { title?: string; terminalAddress?: string } = {},
+): Promise<BoundSessionSurface | null> {
+  const provider = getSessionSurface(channelType);
+  if (!provider) return null;
+  try {
+    const bound = await bindSessionSurface({ group, channelType, provider, ...options });
+    const active = runtime;
+    if (bound && active) {
+      try {
+        await active.add(bound.row);
+      } catch (err) {
+        log.warn('Session surface bound but not mirrored by this process', { agentGroupId: group.id, err });
+      }
+    }
+    return bound;
+  } catch (err) {
+    log.warn('Session surface not opened — sandbox continues without one', {
+      agentGroupId: group.id,
+      channelType,
+      err,
+    });
+    return null;
+  }
+}
+
+// A new sandbox gets one surface: the registered platforms are asked in
+// registration order, after the rows exist and before the first wake, and
+// the first provider that answers binds. A provider answering null passes
+// the turn on; with none registered nothing runs and the sandbox is plain.
+onSandboxCreated(
+  'session-surface',
+  async (group) => {
+    for (const { channelType } of listSessionSurfaces()) {
+      if (await bindSandboxSurface(group, channelType)) return;
+    }
+  },
+  { seam: SANDBOX_HOOKS_SEAM },
+);
+
+export interface SandboxSurfaceSummary {
+  provider: string;
+  surfaceId: string;
+  sessionId: string;
+  title: string;
+  lastStatus: string | null;
+  lastStatusAt: string | null;
+  stoppedAt: string | null;
+  archivedAt: string | null;
+  /** Whether this host process is mirroring the binding right now. */
+  mirrored: boolean;
+  createdAt: string;
+}
+
+export interface SandboxStatus {
+  sandbox: string;
+  id: string;
+  /** The mapper's answer for the session right now. */
+  status: MirrorStatus;
+  running: boolean;
+  turn: TurnStamp | null;
+  /** The chat surface bound to the session, when there is one. */
+  surface: SandboxSurfaceSummary | null;
+}
+
+/** What the sandbox looks like from here: the mapped status and its binding row, if any. */
+export async function sandboxStatus(group: SandboxGroup): Promise<SandboxStatus> {
+  const observation = await observeSandbox(group.id);
+  const row = await getSessionSurfaceByGroup(group.id);
+  return {
+    sandbox: group.folder,
+    id: group.id,
+    status: mapStatus(observation),
+    running: observation.running,
+    turn: observation.turn,
+    surface: row ? summarize(row) : null,
+  };
+}
+
+function summarize(row: SessionSurfaceRow): SandboxSurfaceSummary {
+  return {
+    provider: row.provider,
+    surfaceId: row.surface_id,
+    sessionId: row.session_id,
+    title: row.title,
+    lastStatus: row.last_status,
+    lastStatusAt: row.last_status_at,
+    stoppedAt: row.stopped_at,
+    archivedAt: row.archived_at,
+    mirrored: runtime?.has(row.agent_group_id) ?? false,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * The explicit wrap-up: close the surface through its provider and retire
+ * the binding. Throws when there is none. Nothing else archives a surface —
+ * not a Stop, not deleting the sandbox.
+ */
+export async function archiveSandboxSurface(
+  group: SandboxGroup,
+  options: { summary?: string } = {},
+): Promise<{ sandbox: string; provider: string; surfaceId: string; archived: true; archivedAt: string }> {
+  const row = await getSessionSurfaceByGroup(group.id);
+  if (!row) throw new Error(`sandbox '${group.folder}' has no chat surface`);
+  if (row.archived_at) {
+    return {
+      sandbox: group.folder,
+      provider: row.provider,
+      surfaceId: row.surface_id,
+      archived: true,
+      archivedAt: row.archived_at,
+    };
+  }
+  const provider = getSessionSurface(row.provider) ?? noopSessionSurface;
+  await provider.close({ surfaceId: row.surface_id, sessionId: row.session_id }, options);
+  const archivedAt = new Date().toISOString();
+  await updateSessionSurface(group.id, { archived_at: archivedAt });
+  runtime?.remove(group.id);
+  log.info('Session surface archived', { agentGroupId: group.id, provider: row.provider, surfaceId: row.surface_id });
+  return { sandbox: group.folder, provider: row.provider, surfaceId: row.surface_id, archived: true, archivedAt };
+}
+
+export { getSessionSurfaceByGroup };

--- a/src/code-mode/surface/mapper.test.ts
+++ b/src/code-mode/surface/mapper.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The status mapper as a table: observation → status, coalescing and the
+ * send interval, the stopped gate and what resumes it, and the diff trigger
+ * on a completed turn.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { decide, mapStatus, markStopped, type MirrorState, type TurnStamp } from './mapper.js';
+
+const T0 = Date.parse('2026-09-11T10:00:00.000Z');
+const iso = (ms: number) => new Date(ms).toISOString();
+const stamp = (state: 'idle' | 'busy', seq: number, atMs: number): TurnStamp => ({ state, seq, at: iso(atMs) });
+
+const fresh = (over: Partial<MirrorState> = {}): MirrorState => ({
+  lastStatus: null,
+  lastSentAt: 0,
+  stoppedAt: null,
+  lastTurnSeq: 0,
+  ...over,
+});
+
+describe('mapStatus', () => {
+  it.each([
+    [{ running: false, turn: null }, 'suspended'],
+    [{ running: false, turn: stamp('busy', 3, T0) }, 'suspended'],
+    [{ running: true, turn: null }, 'active'],
+    [{ running: true, turn: stamp('idle', 1, T0) }, 'active'],
+    [{ running: true, turn: stamp('busy', 2, T0) }, 'processing'],
+  ] as const)('%j → %s', (observation, expected) => {
+    expect(mapStatus(observation)).toBe(expected);
+  });
+});
+
+describe('sends and coalescing', () => {
+  it('the first observation sends; an unchanged status never re-sends', () => {
+    const first = decide(fresh(), { running: true, turn: null }, T0);
+    expect(first.send).toEqual({ status: 'active', resume: false });
+    expect(first.next.lastStatus).toBe('active');
+    const again = decide(first.next, { running: true, turn: stamp('idle', 1, T0) }, T0 + 10_000);
+    expect(again.send).toBeUndefined();
+  });
+
+  it('a change inside the send interval waits; the latest value wins when the interval passes', () => {
+    const sent = decide(fresh(), { running: true, turn: null }, T0).next;
+    const tooSoon = decide(sent, { running: true, turn: stamp('busy', 1, T0 + 100) }, T0 + 500);
+    expect(tooSoon.send).toBeUndefined();
+    expect(tooSoon.next.lastStatus).toBe('active');
+    // Flapped back to idle before the interval — only the current state goes out.
+    const later = decide(tooSoon.next, { running: true, turn: stamp('idle', 2, T0 + 900) }, T0 + 2_000);
+    expect(later.send).toBeUndefined(); // active → active: nothing to say
+    const busy = decide(later.next, { running: true, turn: stamp('busy', 3, T0 + 2_100) }, T0 + 4_000);
+    expect(busy.send).toEqual({ status: 'processing', resume: false });
+  });
+
+  it('a reaped container is suspended; waking it goes back to active', () => {
+    const processing = fresh({ lastStatus: 'processing', lastSentAt: T0 });
+    const down = decide(processing, { running: false, turn: stamp('busy', 4, T0) }, T0 + 5_000);
+    expect(down.send).toEqual({ status: 'suspended', resume: false });
+    const up = decide(down.next, { running: true, turn: stamp('busy', 4, T0) }, T0 + 10_000);
+    // The stale busy stamp from before the reap still reads as processing.
+    expect(up.send).toEqual({ status: 'processing', resume: false });
+  });
+});
+
+describe('diff after a completed turn', () => {
+  it('a stamp that moved to idle with a new seq asks for the diff, once', () => {
+    const state = fresh({ lastStatus: 'processing', lastSentAt: T0, lastTurnSeq: 2 });
+    const done = decide(state, { running: true, turn: stamp('idle', 3, T0 + 100) }, T0 + 2_000);
+    expect(done.renderDiff).toEqual({ turnSeq: 3 });
+    expect(done.next.lastTurnSeq).toBe(3);
+    const same = decide(done.next, { running: true, turn: stamp('idle', 3, T0 + 100) }, T0 + 4_000);
+    expect(same.renderDiff).toBeUndefined();
+  });
+
+  it('a busy stamp advances the seq without a diff; an idle stamp while suspended renders nothing', () => {
+    const busy = decide(fresh({ lastTurnSeq: 1 }), { running: true, turn: stamp('busy', 2, T0) }, T0);
+    expect(busy.renderDiff).toBeUndefined();
+    expect(busy.next.lastTurnSeq).toBe(2);
+    const cold = decide(busy.next, { running: false, turn: stamp('idle', 3, T0) }, T0 + 2_000);
+    expect(cold.renderDiff).toBeUndefined();
+    expect(cold.next.lastTurnSeq).toBe(3);
+  });
+});
+
+describe('stopped gate', () => {
+  const stoppedAt = T0 + 10_000;
+
+  it('while stopped nothing is sent, whatever the observation', () => {
+    const stopped = markStopped(fresh({ lastStatus: 'processing', lastSentAt: T0 }), iso(stoppedAt));
+    for (const observation of [
+      { running: true, turn: stamp('busy', 5, T0 + 9_000) }, // the interrupted turn's stamp (older than the stop)
+      { running: true, turn: stamp('idle', 6, T0 + 9_500) },
+      { running: false, turn: null },
+      { running: true, turn: null },
+    ]) {
+      const d = decide(stopped, observation, stoppedAt + 30_000);
+      expect(d.send).toBeUndefined();
+      expect(d.renderDiff).toBeUndefined();
+      expect(d.next.stoppedAt).toBe(iso(stoppedAt));
+    }
+  });
+
+  it('a new busy turn after the stop resumes: processing with resume:true, gate cleared', () => {
+    const stopped = markStopped(fresh({ lastStatus: 'processing', lastSentAt: T0 }), iso(stoppedAt));
+    const d = decide(stopped, { running: true, turn: stamp('busy', 7, stoppedAt + 2_000) }, stoppedAt + 2_500);
+    expect(d.send).toEqual({ status: 'processing', resume: true });
+    expect(d.next.stoppedAt).toBeNull();
+    expect(d.next.lastStatus).toBe('processing');
+    // The turn that resumed completes → diff, ordinary sends again.
+    const done = decide(d.next, { running: true, turn: stamp('idle', 8, stoppedAt + 9_000) }, stoppedAt + 10_000);
+    expect(done.renderDiff).toEqual({ turnSeq: 8 });
+    expect(done.send).toEqual({ status: 'active', resume: false });
+  });
+
+  it('a busy stamp newer than the stop on a container that is not running does not resume', () => {
+    const stopped = markStopped(fresh(), iso(stoppedAt));
+    const d = decide(stopped, { running: false, turn: stamp('busy', 7, stoppedAt + 2_000) }, stoppedAt + 2_500);
+    expect(d.send).toBeUndefined();
+    expect(d.next.stoppedAt).toBe(iso(stoppedAt));
+  });
+
+  it('resume ignores the send interval — the next human turn is never held back', () => {
+    const stopped = markStopped(fresh({ lastStatus: 'active', lastSentAt: stoppedAt }), iso(stoppedAt));
+    const d = decide(stopped, { running: true, turn: stamp('busy', 9, stoppedAt + 100) }, stoppedAt + 200);
+    expect(d.send).toEqual({ status: 'processing', resume: true });
+  });
+});

--- a/src/code-mode/surface/mapper.ts
+++ b/src/code-mode/surface/mapper.ts
@@ -1,0 +1,123 @@
+/**
+ * Runner state → session status, as a pure decision.
+ *
+ * Inputs are two host-side facts per tick: is the coding session's container
+ * running (sessions.container_status, kept by the host), and what does the
+ * runner's turn stamp say (`<sessDir>/code-turns/state.json`, written by the
+ * mailbox hook on UserPromptSubmit/Stop — code-runner/turn-stamp.ts). The
+ * output is what, if anything, to send this tick:
+ *
+ *   container not running        → suspended
+ *   running, turn stamp busy     → processing
+ *   running, stamp idle or none  → active
+ *
+ * Three rules shape the sends:
+ *   - coalesce: an unchanged status is never re-sent; a changed one waits
+ *     until `minIntervalMs` since the last send (flapping is absorbed, the
+ *     latest value wins);
+ *   - stopped gate: after a Stop from the channel nothing is sent — the
+ *     service refuses it anyway — until the runner reports a NEW busy turn
+ *     (a stamp newer than the stop mark), which is the next human turn: that
+ *     one goes out as `processing` with `resume: true`;
+ *   - diff after a turn: a stamp that moved to idle since the last one seen
+ *     means a turn completed; the caller renders the diff for it. Never while
+ *     stopped or suspended.
+ *
+ * Pure so the table is testable without timers, files or a service.
+ */
+import type { SurfaceStatus } from './types.js';
+
+export type MirrorStatus = Exclude<SurfaceStatus, 'closed'>;
+
+export interface TurnStamp {
+  state: 'idle' | 'busy';
+  at: string;
+  seq: number;
+}
+
+export interface MirrorObservation {
+  running: boolean;
+  turn: TurnStamp | null;
+}
+
+export function mapStatus(observation: MirrorObservation): MirrorStatus {
+  if (!observation.running) return 'suspended';
+  return observation.turn?.state === 'busy' ? 'processing' : 'active';
+}
+
+export interface MirrorState {
+  /** Last status the service accepted (null before the first send). */
+  lastStatus: MirrorStatus | null;
+  /** Epoch ms of the last accepted send (0 before the first). */
+  lastSentAt: number;
+  /** ISO time of the Stop from the channel; null while running normally. */
+  stoppedAt: string | null;
+  /** Highest turn-stamp seq already acted on. */
+  lastTurnSeq: number;
+}
+
+export interface MirrorDecision {
+  /** Send this status now (resume flags the first send after a stop). */
+  send?: { status: MirrorStatus; resume: boolean };
+  /** A turn completed since the last tick — render the diff for it. */
+  renderDiff?: { turnSeq: number };
+  /** The state to carry into the next tick (the caller persists what it wants). */
+  next: MirrorState;
+}
+
+export interface MirrorPolicy {
+  /** Minimum gap between two status sends. */
+  minIntervalMs: number;
+}
+
+export const DEFAULT_MIRROR_POLICY: MirrorPolicy = { minIntervalMs: 1_500 };
+
+function newerThan(turn: TurnStamp | null, iso: string): boolean {
+  if (!turn) return false;
+  const at = Date.parse(turn.at);
+  const mark = Date.parse(iso);
+  return Number.isFinite(at) && Number.isFinite(mark) && at > mark;
+}
+
+export function decide(
+  state: MirrorState,
+  observation: MirrorObservation,
+  nowMs: number,
+  policy: MirrorPolicy = DEFAULT_MIRROR_POLICY,
+): MirrorDecision {
+  const desired = mapStatus(observation);
+  const turn = observation.turn;
+  const next: MirrorState = { ...state };
+  const decision: MirrorDecision = { next };
+
+  const turnAdvanced = turn !== null && turn.seq > state.lastTurnSeq;
+  if (turnAdvanced) next.lastTurnSeq = turn.seq;
+
+  if (state.stoppedAt !== null) {
+    // Stopped: only a new human turn — the runner stamping busy AFTER the
+    // stop — resumes. Everything else stays silent, suspended included.
+    const resumed = observation.running && turn?.state === 'busy' && newerThan(turn, state.stoppedAt);
+    if (!resumed) return decision;
+    next.stoppedAt = null;
+    next.lastStatus = 'processing';
+    next.lastSentAt = nowMs;
+    decision.send = { status: 'processing', resume: true };
+    return decision;
+  }
+
+  if (turnAdvanced && turn.state === 'idle' && observation.running) {
+    decision.renderDiff = { turnSeq: turn.seq };
+  }
+
+  if (desired !== state.lastStatus && nowMs - state.lastSentAt >= policy.minIntervalMs) {
+    next.lastStatus = desired;
+    next.lastSentAt = nowMs;
+    decision.send = { status: desired, resume: false };
+  }
+  return decision;
+}
+
+/** Mark a Stop received from the channel: status sends pause until the next human turn. */
+export function markStopped(state: MirrorState, atIso: string): MirrorState {
+  return { ...state, stoppedAt: atIso };
+}

--- a/src/code-mode/surface/registry.test.ts
+++ b/src/code-mode/surface/registry.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The provider registry: one provider per platform, refused on a duplicate
+ * or a seam mismatch (logged, listed, never thrown), change notifications
+ * on register and unregister, a no-op object that opens nothing, and the
+ * contract helper's answer.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
+import { log } from '../../log.js';
+import { resetSeamRefusalsForTesting, seamRefusals } from '../../seams.js';
+import { assertSurfaceRegistered } from './contract.js';
+import {
+  SESSION_SURFACE_SEAM,
+  getSessionSurface,
+  listSessionSurfaces,
+  noopSessionSurface,
+  onSessionSurfaceChange,
+  registerSessionSurface,
+  resetSessionSurfacesForTesting,
+} from './registry.js';
+import type { SessionSurfaceProvider } from './types.js';
+
+function provider(): SessionSurfaceProvider {
+  return { ...noopSessionSurface, open: async () => ({ surfaceId: 'S1', sessionId: 'ag-1' }) };
+}
+
+beforeEach(() => {
+  resetSessionSurfacesForTesting();
+  resetSeamRefusalsForTesting();
+  vi.mocked(log.error).mockClear();
+});
+afterEach(() => {
+  resetSessionSurfacesForTesting();
+  resetSeamRefusalsForTesting();
+});
+
+describe('registerSessionSurface', () => {
+  it('registers one provider per platform and lists it; unregister removes it', () => {
+    const p = provider();
+    const off = registerSessionSurface('chat', p, { seam: SESSION_SURFACE_SEAM });
+    expect(getSessionSurface('chat')).toBe(p);
+    expect(listSessionSurfaces().map((e) => e.channelType)).toEqual(['chat']);
+    expect(() => assertSurfaceRegistered('chat')).not.toThrow();
+    off();
+    expect(getSessionSurface('chat')).toBeUndefined();
+    expect(() => assertSurfaceRegistered('chat')).toThrow("no session surface is registered for 'chat'");
+  });
+
+  it('a second provider for the same platform is refused and logged; the first keeps the slot', () => {
+    const first = provider();
+    registerSessionSurface('chat', first, { seam: SESSION_SURFACE_SEAM });
+    const off = registerSessionSurface('chat', provider(), { seam: SESSION_SURFACE_SEAM });
+    expect(getSessionSurface('chat')).toBe(first);
+    expect(log.error).toHaveBeenCalledWith(
+      'Session surface refused: a provider for this platform is already registered',
+      { channelType: 'chat' },
+    );
+    off(); // the refused registration's undo is a no-op
+    expect(getSessionSurface('chat')).toBe(first);
+  });
+
+  it('a seam mismatch is refused, listed and named by the contract helper', () => {
+    registerSessionSurface('chat', provider(), { seam: SESSION_SURFACE_SEAM + 1 });
+    expect(getSessionSurface('chat')).toBeUndefined();
+    expect(seamRefusals()).toMatchObject([{ registry: 'session-surface', registrant: 'chat' }]);
+    expect(() => assertSurfaceRegistered('chat')).toThrow(/refused: seam 1 expected, 2 given/);
+  });
+
+  it('a change listener hears each registration and unregistration, not a refused one', () => {
+    const seen: Array<[string, boolean]> = [];
+    const off = onSessionSurfaceChange((channelType, p) => seen.push([channelType, p !== null]));
+    const p = provider();
+    const unregister = registerSessionSurface('chat', p, { seam: SESSION_SURFACE_SEAM });
+    registerSessionSurface('chat', provider(), { seam: SESSION_SURFACE_SEAM }); // refused: no notification
+    registerSessionSurface('other', provider(), { seam: SESSION_SURFACE_SEAM + 1 }); // refused: no notification
+    unregister();
+    expect(seen).toEqual([
+      ['chat', true],
+      ['chat', false],
+    ]);
+    off();
+    registerSessionSurface('chat', provider(), { seam: SESSION_SURFACE_SEAM });
+    expect(seen).toHaveLength(2);
+  });
+
+  it('a listener that throws is logged and the others still run', () => {
+    const seen: string[] = [];
+    const off1 = onSessionSurfaceChange(() => {
+      throw new Error('boom');
+    });
+    const off2 = onSessionSurfaceChange((channelType) => seen.push(channelType));
+    registerSessionSurface('chat', provider(), { seam: SESSION_SURFACE_SEAM });
+    expect(seen).toEqual(['chat']);
+    expect(log.error).toHaveBeenCalledWith(
+      'Session surface change listener failed',
+      expect.objectContaining({ channelType: 'chat' }),
+    );
+    off1();
+    off2();
+  });
+
+  it('the no-op provider opens nothing, accepts everything and returns no events', async () => {
+    expect(await noopSessionSurface.open({ id: 'ag-1', name: 'x', folder: 'x' }, {})).toBeNull();
+    await noopSessionSurface.status({ surfaceId: 'S', sessionId: 'ag-1' }, 'active');
+    const abort = new AbortController();
+    const page = noopSessionSurface.events({ surfaceId: 'S', sessionId: 'ag-1' }, 'c1', 60, abort.signal);
+    abort.abort();
+    expect(await page).toEqual({ events: [], cursor: 'c1' });
+  });
+});

--- a/src/code-mode/surface/registry.ts
+++ b/src/code-mode/surface/registry.ts
@@ -1,0 +1,106 @@
+/**
+ * The session-surface registry: which chat platforms can be a surface for a
+ * coding session on this host.
+ *
+ * A module registers one provider per channel type with `{ seam }`
+ * (SESSION_SURFACE_SEAM); a mismatch is refused and logged (src/seams.ts),
+ * a duplicate is refused and logged. With nothing registered a sandbox is
+ * plain: `open` is never called and `ncl sandboxes status | diff | stop` are
+ * the surface. A binding whose provider is not registered (the module has
+ * not activated yet, or left) waits: nothing is sent and nothing is
+ * persisted for it until a provider for its platform registers, which the
+ * runtime learns through `onSessionSurfaceChange`.
+ */
+import { log } from '../../log.js';
+import { seamAccepted } from '../../seams.js';
+import type { SessionSurfaceProvider } from './types.js';
+
+/** Bump only on a breaking change to SessionSurfaceProvider. */
+export const SESSION_SURFACE_SEAM = 1;
+
+const providers = new Map<string, SessionSurfaceProvider>();
+
+/** Undo the registration. */
+export type Unregister = () => void;
+
+/** Fires after a platform's provider registers (`provider` set) or unregisters (null). */
+export type SessionSurfaceChangeListener = (channelType: string, provider: SessionSurfaceProvider | null) => void;
+
+const listeners = new Set<SessionSurfaceChangeListener>();
+
+/** Subscribe to registrations; the runtime rebinds the rows of a platform whose provider just changed. */
+export function onSessionSurfaceChange(listener: SessionSurfaceChangeListener): () => void {
+  listeners.add(listener);
+  return () => void listeners.delete(listener);
+}
+
+function notify(channelType: string, provider: SessionSurfaceProvider | null): void {
+  for (const listener of [...listeners]) {
+    try {
+      listener(channelType, provider);
+    } catch (err) {
+      log.error('Session surface change listener failed', { channelType, err });
+    }
+  }
+}
+
+export function registerSessionSurface(
+  channelType: string,
+  provider: SessionSurfaceProvider,
+  registration: { seam: number },
+): Unregister {
+  if (!seamAccepted('session-surface', channelType, SESSION_SURFACE_SEAM, registration.seam)) return () => {};
+  if (providers.has(channelType)) {
+    log.error('Session surface refused: a provider for this platform is already registered', { channelType });
+    return () => {};
+  }
+  providers.set(channelType, provider);
+  log.info('Session surface registered', { channelType });
+  notify(channelType, provider);
+  return () => {
+    if (providers.get(channelType) !== provider) return;
+    providers.delete(channelType);
+    notify(channelType, null);
+  };
+}
+
+export function getSessionSurface(channelType: string): SessionSurfaceProvider | undefined {
+  return providers.get(channelType);
+}
+
+export function listSessionSurfaces(): Array<{ channelType: string; provider: SessionSurfaceProvider }> {
+  return [...providers.entries()].map(([channelType, provider]) => ({ channelType, provider }));
+}
+
+/**
+ * A provider that opens nothing, accepts every send silently and reports no
+ * events — a base for tests and partial implementations. The runtime treats
+ * a binding resolved to this object as one with NO provider: nothing is
+ * mirrored or persisted through it.
+ */
+export const noopSessionSurface: SessionSurfaceProvider = {
+  spell: async (surfaceId) => ({ platformId: surfaceId, instance: '' }),
+  open: async () => null,
+  status: async () => {},
+  view: async () => {},
+  events: async (_handle, cursor, waitSec, signal) => {
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, waitSec * 1000);
+      signal?.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+    });
+    return { events: [], cursor };
+  },
+  close: async () => {},
+};
+
+/** Test seam. */
+export function resetSessionSurfacesForTesting(): void {
+  providers.clear();
+}

--- a/src/code-mode/surface/routing.test.ts
+++ b/src/code-mode/surface/routing.test.ts
@@ -1,0 +1,200 @@
+/**
+ * The live seam end to end: a surface bound under the adapter's spelling
+ * routes an inbound message — arriving exactly as the adapter stamps it —
+ * into the sandbox's coding session (router session mode 'sandbox'), with
+ * no second messaging group and no registration card; and a row the adapter
+ * created before the bind is adopted and routes the same way.
+ */
+import fs from 'node:fs';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(true),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+vi.mock('../../cli/resources/destinations.js', () => ({
+  projectDestinationsToSessions: vi.fn(async () => {}),
+}));
+vi.mock('../../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../config.js')>();
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-session-surface-routing/data' };
+});
+
+import type { ChannelAdapter, ChannelDefaults } from '../../channels/adapter.js';
+import {
+  initChannelAdapters,
+  registerChannelAdapter,
+  teardownChannelAdapters,
+} from '../../channels/channel-registry.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { getDb } from '../../db/connection.js';
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import { createMessagingGroup, getMessagingGroupsByChannel } from '../../db/messaging-groups.js';
+import { findSandboxSessions, getSessionsByAgentGroup } from '../../db/sessions.js';
+import { inboundDbPath } from '../../mailbox/sqlite/paths.js';
+import { routeInbound } from '../../router.js';
+import { resolveSandboxSession } from '../../session-manager.js';
+import { bindSessionSurface } from './binding.js';
+import type { SurfaceHandle } from './types.js';
+import '../index.js';
+
+const TEST_ROOT = '/tmp/nanoclaw-test-session-surface-routing';
+const GROUP = { id: 'ag-route-1', name: 'box', folder: 'box' };
+
+const defaults: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: true, unknownSenderPolicy: 'public' },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+/** A threaded chat adapter: ids spelled `chat:<conversation>[:<thread>]`. */
+function chatAdapter(): ChannelAdapter {
+  return {
+    name: 'chat',
+    channelType: 'chat',
+    supportsThreads: true,
+    defaults,
+    setup: async () => {},
+    teardown: async () => {},
+    isConnected: () => true,
+    deliver: async () => undefined,
+    conversationPlatformId: (conversationId) => `chat:${conversationId}`,
+  };
+}
+
+function provider() {
+  let n = 0;
+  return {
+    spell: async (surfaceId: string) => ({ platformId: `chat:${surfaceId}`, instance: 'chat' }),
+    open: async (sandbox: { id: string }): Promise<SurfaceHandle> => {
+      n += 1;
+      return { surfaceId: `C${n}`, sessionId: sandbox.id };
+    },
+  };
+}
+
+function inboundRows(sessionId: string): Array<{ id: string; platform_id: string | null; thread_id: string | null }> {
+  const db = new Database(inboundDbPath(GROUP.id, sessionId), { readonly: true });
+  try {
+    return db.prepare('SELECT id, platform_id, thread_id FROM messages_in ORDER BY seq').all() as Array<{
+      id: string;
+      platform_id: string | null;
+      thread_id: string | null;
+    }>;
+  } finally {
+    db.close();
+  }
+}
+
+/** A message as the adapter delivers it: platform id in its spelling, a thread id under the conversation. */
+async function fromSurface(id: string, text: string, isMention = false): Promise<void> {
+  await routeInbound({
+    channelType: 'chat',
+    platformId: 'chat:C1',
+    threadId: 'chat:C1:1757600000.000100',
+    message: {
+      id,
+      kind: 'chat-sdk',
+      content: JSON.stringify({ sender: 'Alex', senderId: 'U1', text }),
+      timestamp: new Date().toISOString(),
+      isMention,
+      isGroup: true,
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(async () => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(TEST_ROOT, { recursive: true });
+  await runMigrations(await initTestDb());
+  await createAgentGroup({ ...GROUP, agent_provider: null, created_at: new Date().toISOString() });
+  registerChannelAdapter('chat', { factory: () => chatAdapter(), defaults });
+  await initChannelAdapters(() => ({
+    onInbound: () => {},
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  }));
+});
+
+afterEach(async () => {
+  await teardownChannelAdapters();
+  await closeDb();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('inbound from the bound surface', () => {
+  it("lands in the sandbox's coding session — no mention needed, threads ignored, no second group, no card", async () => {
+    // As `sandboxes new` does: the coding session exists before the bind.
+    await resolveSandboxSession(GROUP.id);
+    await bindSessionSurface({ group: GROUP, channelType: 'chat', provider: provider() });
+
+    await fromSurface('m1', 'build me the status page');
+
+    const sandbox = await findSandboxSessions(GROUP.id);
+    expect(sandbox).toHaveLength(1);
+    // The one session the group holds: the coding session, not a chat session per thread.
+    expect((await getSessionsByAgentGroup(GROUP.id)).map((s) => s.id)).toEqual([sandbox[0].id]);
+    const rows = inboundRows(sandbox[0].id);
+    // The router stamps the agent group onto the id (one row per agent it fans to).
+    expect(rows.map((r) => r.id)).toEqual(['m1:ag-route-1']);
+    // The reply address is the surface at top level: the wiring runs threads off.
+    expect(rows[0]).toMatchObject({ platform_id: 'chat:C1', thread_id: null });
+
+    expect(await getMessagingGroupsByChannel('chat')).toHaveLength(1);
+    expect(await getDb().get('SELECT 1 AS x FROM pending_channel_approvals')).toBeUndefined();
+  });
+
+  it('a conversation the adapter registered first is adopted by the bind and routes the same way', async () => {
+    // The bot was invited and mentioned before the host bound: the router's
+    // auto-create ran (this is exactly its row) and a card went out.
+    await createMessagingGroup({
+      id: 'mg-adapter',
+      channel_type: 'chat',
+      platform_id: 'chat:C1',
+      instance: 'chat',
+      name: null,
+      is_group: 1,
+      unknown_sender_policy: 'request_approval',
+      created_at: new Date().toISOString(),
+    });
+    await getDb().run(
+      `INSERT INTO pending_channel_approvals (messaging_group_id, agent_group_id, original_message, approver_user_id, created_at, title, question, options_json)
+       VALUES ('mg-adapter', 'ag-route-1', '{}', 'chat:U1', '2026-09-12T00:00:00.000Z', 'New channel', 'Connect?', '[]')`,
+    );
+
+    await resolveSandboxSession(GROUP.id);
+    const bound = await bindSessionSurface({ group: GROUP, channelType: 'chat', provider: provider() });
+    expect(bound?.row.messaging_group_id).toBe('mg-adapter');
+
+    await fromSurface('m2', 'hello again');
+    const sandbox = await findSandboxSessions(GROUP.id);
+    expect(inboundRows(sandbox[0].id).map((r) => r.id)).toEqual(['m2:ag-route-1']);
+    expect(await getMessagingGroupsByChannel('chat')).toHaveLength(1);
+    expect(await getDb().get('SELECT 1 AS x FROM pending_channel_approvals')).toBeUndefined();
+  });
+
+  it('a message in a spelling the adapter never uses (the bare id) matches nothing — the regression this pins', async () => {
+    await resolveSandboxSession(GROUP.id);
+    await bindSessionSurface({ group: GROUP, channelType: 'chat', provider: provider() });
+    await routeInbound({
+      channelType: 'chat',
+      platformId: 'C1',
+      threadId: null,
+      message: {
+        id: 'm3',
+        kind: 'chat-sdk',
+        content: JSON.stringify({ sender: 'Alex', senderId: 'U1', text: 'lost' }),
+        timestamp: new Date().toISOString(),
+        isMention: false,
+        isGroup: true,
+      },
+    });
+    const sandbox = await findSandboxSessions(GROUP.id);
+    expect(inboundRows(sandbox[0].id)).toEqual([]);
+  });
+});

--- a/src/code-mode/surface/runtime.test.ts
+++ b/src/code-mode/surface/runtime.test.ts
@@ -1,0 +1,508 @@
+/**
+ * The host loop with every dependency scripted: status sends follow the
+ * mapper, the diff view renders after a completed turn (and only when it
+ * changed), a Stop interrupts the session and gates sends until the next
+ * human turn resumes with `resume: true`, a provider-side stop the host has
+ * not seen is honoured, a gone surface retires the binding, a binding
+ * restored before its provider registers waits (unpersisted) and goes live
+ * on refresh, a failed diff publish is retried and then given up, and the
+ * event loop drives the stop from the long-poll.
+ */
+import { describe, expect, it, vi, type Mock } from 'vitest';
+
+import type { SessionSurfacePatch, SessionSurfaceRow } from './db.js';
+import type { DiffView } from './diff-view.js';
+import type { MirrorObservation, TurnStamp } from './mapper.js';
+import { noopSessionSurface } from './registry.js';
+import { MAX_DIFF_ATTEMPTS, SessionSurfaceRuntime, type SessionSurfaceRuntimeDeps } from './runtime.js';
+import { SurfaceError, type SessionSurfaceProvider, type SurfaceEvent, type SurfaceHandle } from './types.js';
+
+const T0 = Date.parse('2026-09-11T10:00:00.000Z');
+const iso = (ms: number) => new Date(ms).toISOString();
+const stamp = (state: 'idle' | 'busy', seq: number, atMs: number): TurnStamp => ({ state, seq, at: iso(atMs) });
+const H1: SurfaceHandle = { surfaceId: 'S1', sessionId: 'ag-1' };
+
+function row(over: Partial<SessionSurfaceRow> = {}): SessionSurfaceRow {
+  return {
+    agent_group_id: 'ag-1',
+    provider: 'chat',
+    surface_id: 'S1',
+    session_id: 'ag-1',
+    messaging_group_id: 'mg-1',
+    title: 'box',
+    last_status: null,
+    last_status_at: null,
+    stopped_at: null,
+    last_turn_seq: 0,
+    events_cursor: null,
+    archived_at: null,
+    created_at: iso(T0),
+    updated_at: iso(T0),
+    ...over,
+  };
+}
+
+interface Harness {
+  runtime: SessionSurfaceRuntime;
+  provider: {
+    status: Mock<SessionSurfaceProvider['status']>;
+    view: Mock<SessionSurfaceProvider['view']>;
+    events: Mock<SessionSurfaceProvider['events']>;
+  };
+  observation: MirrorObservation;
+  diff: DiffView | null;
+  interrupt: Mock<(agentGroupId: string) => Promise<boolean>>;
+  patches: Array<[string, SessionSurfacePatch]>;
+  clock: { now: number };
+}
+
+function harness(rows: SessionSurfaceRow[], over: Partial<SessionSurfaceRuntimeDeps> = {}): Harness {
+  const provider = {
+    status: vi.fn(async () => {}),
+    view: vi.fn(async () => {}),
+    events: vi.fn(async () => ({ events: [], cursor: null })),
+  };
+  const h: Harness = {
+    runtime: null as unknown as SessionSurfaceRuntime,
+    provider,
+    observation: { running: true, turn: null },
+    diff: null,
+    interrupt: vi.fn(async () => true),
+    patches: [],
+    clock: { now: T0 },
+  };
+  h.runtime = new SessionSurfaceRuntime({
+    providerFor: () => provider as unknown as SessionSurfaceProvider,
+    listBindings: async () => rows,
+    observe: async () => h.observation,
+    collectDiff: async () => ({ ok: true, view: h.diff }),
+    interrupt: h.interrupt,
+    persist: async (id, patch) => {
+      h.patches.push([id, patch]);
+    },
+    now: () => h.clock.now,
+    watchEvents: false,
+    ...over,
+  });
+  return h;
+}
+
+describe('status mirroring', () => {
+  it('sends active on the first tick, processing when a turn starts, and nothing while unchanged', async () => {
+    const h = harness([row()]);
+    await h.runtime.start();
+    await h.runtime.tick();
+    expect(h.provider.status).toHaveBeenLastCalledWith(H1, 'active', {});
+    expect(h.patches.at(-1)).toEqual(['ag-1', { last_status: 'active', last_status_at: iso(T0) }]);
+
+    h.clock.now += 5_000;
+    await h.runtime.tick();
+    expect(h.provider.status).toHaveBeenCalledTimes(1);
+
+    h.observation = { running: true, turn: stamp('busy', 1, h.clock.now) };
+    await h.runtime.tick();
+    expect(h.provider.status).toHaveBeenLastCalledWith(H1, 'processing', {});
+    await h.runtime.stop();
+  });
+
+  it('a failed send is retried on a later tick; a "stopped" refusal marks the binding stopped', async () => {
+    const h = harness([row()]);
+    h.provider.status.mockRejectedValueOnce(new Error('network'));
+    await h.runtime.start();
+    await h.runtime.tick();
+    expect(h.patches).toHaveLength(0);
+    h.clock.now += 5_000;
+    await h.runtime.tick();
+    expect(h.provider.status).toHaveBeenCalledTimes(2);
+    expect(h.patches.at(-1)?.[1]).toMatchObject({ last_status: 'active' });
+
+    h.clock.now += 5_000;
+    h.observation = { running: true, turn: stamp('busy', 1, h.clock.now) };
+    h.provider.status.mockRejectedValueOnce(new SurfaceError('stopped', 'stopped'));
+    await h.runtime.tick();
+    expect(h.patches.at(-1)).toEqual(['ag-1', { stopped_at: iso(h.clock.now) }]);
+    // Gated now: the same busy stamp (older than the stop) sends nothing more.
+    h.clock.now += 5_000;
+    await h.runtime.tick();
+    expect(h.provider.status).toHaveBeenCalledTimes(3);
+    await h.runtime.stop();
+  });
+
+  it('a surface the provider no longer knows is retired and marked archived', async () => {
+    const h = harness([row()]);
+    h.provider.status.mockRejectedValueOnce(new SurfaceError('gone', 'gone'));
+    await h.runtime.start();
+    await h.runtime.tick();
+    expect(h.runtime.has('ag-1')).toBe(false);
+    expect(h.patches.at(-1)).toEqual(['ag-1', { archived_at: iso(T0) }]);
+    await h.runtime.stop();
+  });
+
+  it('an unavailable feature drops the binding from this process without archiving it', async () => {
+    const h = harness([row()]);
+    h.provider.status.mockRejectedValueOnce(new SurfaceError('unavailable', 'no'));
+    await h.runtime.start();
+    await h.runtime.tick();
+    expect(h.runtime.has('ag-1')).toBe(false);
+    expect(h.patches).toHaveLength(0);
+    await h.runtime.stop();
+  });
+
+  it('archived rows and rows without a provider are never mirrored', async () => {
+    const h = harness([row({ archived_at: iso(T0) }), row({ agent_group_id: 'ag-2', surface_id: 'S2' })], {
+      providerFor: (r) => (r.agent_group_id === 'ag-2' ? null : ({} as SessionSurfaceProvider)),
+    });
+    await h.runtime.start();
+    expect(h.runtime.size).toBe(0);
+    await h.runtime.stop();
+  });
+});
+
+describe('a provider that registers after the bindings were restored', () => {
+  it('a restored row waits unpersisted, then receives status once its provider registers and refresh runs', async () => {
+    let registered: SessionSurfaceProvider | null = null;
+    const h = harness([row()], { providerFor: () => registered });
+    await h.runtime.start();
+    expect(h.runtime.has('ag-1')).toBe(false);
+    expect(h.runtime.isWaiting('ag-1')).toBe(true);
+    await h.runtime.tick();
+    expect(h.provider.status).not.toHaveBeenCalled();
+    expect(h.patches).toHaveLength(0);
+
+    registered = h.provider as unknown as SessionSurfaceProvider;
+    await h.runtime.refresh('chat');
+    expect(h.runtime.has('ag-1')).toBe(true);
+    expect(h.runtime.isWaiting('ag-1')).toBe(false);
+    await h.runtime.tick();
+    expect(h.provider.status).toHaveBeenCalledWith(H1, 'active', {});
+    expect(h.patches.at(-1)).toEqual(['ag-1', { last_status: 'active', last_status_at: iso(T0) }]);
+
+    // The provider leaves: the binding goes back to waiting and nothing more is sent or persisted.
+    registered = null;
+    await h.runtime.refresh('chat');
+    expect(h.runtime.has('ag-1')).toBe(false);
+    expect(h.runtime.isWaiting('ag-1')).toBe(true);
+    h.clock.now += 5_000;
+    h.observation = { running: true, turn: stamp('busy', 1, h.clock.now) };
+    await h.runtime.tick();
+    expect(h.provider.status).toHaveBeenCalledTimes(1);
+    expect(h.patches).toHaveLength(1);
+    await h.runtime.stop();
+  });
+
+  it('the no-op provider counts as no provider; re-adding the row after registration binds it live', async () => {
+    let current: SessionSurfaceProvider = noopSessionSurface;
+    const h = harness([row()], { providerFor: () => current });
+    await h.runtime.start();
+    await h.runtime.tick();
+    expect(h.runtime.has('ag-1')).toBe(false);
+    expect(h.patches).toHaveLength(0);
+
+    current = h.provider as unknown as SessionSurfaceProvider;
+    await h.runtime.add(row());
+    await h.runtime.tick();
+    expect(h.provider.status).toHaveBeenCalledTimes(1);
+    await h.runtime.stop();
+  });
+
+  it('refresh of another platform leaves the binding alone', async () => {
+    let registered: SessionSurfaceProvider | null = null;
+    const h = harness([row()], { providerFor: () => registered });
+    await h.runtime.start();
+    registered = h.provider as unknown as SessionSurfaceProvider;
+    await h.runtime.refresh('other');
+    expect(h.runtime.has('ag-1')).toBe(false);
+    await h.runtime.stop();
+  });
+});
+
+describe('diff publish retries', () => {
+  it('a failed publish keeps the turn pending: the next healthy tick retries once, then persists the turn', async () => {
+    const h = harness([row({ last_status: 'active', last_status_at: iso(T0 - 60_000), last_turn_seq: 1 })]);
+    h.diff = { content: 'diff --git a/x b/x\n+1\n', truncated: false };
+    h.provider.view.mockRejectedValueOnce(new Error('temporarily unavailable'));
+    await h.runtime.start();
+    h.observation = { running: true, turn: stamp('idle', 2, T0) };
+    await h.runtime.tick();
+    expect(h.provider.view).toHaveBeenCalledTimes(1);
+    expect(h.patches.find(([, p]) => p.last_turn_seq === 2)).toBeUndefined();
+
+    h.clock.now += 5_000;
+    await h.runtime.tick();
+    expect(h.provider.view).toHaveBeenCalledTimes(2);
+    expect(h.patches.find(([, p]) => p.last_turn_seq === 2)).toBeTruthy();
+
+    h.clock.now += 5_000;
+    await h.runtime.tick();
+    expect(h.provider.view).toHaveBeenCalledTimes(2);
+    await h.runtime.stop();
+  });
+
+  it('a failed read of the tree (exec failure) is not a clean tree: it is retried the same way and then published', async () => {
+    const h = harness([row({ last_status: 'active', last_status_at: iso(T0 - 60_000), last_turn_seq: 1 })]);
+    let collects = 0;
+    h.runtime = new SessionSurfaceRuntime({
+      providerFor: () => h.provider as unknown as SessionSurfaceProvider,
+      listBindings: async () => [row({ last_status: 'active', last_status_at: iso(T0 - 60_000), last_turn_seq: 1 })],
+      observe: async () => h.observation,
+      collectDiff: async () => {
+        collects += 1;
+        if (collects === 1) return { ok: false, error: new Error('exec failed') };
+        if (collects === 2) throw new Error('exec threw');
+        return { ok: true, view: { content: 'd\n', truncated: false } };
+      },
+      interrupt: h.interrupt,
+      persist: async (id, patch) => {
+        h.patches.push([id, patch]);
+      },
+      now: () => h.clock.now,
+      watchEvents: false,
+    });
+    await h.runtime.start();
+    h.observation = { running: true, turn: stamp('idle', 2, T0) };
+    await h.runtime.tick();
+    expect(h.provider.view).not.toHaveBeenCalled();
+    expect(h.patches.find(([, p]) => p.last_turn_seq === 2)).toBeUndefined();
+    h.clock.now += 5_000;
+    await h.runtime.tick();
+    expect(h.provider.view).not.toHaveBeenCalled();
+    h.clock.now += 5_000;
+    await h.runtime.tick();
+    expect(h.provider.view).toHaveBeenCalledTimes(1);
+    expect(h.patches.at(-1)).toEqual(['ag-1', { last_turn_seq: 2 }]);
+    await h.runtime.stop();
+  });
+
+  it('after MAX_DIFF_ATTEMPTS failures the turn is given up and persisted, with no further attempts', async () => {
+    const h = harness([row({ last_status: 'active', last_status_at: iso(T0 - 60_000), last_turn_seq: 1 })]);
+    h.diff = { content: 'd\n', truncated: false };
+    h.provider.view.mockRejectedValue(new Error('down'));
+    await h.runtime.start();
+    h.observation = { running: true, turn: stamp('idle', 2, T0) };
+    for (let i = 0; i < MAX_DIFF_ATTEMPTS + 2; i++) {
+      await h.runtime.tick();
+      h.clock.now += 5_000;
+    }
+    expect(h.provider.view).toHaveBeenCalledTimes(MAX_DIFF_ATTEMPTS);
+    expect(h.patches.find(([, p]) => p.last_turn_seq === 2)).toBeTruthy();
+    await h.runtime.stop();
+  });
+
+  it('a newer completed turn supersedes the pending one; a busy stamp does not advance the persisted seq past it', async () => {
+    const h = harness([row({ last_status: 'active', last_status_at: iso(T0 - 60_000), last_turn_seq: 1 })]);
+    h.diff = { content: 'd\n', truncated: false };
+    h.provider.view.mockRejectedValueOnce(new Error('down'));
+    await h.runtime.start();
+    h.observation = { running: true, turn: stamp('idle', 2, T0) };
+    await h.runtime.tick();
+    h.clock.now += 5_000;
+    h.observation = { running: true, turn: stamp('busy', 3, h.clock.now) };
+    await h.runtime.tick();
+    expect(h.patches.find(([, p]) => p.last_turn_seq === 3)).toBeUndefined();
+    h.clock.now += 5_000;
+    h.diff = { content: 'd2\n', truncated: false };
+    h.observation = { running: true, turn: stamp('idle', 4, h.clock.now) };
+    await h.runtime.tick();
+    expect(h.provider.view).toHaveBeenLastCalledWith(H1, expect.objectContaining({ content: 'd2\n' }));
+    expect(h.patches.at(-1)).toEqual(['ag-1', { last_turn_seq: 4 }]);
+    await h.runtime.stop();
+  });
+});
+
+describe('diff view after a turn', () => {
+  it('renders the diff when a turn completes, skips an unchanged tree, persists the turn seq', async () => {
+    const h = harness([row({ last_status: 'active', last_status_at: iso(T0 - 60_000) })]);
+    await h.runtime.start();
+    h.observation = { running: true, turn: stamp('busy', 1, T0) };
+    await h.runtime.tick();
+    expect(h.provider.view).not.toHaveBeenCalled();
+    expect(h.patches.find(([, p]) => p.last_turn_seq === 1)).toBeTruthy();
+
+    h.clock.now += 5_000;
+    h.diff = { content: 'diff --git a/x b/x\n+1\n', truncated: false, headBranch: 'work' };
+    h.observation = { running: true, turn: stamp('idle', 2, h.clock.now) };
+    await h.runtime.tick();
+    expect(h.provider.view).toHaveBeenCalledWith(H1, {
+      key: 'diff',
+      type: 'diff',
+      name: 'Changes',
+      content: 'diff --git a/x b/x\n+1\n',
+      headBranch: 'work',
+    });
+    expect(h.patches.find(([, p]) => p.last_turn_seq === 2)).toBeTruthy();
+    expect(h.provider.status).toHaveBeenLastCalledWith(H1, 'active', {});
+
+    // Next turn, same tree: no second view.
+    h.clock.now += 5_000;
+    h.observation = { running: true, turn: stamp('busy', 3, h.clock.now) };
+    await h.runtime.tick();
+    h.clock.now += 5_000;
+    h.observation = { running: true, turn: stamp('idle', 4, h.clock.now) };
+    await h.runtime.tick();
+    expect(h.provider.view).toHaveBeenCalledTimes(1);
+
+    // An empty diff (not a repo, or clean) sends nothing.
+    h.diff = null;
+    h.clock.now += 5_000;
+    h.observation = { running: true, turn: stamp('busy', 5, h.clock.now) };
+    await h.runtime.tick();
+    h.observation = { running: true, turn: stamp('idle', 6, h.clock.now) };
+    await h.runtime.tick();
+    expect(h.provider.view).toHaveBeenCalledTimes(1);
+    await h.runtime.stop();
+  });
+
+  it('a diff refused because the session is stopped is not an error', async () => {
+    const h = harness([row({ last_status: 'active', last_status_at: iso(T0 - 60_000), last_turn_seq: 1 })]);
+    h.diff = { content: 'd', truncated: false };
+    h.provider.view.mockRejectedValueOnce(new SurfaceError('stopped', 's'));
+    await h.runtime.start();
+    h.observation = { running: true, turn: stamp('idle', 2, T0) };
+    await expect(h.runtime.tick()).resolves.toBeUndefined();
+    expect(h.runtime.has('ag-1')).toBe(true);
+    await h.runtime.stop();
+  });
+});
+
+describe('stop from the surface', () => {
+  it('interrupts the session, persists the stop, holds status, then resumes on the next human turn', async () => {
+    const h = harness([row({ last_status: 'processing', last_status_at: iso(T0 - 60_000), last_turn_seq: 3 })]);
+    await h.runtime.start();
+    h.observation = { running: true, turn: stamp('busy', 3, T0 - 30_000) };
+
+    h.clock.now = T0 + 1_000;
+    await h.runtime.handleStop('ag-1', { ts: iso(T0 + 900), user: 'U1' });
+    expect(h.interrupt).toHaveBeenCalledWith('ag-1');
+    expect(h.patches.at(-1)).toEqual(['ag-1', { stopped_at: iso(T0 + 1_000) }]);
+
+    // The interrupted turn leaves a busy stamp older than the stop: silence.
+    h.clock.now += 5_000;
+    await h.runtime.tick();
+    // Even the container going cold is not reported while stopped.
+    h.observation = { running: false, turn: stamp('busy', 3, T0 - 30_000) };
+    h.clock.now += 5_000;
+    await h.runtime.tick();
+    expect(h.provider.status).not.toHaveBeenCalled();
+
+    // The next message from the surface wakes the container and starts a turn.
+    h.clock.now += 5_000;
+    h.observation = { running: true, turn: stamp('busy', 4, h.clock.now - 100) };
+    await h.runtime.tick();
+    expect(h.provider.status).toHaveBeenCalledWith(H1, 'processing', { resume: true });
+    expect(h.patches).toContainEqual([
+      'ag-1',
+      { last_status: 'processing', last_status_at: iso(h.clock.now), stopped_at: null },
+    ]);
+    expect(h.patches.at(-1)).toEqual(['ag-1', { last_turn_seq: 4 }]);
+    await h.runtime.stop();
+  });
+
+  it('an interrupt that fails still records the stop (the gate is the contract)', async () => {
+    const h = harness([row()]);
+    h.interrupt.mockRejectedValueOnce(new Error('exec failed'));
+    await h.runtime.start();
+    await h.runtime.handleStop('ag-1');
+    expect(h.patches.at(-1)?.[1]).toHaveProperty('stopped_at');
+    await h.runtime.stop();
+  });
+
+  it('a stop for an unknown group is ignored', async () => {
+    const h = harness([]);
+    await h.runtime.start();
+    await h.runtime.handleStop('ag-nope');
+    expect(h.interrupt).not.toHaveBeenCalled();
+    await h.runtime.stop();
+  });
+
+  it('a binding that starts stopped (host restart) stays gated until a turn newer than the stop', async () => {
+    const stoppedAt = iso(T0 - 10_000);
+    const h = harness([row({ last_status: 'processing', stopped_at: stoppedAt, last_turn_seq: 2 })]);
+    await h.runtime.start();
+    h.observation = { running: true, turn: stamp('busy', 2, T0 - 20_000) };
+    await h.runtime.tick();
+    expect(h.provider.status).not.toHaveBeenCalled();
+    h.observation = { running: true, turn: stamp('busy', 3, T0) };
+    h.clock.now = T0 + 1_000;
+    await h.runtime.tick();
+    expect(h.provider.status).toHaveBeenCalledWith(H1, 'processing', { resume: true });
+    await h.runtime.stop();
+  });
+});
+
+/** A hand-written long-poll: the first page carries `page`, the second hangs until the runtime aborts it. */
+function pollingProvider(page: SurfaceEvent[], cursor: string, seen: { since: (string | null)[] }) {
+  let polls = 0;
+  const events: SessionSurfaceProvider['events'] = async (_handle, since, _wait, signal) => {
+    polls += 1;
+    seen.since.push(since);
+    if (polls === 1) return { events: page, cursor };
+    await new Promise<void>((r) => signal?.addEventListener('abort', () => r(), { once: true }));
+    throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+  };
+  return { status: async () => {}, view: async () => {}, events } as unknown as SessionSurfaceProvider;
+}
+
+describe('event loop', () => {
+  it('consumes the long-poll: a stop event interrupts and the cursor is persisted', async () => {
+    const seen = { since: [] as (string | null)[] };
+    const provider = pollingProvider([{ type: 'stop', ts: iso(T0), user: 'U1' }], 'EVT#1', seen);
+    const h = harness([row({ events_cursor: 'EVT#0' })], {
+      watchEvents: true,
+      pollWaitSeconds: 1,
+      providerFor: () => provider,
+    });
+    await h.runtime.start();
+    const cursorPersisted = () => h.patches.some(([, p]) => p.events_cursor === 'EVT#1');
+    for (let i = 0; i < 200 && !cursorPersisted(); i++) await new Promise((r) => setTimeout(r, 10));
+    expect(cursorPersisted()).toBe(true);
+    expect(seen.since[0]).toBe('EVT#0');
+    expect(h.interrupt).toHaveBeenCalledWith('ag-1');
+    expect(h.patches.some(([, p]) => 'stopped_at' in p)).toBe(true);
+    await h.runtime.stop();
+  });
+
+  it('a gone surface ends its loop and retires the binding', async () => {
+    const h = harness([row()], { watchEvents: true, pollWaitSeconds: 1 });
+    h.provider.events.mockRejectedValue(new SurfaceError('gone', 'gone'));
+    await h.runtime.start();
+    for (let i = 0; i < 20 && h.runtime.has('ag-1'); i++) await new Promise((r) => setImmediate(r));
+    expect(h.runtime.has('ag-1')).toBe(false);
+    expect(h.patches.at(-1)?.[1]).toHaveProperty('archived_at');
+    await h.runtime.stop();
+  });
+
+  it('a "stopped" refusal from the poll is honoured as a stop, and the loop goes on', async () => {
+    const h = harness([row()], { watchEvents: true, pollWaitSeconds: 1 });
+    h.provider.events.mockRejectedValueOnce(new SurfaceError('stopped', 'stopped'));
+    await h.runtime.start();
+    for (let i = 0; i < 200 && !h.interrupt.mock.calls.length; i++) await new Promise((r) => setTimeout(r, 10));
+    expect(h.interrupt).toHaveBeenCalledWith('ag-1');
+    expect(h.patches.some(([, p]) => 'stopped_at' in p)).toBe(true);
+    expect(h.runtime.has('ag-1')).toBe(true);
+    await h.runtime.stop();
+  });
+
+  it('a command, a membership change, a thread stop and an unknown type are logged and dropped', async () => {
+    const page: SurfaceEvent[] = [
+      { type: 'command', command: '/terminal', text: '', user: 'U1' },
+      { type: 'member_joined', member: { id: 'U2' } },
+      { type: 'stop', threadId: '1700000000.000100', user: 'U1' },
+      { type: 'something_newer' } as unknown as SurfaceEvent,
+    ];
+    const seen = { since: [] as (string | null)[] };
+    const h = harness([row()], {
+      watchEvents: true,
+      pollWaitSeconds: 1,
+      providerFor: () => pollingProvider(page, 'EVT#4', seen),
+    });
+    await h.runtime.start();
+    const cursorPersisted = () => h.patches.some(([, p]) => p.events_cursor === 'EVT#4');
+    for (let i = 0; i < 200 && !cursorPersisted(); i++) await new Promise((r) => setTimeout(r, 10));
+    expect(cursorPersisted()).toBe(true);
+    expect(h.interrupt).not.toHaveBeenCalled();
+    expect(h.patches.some(([, p]) => 'stopped_at' in p)).toBe(false);
+    // The binding is still live: nothing in that page was a reason to drop it.
+    expect(h.runtime.has('ag-1')).toBe(true);
+    await h.runtime.stop();
+  });
+});

--- a/src/code-mode/surface/runtime.ts
+++ b/src/code-mode/surface/runtime.ts
@@ -1,0 +1,492 @@
+/**
+ * The host loop behind every bound coding session.
+ *
+ * Two activities per binding, both fed by the pure mapper (mapper.ts):
+ *   - a tick (every `tickMs`): observe the session — container running?
+ *     what does the runner's turn stamp say? — and act on the decision:
+ *     send a status, render the diff view after a completed turn;
+ *   - a long-poll on the provider's events (types.ts `events`) so a Stop
+ *     pressed on the surface interrupts the turn within a poll interval
+ *     (stop.ts), then gates status sends until the next human turn.
+ *
+ * Everything the loop touches is injected (SessionSurfaceRuntimeDeps) so the
+ * tests drive it with a fake provider, a scripted observation and no timers;
+ * index.ts wires the real DB, session dirs, git and the session driver.
+ *
+ * Failure posture: a provider that refuses a binding for good (surface
+ * gone, feature unavailable) drops that binding from this process and, when
+ * the surface is gone, marks it archived so no future process retries;
+ * anything transient is retried on the next tick or after a bounded
+ * backoff. A binding never fails the sandbox it mirrors.
+ *
+ * Two facts are kept apart on purpose:
+ *   - a binding whose platform has no provider yet (the module activates
+ *     after the host restored the rows, or left) WAITS: it is held aside,
+ *     nothing is sent or persisted for it, and `refresh(channelType)` —
+ *     called when a provider registers or unregisters — binds it live or
+ *     puts it back to waiting;
+ *   - a turn OBSERVED is not a turn PUBLISHED: the diff for a completed
+ *     turn stays pending until the provider took it (or the tree had
+ *     nothing new), and a failed collect or publish is retried on the next
+ *     healthy tick, a bounded number of times, before the turn is given up
+ *     with a log line. Only then is `last_turn_seq` persisted for it.
+ */
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { log } from '../../log.js';
+import type { SessionSurfacePatch, SessionSurfaceRow } from './db.js';
+import type { DiffCollection } from './diff-view.js';
+import {
+  DEFAULT_MIRROR_POLICY,
+  decide,
+  markStopped,
+  type MirrorObservation,
+  type MirrorPolicy,
+  type MirrorState,
+} from './mapper.js';
+import { noopSessionSurface } from './registry.js';
+import { isStopEvent } from './stop.js';
+import { surfaceErrorKind, type SessionSurfaceProvider, type SurfaceEvent, type SurfaceHandle } from './types.js';
+
+export interface SessionSurfaceRuntimeDeps {
+  /** The provider for the row's platform, or null when this host has none for it. */
+  providerFor(row: SessionSurfaceRow): SessionSurfaceProvider | null;
+  listBindings(): Promise<SessionSurfaceRow[]>;
+  observe(row: SessionSurfaceRow): Promise<MirrorObservation>;
+  /** Read the session's tree: an answer (hunks, clean, no repository) or a failed read to retry. */
+  collectDiff(row: SessionSurfaceRow): Promise<DiffCollection>;
+  /** Interrupt the group's coding session; resolves whether a live session took it. */
+  interrupt(agentGroupId: string): Promise<boolean>;
+  persist(agentGroupId: string, patch: SessionSurfacePatch): Promise<void>;
+  now?(): number;
+  tickMs?: number;
+  policy?: MirrorPolicy;
+  /** Start the per-binding long-poll (tests that script stops directly turn it off). */
+  watchEvents?: boolean;
+  pollWaitSeconds?: number;
+}
+
+interface PendingDiff {
+  turnSeq: number;
+  attempts: number;
+}
+
+interface BindingState {
+  row: SessionSurfaceRow;
+  provider: SessionSurfaceProvider;
+  handle: SurfaceHandle;
+  mirror: MirrorState;
+  /** Last diff content sent, so an unchanged tree is not re-sent. */
+  lastDiff: string | null;
+  /** A completed turn whose diff the provider has not taken yet. */
+  pendingDiff: PendingDiff | null;
+  ticking: boolean;
+  watcher: AbortController | null;
+}
+
+export const DEFAULT_TICK_MS = 2_000;
+
+/** Collect-or-publish attempts for one turn's diff before it is given up. */
+export const MAX_DIFF_ATTEMPTS = 3;
+
+/** The one code view, and the name it carries on the surface. */
+export const DIFF_VIEW_KEY = 'diff';
+export const DIFF_VIEW_NAME = 'Changes';
+
+/** How long one events long-poll may wait (a provider may cap it lower). */
+export const DEFAULT_POLL_WAIT_SECONDS = 25;
+
+/** Bounded backoff for a failing long-poll: 1 s, 2 s, 4 s … capped at a minute. */
+export async function backoff(attempt: number, signal?: AbortSignal): Promise<void> {
+  const ms = Math.min(60_000, 1_000 * 2 ** Math.max(0, attempt - 1));
+  try {
+    await sleep(ms, undefined, { signal });
+  } catch {
+    // Aborted: the caller is stopping.
+  }
+}
+
+function mirrorFromRow(row: SessionSurfaceRow): MirrorState {
+  const lastStatus = row.last_status;
+  return {
+    lastStatus:
+      lastStatus === 'active' || lastStatus === 'processing' || lastStatus === 'suspended' ? lastStatus : null,
+    lastSentAt: row.last_status_at ? Date.parse(row.last_status_at) || 0 : 0,
+    stoppedAt: row.stopped_at,
+    lastTurnSeq: Number(row.last_turn_seq) || 0,
+  };
+}
+
+export class SessionSurfaceRuntime {
+  private readonly deps: SessionSurfaceRuntimeDeps;
+  /** Bindings with a provider: ticked, watched, persisted. */
+  private readonly bindings = new Map<string, BindingState>();
+  /** Bindings whose platform has no provider on this host right now. */
+  private readonly waiting = new Map<string, SessionSurfaceRow>();
+  private timer: NodeJS.Timeout | null = null;
+  private stopped = false;
+
+  constructor(deps: SessionSurfaceRuntimeDeps) {
+    this.deps = deps;
+  }
+
+  /** Bindings mirrored live (a waiting one is not). */
+  get size(): number {
+    return this.bindings.size;
+  }
+
+  /** Whether this process mirrors the group's binding live. */
+  has(agentGroupId: string): boolean {
+    return this.bindings.has(agentGroupId);
+  }
+
+  /** Whether the group's binding is known but waiting for a provider. */
+  isWaiting(agentGroupId: string): boolean {
+    return this.waiting.has(agentGroupId);
+  }
+
+  async start(): Promise<void> {
+    this.stopped = false;
+    for (const row of await this.deps.listBindings()) await this.add(row);
+    const tickMs = this.deps.tickMs ?? DEFAULT_TICK_MS;
+    this.timer = setInterval(() => {
+      this.tick().catch((err) => log.error('Session surface tick failed', { err }));
+    }, tickMs);
+    this.timer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+    for (const id of [...this.bindings.keys()]) this.remove(id);
+    this.waiting.clear();
+  }
+
+  /** The row's provider, or null: a platform with none, or the no-op object, is no provider. */
+  private resolveProvider(row: SessionSurfaceRow): SessionSurfaceProvider | null {
+    const provider = this.deps.providerFor(row);
+    return provider && provider !== noopSessionSurface ? provider : null;
+  }
+
+  /**
+   * Register a binding (new or loaded), or re-resolve a known one. A row
+   * whose platform has a provider is mirrored live; one without waits,
+   * unpersisted, until `refresh` finds a provider for it. A live binding
+   * whose provider changed is rebound with its mirror state kept.
+   */
+  async add(row: SessionSurfaceRow): Promise<void> {
+    const id = row.agent_group_id;
+    if (row.archived_at) return;
+    const provider = this.resolveProvider(row);
+    const live = this.bindings.get(id);
+    if (live) {
+      if (provider === live.provider) return;
+      live.watcher?.abort();
+      live.watcher = null;
+      if (!provider) {
+        this.bindings.delete(id);
+        this.hold(live.row);
+        return;
+      }
+      live.provider = provider;
+      if (this.deps.watchEvents !== false) this.watch(live);
+      log.info('Session surface rebound to a new provider', { agentGroupId: id, provider: row.provider });
+      return;
+    }
+    if (!provider) {
+      this.hold(row);
+      return;
+    }
+    this.waiting.delete(id);
+    const state: BindingState = {
+      row: { ...row },
+      provider,
+      handle: { surfaceId: row.surface_id, sessionId: row.session_id },
+      mirror: mirrorFromRow(row),
+      lastDiff: null,
+      pendingDiff: null,
+      ticking: false,
+      watcher: null,
+    };
+    this.bindings.set(id, state);
+    if (this.deps.watchEvents !== false) this.watch(state);
+  }
+
+  private hold(row: SessionSurfaceRow): void {
+    if (!this.waiting.has(row.agent_group_id)) {
+      log.warn('Session surface has no provider on this host — waiting, not mirrored', {
+        agentGroupId: row.agent_group_id,
+        provider: row.provider,
+        surfaceId: row.surface_id,
+      });
+    }
+    this.waiting.set(row.agent_group_id, { ...row });
+  }
+
+  /**
+   * A platform's provider registered or unregistered: re-resolve every
+   * binding of that platform — a waiting one goes live and starts ticking,
+   * a live one whose provider went away goes back to waiting.
+   */
+  async refresh(channelType: string): Promise<void> {
+    const rows = [
+      ...[...this.waiting.values()].filter((row) => row.provider === channelType),
+      ...[...this.bindings.values()].filter((state) => state.row.provider === channelType).map((state) => state.row),
+    ];
+    for (const row of rows) {
+      try {
+        await this.add(row);
+      } catch (err) {
+        log.warn('Session surface not rebound', { agentGroupId: row.agent_group_id, channelType, err });
+      }
+    }
+  }
+
+  remove(agentGroupId: string): void {
+    this.waiting.delete(agentGroupId);
+    const state = this.bindings.get(agentGroupId);
+    if (!state) return;
+    state.watcher?.abort();
+    this.bindings.delete(agentGroupId);
+  }
+
+  /** One pass over every binding — exported so tests run it without the timer. */
+  async tick(): Promise<void> {
+    for (const state of [...this.bindings.values()]) {
+      if (state.ticking) continue;
+      state.ticking = true;
+      try {
+        await this.tickOne(state);
+      } catch (err) {
+        log.warn('Session surface mirror tick failed', { agentGroupId: state.row.agent_group_id, err });
+      } finally {
+        state.ticking = false;
+      }
+    }
+  }
+
+  private now(): number {
+    return this.deps.now ? this.deps.now() : Date.now();
+  }
+
+  private async tickOne(state: BindingState): Promise<void> {
+    const observation = await this.deps.observe(state.row);
+    const before = state.mirror;
+    const decision = decide(before, observation, this.now(), this.deps.policy ?? DEFAULT_MIRROR_POLICY);
+    state.mirror = decision.next;
+    const id = state.row.agent_group_id;
+
+    if (decision.send) {
+      const { status, resume } = decision.send;
+      try {
+        await state.provider.status(state.handle, status, resume ? { resume: true } : {});
+        const at = new Date(this.now()).toISOString();
+        await this.deps.persist(id, {
+          last_status: status,
+          last_status_at: at,
+          ...(resume ? { stopped_at: null } : {}),
+        });
+        log.debug('Session surface status sent', { agentGroupId: id, status, resume });
+      } catch (err) {
+        if (surfaceErrorKind(err) === 'stopped') {
+          // The provider knows of a Stop this process has not seen (a missed
+          // or not-yet-polled event): honour it now; the watcher's interrupt
+          // follows when the event arrives.
+          const at = new Date(this.now()).toISOString();
+          state.mirror = markStopped({ ...state.mirror, lastStatus: before.lastStatus }, at);
+          await this.deps.persist(id, { stopped_at: at });
+          log.info('Session surface reports the session stopped', { agentGroupId: id });
+          return;
+        }
+        // Keep the send slot (rate limit) but not the status: the next tick retries.
+        state.mirror = { ...state.mirror, lastStatus: before.lastStatus };
+        if (await this.dropIfDead(state, err, 'status')) return;
+        log.warn('Session surface status not sent', { agentGroupId: id, status, err });
+      }
+    }
+
+    // A completed turn is observed here and published below; the two are
+    // not the same event. A newer completed turn supersedes a pending one
+    // (its diff shows the newer tree anyway). A turn that needs no diff (a
+    // busy stamp) advances the persisted seq only while nothing is pending,
+    // so a restart still finds the pending turn newer than what it stored.
+    if (decision.renderDiff) {
+      state.pendingDiff = { turnSeq: decision.renderDiff.turnSeq, attempts: 0 };
+    } else if (decision.next.lastTurnSeq !== before.lastTurnSeq && !state.pendingDiff) {
+      await this.deps.persist(id, { last_turn_seq: decision.next.lastTurnSeq });
+    }
+    if (state.pendingDiff && observation.running && state.mirror.stoppedAt === null) {
+      await this.publishDiff(state, state.pendingDiff);
+    }
+  }
+
+  /**
+   * One attempt at the pending turn's diff. Settled — persisted as the
+   * binding's last turn and cleared — when the provider took the view, or
+   * when there was nothing new to send; kept pending otherwise, until the
+   * attempts run out.
+   */
+  private async publishDiff(state: BindingState, pending: PendingDiff): Promise<void> {
+    const id = state.row.agent_group_id;
+    const { turnSeq } = pending;
+    const settle = async (): Promise<void> => {
+      if (state.pendingDiff === pending) state.pendingDiff = null;
+      await this.deps.persist(id, { last_turn_seq: turnSeq });
+    };
+    const failed = async (what: string, err: unknown): Promise<void> => {
+      pending.attempts += 1;
+      if (pending.attempts >= MAX_DIFF_ATTEMPTS) {
+        log.warn(`Session surface diff ${what} failed ${pending.attempts} times — giving up on this turn`, {
+          agentGroupId: id,
+          turnSeq,
+          err,
+        });
+        await settle();
+        return;
+      }
+      log.warn(`Session surface diff not ${what === 'collect' ? 'collected' : 'published'} — will retry`, {
+        agentGroupId: id,
+        turnSeq,
+        attempt: pending.attempts,
+        err,
+      });
+    };
+
+    // A read that failed (the exec, git) is NOT a clean tree: it stays
+    // pending and is retried like a failed publish.
+    let collected: DiffCollection;
+    try {
+      collected = await this.deps.collectDiff(state.row);
+    } catch (err) {
+      collected = { ok: false, error: err };
+    }
+    if (!collected.ok) {
+      await failed('collect', collected.error);
+      return;
+    }
+    const diff = collected.view;
+    if (!diff || !diff.content || diff.content === state.lastDiff) {
+      await settle();
+      return;
+    }
+    try {
+      await state.provider.view(state.handle, {
+        key: DIFF_VIEW_KEY,
+        type: 'diff',
+        name: DIFF_VIEW_NAME,
+        content: diff.content,
+        ...(diff.headBranch ? { headBranch: diff.headBranch } : {}),
+      });
+      state.lastDiff = diff.content;
+      await settle();
+      log.debug('Session surface diff view updated', { agentGroupId: id, turnSeq, truncated: diff.truncated });
+    } catch (err) {
+      if (await this.dropIfDead(state, err, 'diff')) return;
+      // A 'stopped' refusal is the provider gating a stop this process has
+      // not seen; the turn stays pending like any other failed attempt.
+      await failed('publish', err);
+    }
+  }
+
+  /** A binding the provider will never serve again leaves this process (and, when the surface is gone, the table's live set). */
+  private async dropIfDead(state: BindingState, err: unknown, what: string): Promise<boolean> {
+    const id = state.row.agent_group_id;
+    const kind = surfaceErrorKind(err);
+    if (kind === 'gone') {
+      log.info('Session surface is gone — binding retired', {
+        agentGroupId: id,
+        surfaceId: state.row.surface_id,
+        what,
+      });
+      this.remove(id);
+      await this.deps.persist(id, { archived_at: new Date(this.now()).toISOString() });
+      return true;
+    }
+    if (kind === 'unavailable') {
+      log.warn('Session surface unavailable — not mirrored by this process', { agentGroupId: id, what, err });
+      this.remove(id);
+      return true;
+    }
+    return false;
+  }
+
+  /** A Stop from the surface: interrupt the turn, then hold status until the next human turn. */
+  async handleStop(agentGroupId: string, event?: { ts?: string; user?: string }): Promise<void> {
+    const state = this.bindings.get(agentGroupId);
+    if (!state) return;
+    let interrupted = false;
+    try {
+      interrupted = await this.deps.interrupt(agentGroupId);
+    } catch (err) {
+      log.error('Session surface stop: interrupt failed', { agentGroupId, err });
+    }
+    const at = new Date(this.now()).toISOString();
+    state.mirror = markStopped(state.mirror, at);
+    await this.deps.persist(agentGroupId, { stopped_at: at });
+    log.info('Session surface stop honoured', {
+      agentGroupId,
+      surfaceId: state.row.surface_id,
+      interrupted,
+      user: event?.user,
+      eventTs: event?.ts,
+    });
+  }
+
+  /**
+   * One host-bound notification. A surface-wide Stop is the one event the
+   * host acts on today. A command, a membership change, a board change, a
+   * thread-scoped stop and any type this host does not know are logged and
+   * dropped, never raised: the provider may carry events newer than this
+   * host, and none of them is a message for the session.
+   */
+  private async handleEvent(state: BindingState, event: SurfaceEvent): Promise<void> {
+    const agentGroupId = state.row.agent_group_id;
+    if (event.type === 'stop') {
+      if (isStopEvent(event)) await this.handleStop(agentGroupId, event);
+      else log.debug('Session surface thread stop relayed only', { agentGroupId, threadId: event.threadId });
+      return;
+    }
+    if (event.type === 'command') {
+      log.info('Session surface command noted', { agentGroupId, command: event.command, user: event.user });
+      return;
+    }
+    log.info('Session surface event ignored', { agentGroupId, type: event.type });
+  }
+
+  private watch(state: BindingState): void {
+    const abort = new AbortController();
+    state.watcher = abort;
+    const id = state.row.agent_group_id;
+    const wait = this.deps.pollWaitSeconds ?? DEFAULT_POLL_WAIT_SECONDS;
+    const loop = async (): Promise<void> => {
+      let attempt = 0;
+      while (!abort.signal.aborted && !this.stopped) {
+        try {
+          const page = await state.provider.events(state.handle, state.row.events_cursor, wait, abort.signal);
+          attempt = 0;
+          for (const event of page.events) await this.handleEvent(state, event);
+          if (page.cursor && page.cursor !== state.row.events_cursor) {
+            state.row.events_cursor = page.cursor;
+            await this.deps.persist(id, { events_cursor: page.cursor });
+          }
+        } catch (err) {
+          if (abort.signal.aborted || this.stopped) return;
+          if (surfaceErrorKind(err) === 'stopped') {
+            // The provider refuses the poll because the user stopped the
+            // session: that IS the stop event. Honour it and keep polling.
+            await this.handleStop(id);
+            continue;
+          }
+          if (await this.dropIfDead(state, err, 'events')) return;
+          attempt++;
+          if (attempt === 1 || attempt % 10 === 0) {
+            log.warn('Session surface event poll failed — backing off', { agentGroupId: id, attempt, err });
+          }
+          await backoff(attempt, abort.signal);
+        }
+      }
+    };
+    loop().catch((err) => log.error('Session surface event loop died', { agentGroupId: id, err }));
+  }
+}

--- a/src/code-mode/surface/stop.test.ts
+++ b/src/code-mode/surface/stop.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Stop → interrupt: the keystroke rides the driver's exec dialect into the
+ * session's tmux pane; no live session means nothing to press; a thread
+ * stop is not a stop.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SessionExecSpec, SessionHandle } from '../../drivers/types.js';
+import { INTERRUPT_COMMAND, interruptCodingSession, isStopEvent } from './stop.js';
+
+function handle(name: string): SessionHandle {
+  return {
+    key: { installSlug: 'i', agentGroupId: 'ag-1', sessionId: 's-1' },
+    name,
+    start: async () => {},
+    status: async () => ({ phase: 'running' }),
+    stop: async () => {},
+    execSpec: (command: string[]) => ({
+      bin: 'fake-runtime',
+      argsTty: ['exec', '-it', name, ...command],
+      argsPlain: ['exec', '-i', name, ...command],
+    }),
+  };
+}
+
+describe('interruptCodingSession', () => {
+  it('presses Escape in the live session through the plain exec argv', async () => {
+    const run = vi.fn(async (_spec: SessionExecSpec) => {});
+    const ok = await interruptCodingSession('ag-1', { findLiveHandle: async () => handle('ncl-s-1'), run });
+    expect(ok).toBe(true);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0][0]).toEqual({
+      bin: 'fake-runtime',
+      argsTty: ['exec', '-it', 'ncl-s-1', ...INTERRUPT_COMMAND],
+      argsPlain: ['exec', '-i', 'ncl-s-1', ...INTERRUPT_COMMAND],
+    });
+    expect(INTERRUPT_COMMAND).toEqual([
+      'tmux',
+      '-S',
+      '/tmp/code-runner/tmux.sock',
+      'send-keys',
+      '-t',
+      'agent',
+      'Escape',
+    ]);
+  });
+
+  it('no live session → false, nothing run', async () => {
+    const run = vi.fn(async () => {});
+    expect(await interruptCodingSession('ag-1', { findLiveHandle: async () => undefined, run })).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('a failed exec surfaces', async () => {
+    await expect(
+      interruptCodingSession('ag-1', {
+        findLiveHandle: async () => handle('x'),
+        run: async () => {
+          throw new Error('exec failed');
+        },
+      }),
+    ).rejects.toThrow('exec failed');
+  });
+});
+
+describe('isStopEvent', () => {
+  it('a surface-wide stop is a stop; a thread stop or another type is not', () => {
+    expect(isStopEvent({ type: 'stop' })).toBe(true);
+    expect(isStopEvent({ type: 'stop', threadId: '1.2' })).toBe(false);
+    expect(isStopEvent({ type: 'command', command: '/x' })).toBe(false);
+  });
+});

--- a/src/code-mode/surface/stop.ts
+++ b/src/code-mode/surface/stop.ts
@@ -1,0 +1,76 @@
+/**
+ * Stop → interrupt the coding session's current turn.
+ *
+ * The interrupt path is the session's own: the runner keeps the interactive
+ * CLI in a tmux session on a container-private socket
+ * (code-runner/tmux-session.ts), and Escape is how a human at that terminal
+ * interrupts a turn. The host reaches the same pane the way attach does —
+ * the driver's exec dialect (SessionHandle.execSpec) — and presses Escape
+ * with `tmux send-keys`. Nothing is archived and nothing else changes: the
+ * session stays attached, the workspace stays, and the next human message
+ * resumes it (mapper.ts stopped gate).
+ *
+ * `ncl sandboxes stop` and a Stop from a chat surface both come here. A
+ * session that is not running has nothing to interrupt; that is a success —
+ * the stop is honoured by the mirror's gate alone.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { findSandboxSessions } from '../../db/sessions.js';
+import { getSessionDriver, type SessionExecSpec, type SessionHandle } from '../../drivers/index.js';
+import { getInstallSlug } from '../../install-slug.js';
+import { TMUX_SESSION_NAME, TMUX_SOCKET_PATH } from '../sandboxes.js';
+import type { SurfaceEvent } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+/** The keystroke the runner's terminal understands as "interrupt this turn". */
+export const INTERRUPT_COMMAND: readonly string[] = [
+  'tmux',
+  '-S',
+  TMUX_SOCKET_PATH,
+  'send-keys',
+  '-t',
+  TMUX_SESSION_NAME,
+  'Escape',
+];
+
+/** A surface-wide stop (a thread-scoped stop is relayed only; the turn runs on). */
+export function isStopEvent(event: SurfaceEvent): boolean {
+  return event.type === 'stop' && !event.threadId;
+}
+
+export interface InterruptDeps {
+  /** The live runtime handle for the group's coding session, if any. */
+  findLiveHandle?: (agentGroupId: string) => Promise<SessionHandle | undefined>;
+  /** Run the driver-composed exec (the plain, non-tty argv). */
+  run?: (spec: SessionExecSpec) => Promise<void>;
+}
+
+/** Discovery through the driver, like attach: the listing's phase is the truth. */
+export async function findLiveSandboxHandle(agentGroupId: string): Promise<SessionHandle | undefined> {
+  const sessions = await findSandboxSessions(agentGroupId);
+  if (sessions.length === 0) return undefined;
+  const wanted = new Set(sessions.map((s) => s.id));
+  for (const snapshot of await getSessionDriver().listSessions(getInstallSlug())) {
+    if (snapshot.phase === 'running' && wanted.has(snapshot.handle.key.sessionId)) return snapshot.handle;
+  }
+  return undefined;
+}
+
+async function runExec(spec: SessionExecSpec): Promise<void> {
+  await execFileAsync(spec.bin, spec.argsPlain, { timeout: 15_000 });
+}
+
+/**
+ * Press Escape in the group's coding session. Resolves true when a live
+ * session received the keystroke, false when there was no live session to
+ * interrupt. Throws when the exec itself failed.
+ */
+export async function interruptCodingSession(agentGroupId: string, deps: InterruptDeps = {}): Promise<boolean> {
+  const handle = await (deps.findLiveHandle ?? findLiveSandboxHandle)(agentGroupId);
+  if (!handle) return false;
+  await (deps.run ?? runExec)(handle.execSpec([...INTERRUPT_COMMAND]));
+  return true;
+}

--- a/src/code-mode/surface/turn-stamp.ts
+++ b/src/code-mode/surface/turn-stamp.ts
@@ -1,0 +1,30 @@
+/**
+ * Host-side reader of the runner's turn stamp.
+ *
+ * The runner writes `<sessDir>/code-turns/state.json` from the mailbox hook
+ * (container/agent-runner/src/code-runner/turn-stamp.ts — the two files
+ * cannot share code across the host/container wall, so each cites the
+ * other; keep the path and the shape in lockstep). A torn, absent or
+ * unrecognized file reads as null, which the mapper treats as "idle".
+ */
+import fs from 'node:fs';
+
+import type { TurnStamp } from './mapper.js';
+
+/** Where the stamp lands inside a session dir (the container's /workspace/code-turns/state.json). */
+export const TURN_STAMP_SUBDIR = 'code-turns/state.json';
+
+export function readTurnStamp(filePath: string): TurnStamp | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+  if (!raw || typeof raw !== 'object') return null;
+  const stamp = raw as Partial<TurnStamp>;
+  if (stamp.state !== 'idle' && stamp.state !== 'busy') return null;
+  if (typeof stamp.seq !== 'number' || !Number.isFinite(stamp.seq)) return null;
+  if (typeof stamp.at !== 'string') return null;
+  return { state: stamp.state, at: stamp.at, seq: stamp.seq };
+}

--- a/src/code-mode/surface/types.ts
+++ b/src/code-mode/surface/types.ts
@@ -1,0 +1,166 @@
+/**
+ * The session-surface contract: how a chat platform becomes a surface for a
+ * coding session.
+ *
+ * A SessionSurfaceProvider is an optional capability, one object per chat
+ * platform, attached with `registerSessionSurface(channelType, provider, {
+ * seam })` (registry.ts) or offered from a channel adapter. Every method is
+ * async so a REMOTE implementer (a service the host talks to over HTTP) is
+ * a legal implementation, and no method exposes a platform SDK object: core
+ * hands the provider its own ids and gets ids back.
+ *
+ * What stays in core (this directory): the mapper (turn stamp → status),
+ * diff collection, the interrupt, the binding table and wiring, the runtime
+ * (tick, coalescing, stopped gate, event cursor, backoff) and the CLI
+ * verbs. The provider owns everything that touches the platform.
+ *
+ * Failure vocabulary: a provider signals "cannot at all" / "gone for good" /
+ * "the user stopped it" by throwing a SurfaceError with that kind; anything
+ * else is transient and retried by the runtime.
+ */
+import type { SandboxGroup } from '../hooks.js';
+
+export type SurfaceStatus = 'active' | 'processing' | 'suspended' | 'closed';
+
+/** The provider's handle for one open surface. */
+export interface SurfaceHandle {
+  surfaceId: string;
+  /** The provider's id for the session behind it (core passes the agent group id at open). */
+  sessionId: string;
+}
+
+/** How the platform's adapter spells the surface as a messaging_groups row. */
+export interface SurfaceSpelling {
+  platformId: string;
+  instance: string;
+}
+
+export interface SurfaceView {
+  key: string;
+  type: 'diff' | 'html' | 'blocks' | 'canvas';
+  name?: string;
+  content: string;
+  /** For a diff view: the working branch, when known. */
+  headBranch?: string;
+}
+
+export interface SurfaceBarItem {
+  key: string;
+  label: string;
+  icon?: string;
+  url?: string;
+}
+
+export interface SurfaceBoardItem {
+  id: string;
+  text: string;
+  claimedBy?: string | null;
+  done?: boolean;
+}
+
+export interface BoardState {
+  items: SurfaceBoardItem[];
+}
+
+export type SurfaceBoardOp =
+  | { op: 'init'; items?: string[] }
+  | { op: 'add'; text: string }
+  | { op: 'claim'; id: string; by: string }
+  | { op: 'done'; id: string }
+  | { op: 'unclaim'; id: string }
+  | { op: 'show' };
+
+export interface SurfaceCommandSpec {
+  name: string;
+  description: string;
+}
+
+export interface SurfaceMember {
+  /** The platform's id for the member (a user id, a bot id). */
+  id: string;
+  name?: string;
+  role?: string;
+}
+
+export type SurfaceEvent =
+  | {
+      type: 'stop';
+      ts?: string;
+      /** Who pressed it, in the platform's id. */
+      user?: string;
+      /** Set when the stop was scoped to a thread (relayed only; the turn runs on). */
+      threadId?: string;
+    }
+  | { type: 'command'; command: string; text?: string; user?: string; ts?: string }
+  | { type: 'member_joined'; member: SurfaceMember }
+  | { type: 'member_left'; member: SurfaceMember }
+  | { type: 'board_changed'; board?: BoardState };
+
+export interface SurfaceEventsPage {
+  events: SurfaceEvent[];
+  /** The cursor to continue from; null when the provider has none. */
+  cursor: string | null;
+}
+
+export interface SessionSurfaceProvider {
+  /**
+   * The messaging_groups spelling the adapter's inbound path will resolve
+   * for this surface, so the binding writes the row the adapter matches
+   * (today's `ChannelAdapter.conversationPlatformId`).
+   */
+  spell(surfaceId: string): Promise<SurfaceSpelling>;
+  /**
+   * Open (or find) the surface for a sandbox. Null means "not available" —
+   * no install, no sign-in, a platform that cannot do it yet — and the
+   * sandbox goes on without one. Never throws for that; a thrown error is
+   * logged and treated the same.
+   */
+  open(sandbox: SandboxGroup, options: { title?: string; terminalAddress?: string }): Promise<SurfaceHandle | null>;
+  /** The mapper's output, coalesced by the runtime. `resume` flags the first send after a stop. */
+  status(handle: SurfaceHandle, status: SurfaceStatus, options?: { resume?: boolean }): Promise<void>;
+  /** The diff after a turn, or another view the platform can show. */
+  view(handle: SurfaceHandle, view: SurfaceView): Promise<void>;
+  /** Items on the surface's context bar (a terminal address, a link). */
+  bar?(handle: SurfaceHandle, items: SurfaceBarItem[]): Promise<void>;
+  /** A shared task board on the surface. */
+  board?(handle: SurfaceHandle, op: SurfaceBoardOp): Promise<BoardState>;
+  /** Commands the surface offers its members. */
+  commands?(handle: SurfaceHandle, specs: SurfaceCommandSpec[]): Promise<void>;
+  members?(handle: SurfaceHandle): Promise<SurfaceMember[]>;
+  join?(handle: SurfaceHandle, member: SurfaceMember): Promise<void>;
+  leave?(handle: SurfaceHandle, member: SurfaceMember): Promise<void>;
+  /**
+   * The runtime's long-poll: events since `cursor`, waiting up to `waitSec`
+   * for one. A provider that pushes nothing returns an empty page after the
+   * wait. `signal` aborts the wait when the runtime stops.
+   */
+  events(
+    handle: SurfaceHandle,
+    cursor: string | null,
+    waitSec: number,
+    signal?: AbortSignal,
+  ): Promise<SurfaceEventsPage>;
+  /** The explicit wrap-up: the surface closes, with a summary first when given. */
+  close(handle: SurfaceHandle, options?: { summary?: string }): Promise<void>;
+}
+
+export type SurfaceErrorKind =
+  /** The platform cannot give this host a surface at all — degrade, do not retry. */
+  | 'unavailable'
+  /** The surface is gone for good (closed elsewhere, unknown) — stop mirroring it. */
+  | 'gone'
+  /** The user stopped the session from the surface; status is refused until the next human turn resumes. */
+  | 'stopped';
+
+export class SurfaceError extends Error {
+  readonly kind: SurfaceErrorKind;
+  constructor(kind: SurfaceErrorKind, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'SurfaceError';
+    this.kind = kind;
+  }
+}
+
+export function surfaceErrorKind(error: unknown): SurfaceErrorKind | undefined {
+  return error instanceof SurfaceError ? error.kind : undefined;
+}

--- a/src/code-mode/template.test.ts
+++ b/src/code-mode/template.test.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+vi.mock('../config.js', async (original) => ({
+  ...(await original<typeof import('../config.js')>()),
+  DATA_DIR: '/tmp/nanoclaw-code-template/data',
+  GROUPS_DIR: '/tmp/nanoclaw-code-template/groups',
+  TEMPLATES_DIR: '/tmp/nanoclaw-code-template/templates',
+}));
+
+import { closeDb, initTestDb, runMigrations } from '../db/index.js';
+import { getContainerConfig } from '../db/container-configs.js';
+import { createAgentFromTemplate } from '../templates/create-agent.js';
+import { parseTemplate } from '../templates/parse.js';
+import { NANOCLAW_EXTENSION_NS } from '../templates/extension.js';
+import './index.js';
+
+const root = '/tmp/nanoclaw-code-template';
+const dir = path.join(root, 'templates/dev-sandbox');
+beforeEach(async () => {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'plugin.json'),
+    JSON.stringify({
+      $schema: 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json',
+      name: 'dev-sandbox',
+      version: '1.0.0',
+      description: 'Coding workspace',
+      extensions: { [NANOCLAW_EXTENSION_NS]: { agentName: 'Dev Sandbox', codeMode: true } },
+    }),
+  );
+  await runMigrations(await initTestDb());
+});
+afterEach(async () => {
+  await closeDb();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+it('stamps code mode before a templated group has any session', async () => {
+  expect(parseTemplate(dir)).toMatchObject({ codeMode: true, report: [] });
+  const { group } = await createAgentFromTemplate('dev-sandbox');
+  expect((await getContainerConfig(group.id))?.code_mode).toBe(1);
+});
+
+it('rejects malformed facts; omission and false keep chat mode', async () => {
+  const file = path.join(dir, 'plugin.json');
+  const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+  for (const value of ['true', 1, null]) {
+    manifest.extensions[NANOCLAW_EXTENSION_NS].codeMode = value;
+    fs.writeFileSync(file, JSON.stringify(manifest));
+    await expect(createAgentFromTemplate('dev-sandbox')).rejects.toThrow('codeMode must be a boolean');
+  }
+  for (const value of [undefined, false]) {
+    manifest.extensions[NANOCLAW_EXTENSION_NS].codeMode = value;
+    fs.writeFileSync(file, JSON.stringify(manifest));
+    const { group } = await createAgentFromTemplate('dev-sandbox');
+    expect((await getContainerConfig(group.id))?.code_mode).toBe(0);
+  }
+});

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -257,6 +257,11 @@ export interface ContainerConfig {
   /** Provider-declared speed tier (`standard` or `fast` for Claude); the group value overrides the install default. */
   speed?: ContainerSpeed;
   timezone?: string;
+  /** The group runs the code runner instead of the chat runner. Spawn-time; flip takes effect on respawn. */
+  codeMode?: boolean;
+  /** Per-group permission posture override. Absent = follow the
+   *  deployment default (NANOCLAW_CODE_PERMISSION_MODE); group wins when set. */
+  codePermissionMode?: 'auto' | 'bypass';
   /** Session isolation tier for the group's containers; absent = the composer's default ('container'). */
   runtimeTier?: 'container' | 'vm';
 }
@@ -382,6 +387,11 @@ export function configFromDb(row: ContainerConfigRow, group: AgentGroup): Contai
     // A cleared group value falls back to the install-wide default.
     ...speedFields(parseContainerSpeed(row.speed) ?? (FAST_MODE ? 'fast' : undefined)),
     timezone: row.timezone && isValidTimezone(row.timezone) ? row.timezone : undefined,
+    codeMode: row.code_mode === 1 || undefined,
+    // A hand-edited DB value must not silently pick a posture: anything but
+    // the two known modes reads as "no override" (the timezone rule).
+    codePermissionMode:
+      row.permission_mode === 'auto' || row.permission_mode === 'bypass' ? row.permission_mode : undefined,
     runtimeTier: parseRuntimeTier(row.runtime_tier, group.name),
   };
 }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -25,6 +25,14 @@ import {
   TIMEZONE,
 } from './config.js';
 import { CONTAINER_PLUGINS_DIR, materializeContainerJson } from './container-config.js';
+import { devInstructionMounts } from './code-mode/compose.js';
+import {
+  boundaryDecisionMounts,
+  deploymentPermissionMode,
+  managedSettingsMounts,
+  resolveCodePermissionMode,
+} from './code-mode/permissions.js';
+import { readEnvFile } from './env.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { updateContainerConfigScalars } from './db/container-configs.js';
 import { CONTAINER_RUNTIME_BIN } from './container-runtime.js';
@@ -819,6 +827,12 @@ export async function buildMounts(
   // Undeclared payloads stay on the legacy capability gate. Declared payloads
   // are realized below from their contract.
   const defaultSurfaces = !contract && !providerProvidesAgentSurfaces(provider);
+  // Code mode strips chat COMPOSITION, not capabilities: the composed project
+  // document, stamped plugins, skill views and the shared skills tree stay
+  // host-side, while provider state volumes (settings, credential state) still
+  // mount — the coding agent is still a provider session. Its own instruction
+  // surface is stamped below (code-mode/compose.ts).
+  const chatSurfaces = containerConfig.codeMode !== true;
 
   const groupDir = path.resolve(GROUPS_DIR, agentGroup.folder);
   const claudeDir = path.join(DATA_DIR, 'v2-sessions', agentGroup.id, '.claude-shared');
@@ -828,7 +842,7 @@ export async function buildMounts(
   const lateStateVolumeMounts = new Map<string, VolumeMount>();
   const lateSkillViewMounts = new Map<string, VolumeMount[]>();
   let skillBackingPaths = new Map<string, string>();
-  if (contract) {
+  if (contract && chatSurfaces) {
     providerSurfaces ??= await realizeProviderSpawnSurfaces(
       provider,
       contract,
@@ -842,7 +856,7 @@ export async function buildMounts(
       },
     );
     skillBackingPaths = providerSurfaces.skillBackingPaths;
-  } else if (defaultSurfaces) {
+  } else if (defaultSurfaces && chatSurfaces) {
     syncSkillSymlinks(claudeDir, containerConfig);
 
     // Compose CLAUDE.md fresh every spawn: every instruction source inlined
@@ -851,6 +865,10 @@ export async function buildMounts(
   }
 
   const mounts: VolumeMount[] = [];
+  // The code runner's cwd (/workspace/group) must exist host-side before the
+  // runtime would create it as root. Prepared in every mode, so a group later
+  // flipped to code mode keeps a directory the host can still write into.
+  fs.mkdirSync(path.join(sessDir, 'group'), { recursive: true });
   const scope = agentGroup.id;
 
   // Session workspace: mailbox-selected state plus outbox and heartbeat files.
@@ -897,19 +915,25 @@ export async function buildMounts(
   // whose read-only rule is enforced instead of chosen. It lives under the
   // group folder rather than an install root, so the mount policy pins it
   // through the group-folder label — see `stampedPluginsRoot`.
-  mounts.push({
-    hostPath: path.join(groupDir, 'plugins'),
-    containerPath: CONTAINER_PLUGINS_DIR,
-    readonly: true,
-    mountClass: 'install-surface',
-    scope,
-  });
+  //
+  // Chat surfaces only: stamped plugins are chat-agent composition (skills,
+  // MCP servers, persona); code mode strips them with the rest of the composed
+  // surface, while plugin-data/ stays reachable through the group mount.
+  if (chatSurfaces) {
+    mounts.push({
+      hostPath: path.join(groupDir, 'plugins'),
+      containerPath: CONTAINER_PLUGINS_DIR,
+      readonly: true,
+      mountClass: 'install-surface',
+      scope,
+    });
+  }
 
   // The composed project document — one nested RO mount on top of the RW group
   // dir, holding the full text of every instruction source. `container/CLAUDE.md`
   // is read on the host at compose time, so nothing needs it inside the container.
   const composedProjectDocument = path.join(groupDir, projectDocument?.fileName ?? DEFAULT_PROJECT_DOC.fileName);
-  if ((projectDocument || defaultSurfaces) && fs.existsSync(composedProjectDocument)) {
+  if (chatSurfaces && (projectDocument || defaultSurfaces) && fs.existsSync(composedProjectDocument)) {
     const mount = {
       hostPath: composedProjectDocument,
       containerPath: projectDocument?.containerPath ?? '/workspace/agent/CLAUDE.md',
@@ -919,6 +943,22 @@ export async function buildMounts(
     } satisfies VolumeMount;
     if (mount.mountClass === 'allowlisted-extra') lateProjectDocumentMount = mount;
     else mounts.push(mount);
+  }
+
+  // Code-mode surfaces: the operating manual and dev skills the interactive
+  // CLI reads at its cwd, the host-owned permission policy at the CLI's admin
+  // tier, and the boundary decision dir the agent can read but never write.
+  // Every helper stamps outside the RW workspace and never throws.
+  if (containerConfig.codeMode) {
+    mounts.push(...devInstructionMounts(sessDir, scope));
+    mounts.push(
+      ...managedSettingsMounts(
+        sessDir,
+        scope,
+        resolveCodePermissionMode(containerConfig.codePermissionMode, deploymentPermissionMode()),
+      ),
+    );
+    mounts.push(...boundaryDecisionMounts(sessDir, scope));
   }
 
   // Per-group .claude-shared at /home/node/.claude (provider state, settings,
@@ -936,7 +976,7 @@ export async function buildMounts(
       if (mount.mountClass === 'allowlisted-extra') lateStateVolumeMounts.set(volume.id, mount);
       else mounts.push(mount);
     }
-    for (const view of contract.skillViews) {
+    for (const view of chatSurfaces ? contract.skillViews : []) {
       const hostPath = skillBackingPaths.get(view.backingId);
       if (!hostPath)
         throw new Error(`Provider '${provider}' skill view references unknown backing '${view.backingId}'`);
@@ -977,7 +1017,7 @@ export async function buildMounts(
 
   // Shared skills — read-only, symlinks in .claude-shared/skills/ point here.
   const skillsSrc = path.join(projectRoot, 'container', 'skills');
-  if (fs.existsSync(skillsSrc)) {
+  if (chatSurfaces && fs.existsSync(skillsSrc)) {
     mounts.push({
       hostPath: skillsSrc,
       containerPath: '/app/skills',
@@ -1000,7 +1040,7 @@ export async function buildMounts(
       const mount = lateStateVolumeMounts.get(volume.id);
       if (mount) mounts.push(mount);
     }
-    for (const backing of contract.skillBackings) {
+    for (const backing of chatSurfaces ? contract.skillBackings : []) {
       mounts.push(...(lateSkillViewMounts.get(backing.id) ?? []));
     }
     if (lateProjectDocumentMount) mounts.push(lateProjectDocumentMount);
@@ -1027,6 +1067,13 @@ export function toMountSpecs(mounts: readonly VolumeMount[], defaultScope: strin
     groupScope: mount.scope ?? defaultScope,
   }));
 }
+
+/**
+ * The code runner's start line: the runner package's named script, run from
+ * the image's package root (`/app` holds the baked package.json and
+ * node_modules; `/app/src` is the host-mounted source both runners share).
+ */
+export const CODE_RUNNER_START = 'cd /app && exec bun run start:code';
 
 export interface ComposeSessionSpecInput {
   agentGroup: AgentGroup;
@@ -1081,6 +1128,53 @@ export function composeSessionSpec(input: ComposeSessionSpecInput): SessionSpec 
     ...(gateway.env ?? {}),
   };
 
+  // Code-mode configuration, forwarded to the code runner. The gateway
+  // provider owns credential placeholders; extra env never enters that lane
+  // and never overrides a key already set.
+  if (containerConfig.codeMode) {
+    if (containerConfig.provider && containerConfig.provider !== 'claude') {
+      throw new Error('code mode currently supports only Claude Code; set the group provider to claude');
+    }
+    const settings = [
+      'NANOCLAW_CODE_IDLE_TTL_MS',
+      'NANOCLAW_CODE_ATTACH_IDLE_TTL_MS',
+      'NANOCLAW_CODE_PERMISSION_MODE',
+      'NANOCLAW_CODE_CHANNELS',
+      'NANOCLAW_CODE_ENV',
+    ] as const;
+    const fromFile = readEnvFile([...settings]);
+    const setting = (name: (typeof settings)[number]): string | undefined =>
+      process.env[name]?.trim() || fromFile[name]?.trim() || undefined;
+    for (const name of settings) {
+      if (name === 'NANOCLAW_CODE_ENV') continue;
+      const value =
+        name === 'NANOCLAW_CODE_PERMISSION_MODE'
+          ? (containerConfig.codePermissionMode ?? setting(name))
+          : setting(name);
+      if (value) env[name] = value;
+    }
+    const extra = setting('NANOCLAW_CODE_ENV');
+    if (extra) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(extra);
+      } catch (error) {
+        throw new Error('NANOCLAW_CODE_ENV must be valid JSON', { cause: error });
+      }
+      if (
+        !parsed ||
+        typeof parsed !== 'object' ||
+        Array.isArray(parsed) ||
+        Object.values(parsed).some((value) => typeof value !== 'string')
+      ) {
+        throw new Error('NANOCLAW_CODE_ENV must be a JSON object of strings');
+      }
+      for (const [key, value] of Object.entries(parsed as Record<string, string>)) {
+        if (!(key in env)) env[key] = value;
+      }
+    }
+  }
+
   const hostUid = process.getuid?.();
   const hostGid = process.getgid?.();
   // The spec contract (drivers/types.ts, `runAs`): the identity that must read
@@ -1104,8 +1198,12 @@ export function composeSessionSpec(input: ComposeSessionSpecInput): SessionSpec 
     env,
     // Run the v2 entry point directly (no tsc, no stdin). The driver maps the
     // 'standard' posture's PID-1 requirement onto this: Docker adds `--init`.
+    // Runner-type selection happens here and nowhere else: both runners ride
+    // the same image and the same /app/src mount. A code-mode group starts
+    // the runner package's `start:code` script (container/agent-runner
+    // package.json names both runners); the chat runner's line is untouched.
     command: ['bash', '-c'],
-    args: ['exec bun run /app/src/index.ts'],
+    args: [containerConfig.codeMode ? CODE_RUNNER_START : 'exec bun run /app/src/index.ts'],
     mounts: mergeMounts(toMountSpecs(mounts, agentGroup.id), gateway.mounts ?? []),
     contributedEnv,
   };

--- a/src/db/container-configs.ts
+++ b/src/db/container-configs.ts
@@ -12,6 +12,8 @@ const SCALAR_COLUMNS = new Set([
   'cli_scope',
   'timezone',
   'speed',
+  'code_mode',
+  'permission_mode',
 ]);
 const JSON_COLUMNS = new Set(['skills', 'mcp_servers', 'packages_apt', 'packages_npm', 'additional_mounts']);
 
@@ -88,6 +90,8 @@ export async function updateContainerConfigScalars(
       | 'cli_scope'
       | 'timezone'
       | 'speed'
+      | 'code_mode'
+      | 'permission_mode'
     >
   >,
 ): Promise<void> {

--- a/src/db/db-v2.test.ts
+++ b/src/db/db-v2.test.ts
@@ -37,6 +37,12 @@ import {
   ensureContainerConfig,
   updateContainerConfigScalars,
 } from './index.js';
+import {
+  SANDBOX_SYSTEM_THREAD_ID,
+  findAttachableSessions,
+  findSandboxSessions,
+  findSessionByAgentGroup,
+} from './sessions.js';
 
 function now() {
   return new Date().toISOString();
@@ -396,6 +402,33 @@ describe('sessions', () => {
     await createSession(sess());
     await deleteSession('sess-1');
     expect(await getSession('sess-1')).toBeUndefined();
+  });
+
+  it('sandbox sessions: found by the scoped query, appended to the attach view', async () => {
+    await createSession({
+      ...sess(),
+      id: 'sess-sandbox',
+      messaging_group_id: null,
+      thread_id: SANDBOX_SYSTEM_THREAD_ID,
+    });
+    await createSession(sess()); // channel-wired
+    expect((await findSandboxSessions('ag-1')).map((s) => s.id)).toEqual(['sess-sandbox']);
+    // The channel-wired session keeps winning the wake choice (index 0);
+    // the sandbox session is appended, never mixed in.
+    expect((await findAttachableSessions('ag-1')).map((s) => s.id)).toEqual(['sess-1', 'sess-sandbox']);
+  });
+
+  it('sandbox sessions: invisible to chat routing (agent-shared resolution)', async () => {
+    await createSession({
+      ...sess(),
+      id: 'sess-sandbox',
+      messaging_group_id: null,
+      thread_id: SANDBOX_SYSTEM_THREAD_ID,
+    });
+    // A sandbox-only group must attach, yet look sessionless to resolveSession's
+    // agent-shared path — the composed-query pattern keeps the filter intact.
+    expect(await findSessionByAgentGroup('ag-1')).toBeUndefined();
+    expect((await findAttachableSessions('ag-1')).map((s) => s.id)).toEqual(['sess-sandbox']);
   });
 });
 

--- a/src/db/migrations/registered-modules.ts
+++ b/src/db/migrations/registered-modules.ts
@@ -1,0 +1,11 @@
+/**
+ * Module migrations, in one place.
+ *
+ * Every module that contributes a `module:<owner>:<name>` migration registers
+ * it at import time. The host loads those modules through its own barrels;
+ * the standalone migration command (scripts/migrate.ts) does not, so it
+ * imports this file to see the same set. A module that registers a migration
+ * appends its import here — the host and the command then agree on what
+ * "current" means.
+ */
+export {};

--- a/src/db/migrations/registered-modules.ts
+++ b/src/db/migrations/registered-modules.ts
@@ -8,4 +8,4 @@
  * appends its import here — the host and the command then agree on what
  * "current" means.
  */
-export {};
+import '../../code-mode/index.js';

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -5,6 +5,14 @@ import { getDb, hasTable } from './connection.js';
 
 export const TASKS_SYSTEM_THREAD_ID = 'system:tasks';
 
+/**
+ * Thread id of a group's sandbox session (`ncl sandboxes new`). An explicit
+ * system thread, not a NULL/NULL row: a NULL/NULL session would silently
+ * become the group's agent-shared channel session if the group were later
+ * wired to a channel — the sandbox session must stay invisible to chat routing.
+ */
+export const SANDBOX_SYSTEM_THREAD_ID = 'system:sandbox';
+
 export async function createSession(session: Session): Promise<void> {
   await getDb().run(
     `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, agent_provider, status, container_status, last_active, created_at)
@@ -57,6 +65,42 @@ export async function findSessionForAgent(
     agentGroupId,
     messagingGroupId,
   );
+}
+
+/**
+ * All active sessions for an agent group (excluding system task threads),
+ * newest first. A group can hold several — one per wired messaging
+ * group/thread — and callers that need "the one with a live container"
+ * (groups attach) must scan them all, not just the newest.
+ */
+export async function findActiveSessionsByAgentGroup(agentGroupId: string): Promise<Session[]> {
+  return getDb().all<Session>(
+    `SELECT * FROM sessions
+     WHERE agent_group_id = ?
+       AND status = 'active'
+       AND NOT (messaging_group_id IS NULL AND thread_id IS NOT NULL AND thread_id LIKE 'system:%')
+     ORDER BY created_at DESC`,
+    agentGroupId,
+  );
+}
+
+/**
+ * The attach view of a group's active sessions: channel-wired sessions
+ * first (newest first), then system task sessions (newest first), then the
+ * sandbox session. On a box whose only sessions are task-created (headless,
+ * schedule-driven) or sandbox-created (`sandboxes new`), attach must still
+ * have a sandbox session — but when a channel-wired session exists it is the one an
+ * operator means, so it wins the wake choice (attach wakes index 0).
+ * Composed from the scoped queries rather than relaxing any of them:
+ * resolveSession's agent-shared mode rides findSessionByAgentGroup and must
+ * keep never seeing system threads.
+ */
+export async function findAttachableSessions(agentGroupId: string): Promise<Session[]> {
+  return [
+    ...(await findActiveSessionsByAgentGroup(agentGroupId)),
+    ...(await findTaskSessions(agentGroupId)),
+    ...(await findSandboxSessions(agentGroupId)),
+  ];
 }
 
 /** Find an active session scoped to an agent group (ignoring messaging group). */
@@ -112,6 +156,20 @@ export async function findTaskSessions(agentGroupId: string, includeClosed = fal
     agentGroupId,
     TASKS_SYSTEM_THREAD_ID,
     `${TASKS_SYSTEM_THREAD_ID}:%`,
+  );
+}
+
+/** All active sandbox sessions for a group — `sandboxes new` creates at most one (thread `system:sandbox`). */
+export async function findSandboxSessions(agentGroupId: string): Promise<Session[]> {
+  return getDb().all<Session>(
+    `SELECT * FROM sessions
+     WHERE agent_group_id = ?
+       AND messaging_group_id IS NULL
+       AND status = 'active'
+       AND thread_id = ?
+     ORDER BY created_at DESC`,
+    agentGroupId,
+    SANDBOX_SYSTEM_THREAD_ID,
   );
 }
 
@@ -320,4 +378,12 @@ export async function getAskQuestionRender(id: string): Promise<
   }
 
   return undefined;
+}
+
+/** move an approval row between hold states. */
+export async function updatePendingApprovalStatus(
+  approvalId: string,
+  status: PendingApproval['status'],
+): Promise<void> {
+  await getDb().run('UPDATE pending_approvals SET status = ? WHERE approval_id = ?', status, approvalId);
 }

--- a/src/drivers/docker-api.test.ts
+++ b/src/drivers/docker-api.test.ts
@@ -1,0 +1,225 @@
+/**
+ * The interactive exec over the daemon's API against a fake daemon on a
+ * unix socket: create, the hijacked start, raw bytes both ways under a TTY,
+ * resize, the exit code, stdout/stderr demultiplexing without a TTY, and
+ * the daemon's own messages on failure. Plus where the socket is found.
+ */
+import http from 'node:http';
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Cli } from './cli.js';
+import { demultiplex, dockerExecStream, resolveDockerSocket } from './docker-api.js';
+
+const SOCKET = `/tmp/nanoclaw-docker-api-${process.pid}.sock`;
+
+interface FakeDaemon {
+  server: http.Server;
+  execs: Map<string, { container: string; body: Record<string, unknown> }>;
+  resizes: { id: string; h: string; w: string }[];
+  exitCode: number;
+  upgrade: boolean;
+  /** Hijacked sockets, which the http server no longer tracks. */
+  sockets: Set<import('node:stream').Duplex>;
+}
+
+function frame(type: 1 | 2, text: string): Buffer {
+  const payload = Buffer.from(text);
+  const header = Buffer.alloc(8);
+  header[0] = type;
+  header.writeUInt32BE(payload.length, 4);
+  return Buffer.concat([header, payload]);
+}
+
+function startFakeDaemon(): Promise<FakeDaemon> {
+  const daemon: FakeDaemon = {
+    server: http.createServer(),
+    execs: new Map(),
+    resizes: [],
+    exitCode: 7,
+    upgrade: true,
+    sockets: new Set(),
+  };
+  let next = 1;
+  daemon.server.on('request', (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://docker');
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = chunks.length ? (JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>) : {};
+      const json = (status: number, value: unknown): void => {
+        res.writeHead(status, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(value));
+      };
+      let m: RegExpMatchArray | null;
+      if (req.method === 'POST' && (m = url.pathname.match(/^\/containers\/([^/]+)\/exec$/))) {
+        const container = decodeURIComponent(m[1]);
+        if (container === 'missing') return json(404, { message: 'No such container: missing' });
+        const id = `exec-${next++}`;
+        daemon.execs.set(id, { container, body });
+        return json(201, { Id: id });
+      }
+      if (req.method === 'POST' && (m = url.pathname.match(/^\/exec\/([^/]+)\/resize$/))) {
+        daemon.resizes.push({ id: m[1], h: url.searchParams.get('h') ?? '', w: url.searchParams.get('w') ?? '' });
+        return json(200, {});
+      }
+      if (req.method === 'GET' && (m = url.pathname.match(/^\/exec\/([^/]+)\/json$/))) {
+        return json(200, { Running: false, ExitCode: daemon.exitCode });
+      }
+      if (req.method === 'POST' && url.pathname.match(/^\/exec\/([^/]+)\/start$/)) {
+        // A daemon that does not upgrade (the client must treat this as failure).
+        return json(200, { message: 'streamed without upgrade' });
+      }
+      json(404, { message: `page not found: ${req.method} ${url.pathname}` });
+    });
+  });
+  daemon.server.on('upgrade', (req, socket, head) => {
+    daemon.sockets.add(socket);
+    socket.on('error', () => {});
+    socket.on('close', () => daemon.sockets.delete(socket));
+    const m = (req.url ?? '').match(/^\/exec\/([^/]+)\/start$/);
+    const exec = m ? daemon.execs.get(m[1]) : undefined;
+    if (!exec || !daemon.upgrade) {
+      socket.end('HTTP/1.1 404 Not Found\r\ncontent-type: application/json\r\n\r\n{"message":"no such exec"}');
+      return;
+    }
+    socket.write('HTTP/1.1 101 UPGRADED\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n');
+    void head;
+    if (exec.body.Tty) {
+      socket.write('ready\r\n');
+      socket.on('data', (data: Buffer) => {
+        const input = data.toString();
+        if (input.includes('quit')) socket.end();
+        else socket.write(input.toUpperCase());
+      });
+    } else {
+      socket.write(frame(1, 'out\n'));
+      socket.write(frame(2, 'err\n'));
+      socket.end();
+    }
+  });
+  return new Promise((resolve) => daemon.server.listen(SOCKET, () => resolve(daemon)));
+}
+
+async function read(stream: NodeJS.ReadableStream, until: (text: string) => boolean): Promise<string> {
+  let text = '';
+  return new Promise((resolve) => {
+    const onData = (chunk: Buffer): void => {
+      text += chunk.toString();
+      if (until(text)) {
+        stream.off('data', onData);
+        resolve(text);
+      }
+    };
+    stream.on('data', onData);
+    stream.on('end', () => resolve(text));
+  });
+}
+
+let daemon: FakeDaemon;
+
+beforeEach(async () => {
+  daemon = await startFakeDaemon();
+});
+
+afterEach(async () => {
+  for (const socket of daemon.sockets) socket.destroy();
+  daemon.server.closeAllConnections();
+  await new Promise<void>((resolve) => daemon.server.close(() => resolve()));
+});
+
+describe('dockerExecStream', () => {
+  it('creates a TTY exec sized from the caller, hijacks it, pumps bytes both ways, resizes, and reports the exit code', async () => {
+    const exec = await dockerExecStream(SOCKET, 'ncl-sess-1', ['sh', '-c', 'tmux attach'], {
+      tty: true,
+      cols: 80,
+      rows: 24,
+    });
+    const created = daemon.execs.get('exec-1')!;
+    expect(created.container).toBe('ncl-sess-1');
+    expect(created.body).toMatchObject({
+      Tty: true,
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      Cmd: ['sh', '-c', 'tmux attach'],
+      ConsoleSize: [24, 80],
+    });
+    expect(daemon.resizes).toEqual([{ id: 'exec-1', h: '24', w: '80' }]);
+    expect(exec.stderr).toBeUndefined();
+
+    expect(await read(exec.stdout, (t) => t.includes('ready'))).toContain('ready\r\n');
+    const echoed = read(exec.stdout, (t) => t.includes('HELLO'));
+    exec.stdin.write('hello');
+    expect(await echoed).toContain('HELLO');
+
+    await exec.resize(120, 40);
+    expect(daemon.resizes.at(-1)).toEqual({ id: 'exec-1', h: '40', w: '120' });
+
+    exec.stdin.write('quit');
+    expect(await exec.exited).toBe(7);
+  });
+
+  it('demultiplexes stdout and stderr without a TTY and ends both', async () => {
+    const exec = await dockerExecStream(SOCKET, 'ncl-sess-2', ['ls'], { tty: false });
+    expect(daemon.execs.get('exec-1')!.body).toMatchObject({ Tty: false, Cmd: ['ls'] });
+    expect(daemon.execs.get('exec-1')!.body.ConsoleSize).toBeUndefined();
+    expect(daemon.resizes).toEqual([]);
+    const [out, err] = await Promise.all([read(exec.stdout, () => false), read(exec.stderr!, () => false)]);
+    expect(out).toBe('out\n');
+    expect(err).toBe('err\n');
+    expect(await exec.exited).toBe(7);
+  });
+
+  it('hangs up on close and reports the daemon’s messages on failure', async () => {
+    const exec = await dockerExecStream(SOCKET, 'ncl-sess-3', ['sh'], { tty: true });
+    daemon.exitCode = 129;
+    exec.close();
+    expect(await exec.exited).toBe(129);
+
+    await expect(dockerExecStream(SOCKET, 'missing', ['sh'], { tty: true })).rejects.toThrow(
+      /docker exec create failed: No such container: missing/,
+    );
+    daemon.upgrade = false;
+    await expect(dockerExecStream(SOCKET, 'ncl-sess-4', ['sh'], { tty: true })).rejects.toThrow(
+      /docker exec start failed/,
+    );
+  });
+});
+
+describe('demultiplex', () => {
+  it('reassembles frames split across chunks', async () => {
+    const input = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    demultiplex(input, stdout, stderr);
+    const bytes = Buffer.concat([frame(1, 'hello '), frame(2, 'warn'), frame(1, 'world')]);
+    for (let i = 0; i < bytes.length; i += 5) input.write(bytes.subarray(i, i + 5));
+    input.end();
+    const [out, err] = await Promise.all([read(stdout, () => false), read(stderr, () => false)]);
+    expect(out).toBe('hello world');
+    expect(err).toBe('warn');
+  });
+});
+
+describe('resolveDockerSocket', () => {
+  const cli = (host: string): Cli => ({ bin: 'docker', run: vi.fn(() => `${host}\n`), start: vi.fn() });
+
+  it('prefers DOCKER_HOST, then the system socket, then Docker Desktop’s, then the CLI context', () => {
+    const none = (): boolean => false;
+    expect(resolveDockerSocket({ env: { DOCKER_HOST: 'unix:///srv/docker.sock' }, exists: none })).toBe(
+      '/srv/docker.sock',
+    );
+    expect(resolveDockerSocket({ env: {}, exists: (p) => p === '/var/run/docker.sock' })).toBe('/var/run/docker.sock');
+    expect(
+      resolveDockerSocket({ env: {}, homeDir: '/home/a', exists: (p) => p === '/home/a/.docker/run/docker.sock' }),
+    ).toBe('/home/a/.docker/run/docker.sock');
+    expect(resolveDockerSocket({ env: {}, exists: none, cli: cli('unix:///ctx/docker.sock') })).toBe(
+      '/ctx/docker.sock',
+    );
+    expect(resolveDockerSocket({ env: {}, exists: none, cli: cli('tcp://10.0.0.1:2375') })).toBe(
+      '/var/run/docker.sock',
+    );
+    expect(resolveDockerSocket({ env: { DOCKER_HOST: 'tcp://x' }, exists: none })).toBe('/var/run/docker.sock');
+  });
+});

--- a/src/drivers/docker-api.ts
+++ b/src/drivers/docker-api.ts
@@ -1,0 +1,212 @@
+/**
+ * The slice of the Docker Engine API the driver needs beyond its CLI: an
+ * interactive exec whose byte stream the host itself holds. `docker exec -it`
+ * gives a terminal to a process the host spawns; a remote terminal session
+ * has no process to give it to, so the host creates the exec, starts it
+ * with a hijacked connection, pipes bytes both ways, and resizes it as the
+ * far terminal changes. With a TTY the stream is raw; without one Docker
+ * multiplexes stdout and stderr into framed records, demultiplexed here.
+ */
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import { PassThrough, type Readable, type Writable } from 'node:stream';
+
+import type { Cli } from './cli.js';
+import type { SessionExecOptions, SessionExecStream } from './types.js';
+
+/** Where the daemon listens, in order: `DOCKER_HOST`, the system socket, Docker Desktop's, the CLI's context. */
+export function resolveDockerSocket({
+  env = process.env,
+  homeDir = os.homedir(),
+  cli,
+  exists = fs.existsSync,
+}: {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  cli?: Cli;
+  exists?: (path: string) => boolean;
+} = {}): string {
+  const fromEnv = env.DOCKER_HOST;
+  if (fromEnv?.startsWith('unix://')) return fromEnv.slice('unix://'.length);
+  const system = '/var/run/docker.sock';
+  if (exists(system)) return system;
+  const desktop = `${homeDir}/.docker/run/docker.sock`;
+  if (exists(desktop)) return desktop;
+  if (cli) {
+    try {
+      const host = cli
+        .run(['context', 'inspect', '--format', '{{.Endpoints.docker.Host}}'], { timeoutMs: 5000 })
+        .trim();
+      if (host.startsWith('unix://')) return host.slice('unix://'.length);
+    } catch (error) {
+      if (!(error instanceof Error)) throw error;
+      // No usable context; the system path below is the daemon's own default.
+    }
+  }
+  return system;
+}
+
+interface Reply {
+  status: number;
+  body: string;
+}
+
+function request(socketPath: string, method: string, path: string, body?: unknown): Promise<Reply> {
+  return new Promise((resolve, reject) => {
+    const payload = body === undefined ? undefined : JSON.stringify(body);
+    const req = http.request(
+      {
+        socketPath,
+        method,
+        path,
+        // One connection per request: a pooled connection to a daemon that
+        // went away (or a different daemon on the same path later) fails
+        // with a broken pipe instead of a clean reconnect.
+        agent: false,
+        headers: payload ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) } : {},
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') }));
+        res.on('error', reject);
+      },
+    );
+    req.on('error', reject);
+    req.end(payload);
+  });
+}
+
+function daemonMessage(reply: Reply): string {
+  try {
+    const parsed = JSON.parse(reply.body) as { message?: unknown };
+    if (typeof parsed.message === 'string') return parsed.message;
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error;
+  }
+  return reply.body.trim() || `status ${reply.status}`;
+}
+
+/** Split Docker's non-TTY attach stream (8-byte header: type, 0, 0, 0, size BE) into stdout and stderr. */
+export function demultiplex(input: Readable, stdout: Writable, stderr: Writable): void {
+  let pending: Buffer = Buffer.alloc(0);
+  input.on('data', (chunk: Buffer) => {
+    pending = pending.length ? Buffer.concat([pending, chunk]) : chunk;
+    for (;;) {
+      if (pending.length < 8) return;
+      const size = pending.readUInt32BE(4);
+      if (pending.length < 8 + size) return;
+      const payload = pending.subarray(8, 8 + size);
+      (pending[0] === 2 ? stderr : stdout).write(payload);
+      pending = pending.subarray(8 + size);
+    }
+  });
+  input.on('end', () => {
+    stdout.end();
+    stderr.end();
+  });
+}
+
+const EXIT_POLL_MS = 200;
+const EXIT_POLL_ROUNDS = 10;
+
+/** Create and start an exec against `container`, hijacking its stream. */
+export async function dockerExecStream(
+  socketPath: string,
+  container: string,
+  command: string[],
+  options: SessionExecOptions,
+): Promise<SessionExecStream> {
+  const created = await request(socketPath, 'POST', `/containers/${encodeURIComponent(container)}/exec`, {
+    AttachStdin: true,
+    AttachStdout: true,
+    AttachStderr: true,
+    Tty: options.tty,
+    Cmd: command,
+    ...(options.env ? { Env: options.env } : {}),
+    ...(options.tty && options.cols && options.rows ? { ConsoleSize: [options.rows, options.cols] } : {}),
+  });
+  if (created.status !== 201) throw new Error(`docker exec create failed: ${daemonMessage(created)}`);
+  const { Id: id } = JSON.parse(created.body) as { Id: string };
+
+  const socket = await new Promise<import('node:net').Socket>((resolve, reject) => {
+    const payload = JSON.stringify({ Detach: false, Tty: options.tty });
+    const req = http.request({
+      socketPath,
+      method: 'POST',
+      path: `/exec/${id}/start`,
+      agent: false,
+      headers: {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(payload),
+        connection: 'Upgrade',
+        upgrade: 'tcp',
+      },
+    });
+    req.on('upgrade', (_res, upgraded, head) => {
+      // A late error (the far side gone, a write after hang-up) ends the
+      // stream; 'close' follows and the exit code is read from the daemon.
+      upgraded.on('error', () => {});
+      if (head.length) upgraded.unshift(head);
+      resolve(upgraded);
+    });
+    req.on('response', (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () =>
+        reject(
+          new Error(
+            `docker exec start failed: ${daemonMessage({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') })}`,
+          ),
+        ),
+      );
+    });
+    req.on('error', reject);
+    req.end(payload);
+  });
+
+  const resize = async (cols: number, rows: number): Promise<void> => {
+    const reply = await request(socketPath, 'POST', `/exec/${id}/resize?h=${Math.max(1, rows)}&w=${Math.max(1, cols)}`);
+    // A finished exec cannot be resized; that is not an error for the caller.
+    if (reply.status >= 500) throw new Error(`docker exec resize failed: ${daemonMessage(reply)}`);
+  };
+
+  const exited = new Promise<number>((resolve) => {
+    socket.once('close', () => {
+      void (async () => {
+        for (let round = 0; round < EXIT_POLL_ROUNDS; round++) {
+          const reply = await request(socketPath, 'GET', `/exec/${id}/json`).catch(() => undefined);
+          if (reply?.status === 200) {
+            const state = JSON.parse(reply.body) as { Running?: boolean; ExitCode?: number | null };
+            if (!state.Running && typeof state.ExitCode === 'number') return resolve(state.ExitCode);
+          }
+          await new Promise((wait) => setTimeout(wait, EXIT_POLL_MS));
+        }
+        resolve(1);
+      })();
+    });
+  });
+
+  let stdout: Readable = socket;
+  let stderr: Readable | undefined;
+  if (!options.tty) {
+    const out = new PassThrough();
+    const err = new PassThrough();
+    demultiplex(socket, out, err);
+    stdout = out;
+    stderr = err;
+  } else if (options.cols && options.rows) {
+    // The initial size may predate the daemon's support for it at create; set it now that the exec runs.
+    await resize(options.cols, options.rows).catch(() => {});
+  }
+
+  return {
+    stdin: socket,
+    stdout,
+    ...(stderr ? { stderr } : {}),
+    resize,
+    exited,
+    close: () => socket.destroy(),
+  };
+}

--- a/src/drivers/docker-driver.ts
+++ b/src/drivers/docker-driver.ts
@@ -23,6 +23,7 @@ import fs from 'fs';
 import { log } from '../log.js';
 
 import { realCli, validateRuntimeName, type Cli, type SupervisedProcess } from './cli.js';
+import { dockerExecStream, resolveDockerSocket } from './docker-api.js';
 import { JsonDocumentStream } from './json-stream.js';
 import {
   LABELS,
@@ -36,7 +37,9 @@ import {
   type MountSpec,
   type SessionDriver,
   type SessionEvent,
+  type SessionExecOptions,
   type SessionExecSpec,
+  type SessionExecStream,
   type SessionFailure,
   type SessionHandle,
   type SessionKey,
@@ -49,6 +52,8 @@ import {
 
 export interface DockerDriverOptions extends MountPolicy {
   cli?: Cli;
+  /** The daemon's unix socket for interactive execs; resolved from the environment when omitted. */
+  dockerSocket?: string;
   /** Docker network the session's containers attach to, resolved by the overlay. */
   networkArgsFor?: (spec: SessionSpec) => string[];
 }
@@ -76,10 +81,18 @@ export class DockerSessionDriver implements SessionDriver {
    */
   readonly #knownKeys = new Map<string, Map<string, SessionKey>>();
 
+  #socketPath?: string;
+
   constructor(private readonly opts: DockerDriverOptions) {
     this.#cli = opts.cli ?? realCli('docker');
     this.#policy = opts;
   }
+
+  /** Resolved once, on first interactive exec. */
+  readonly #dockerSocket = (): string => {
+    this.#socketPath ??= this.opts.dockerSocket ?? resolveDockerSocket({ cli: this.#cli });
+    return this.#socketPath;
+  };
 
   capabilities(): DriverCapabilities {
     return {
@@ -126,7 +139,7 @@ export class DockerSessionDriver implements SessionDriver {
 
     // Idempotency on key: an existing live container for this key is the session.
     if (this.#existingSession(name, spec.key)) {
-      return new DockerHandle(spec.key, name, this.#cli, null, this.#emit);
+      return new DockerHandle(spec.key, name, this.#cli, null, this.#emit, this.#dockerSocket);
     }
 
     // Composition existsSync-gates mount sources; re-check here so a
@@ -171,7 +184,7 @@ export class DockerSessionDriver implements SessionDriver {
       }
       throw normalizeDockerError(error);
     }
-    return new DockerHandle(spec.key, name, this.#cli, spec, this.#emit);
+    return new DockerHandle(spec.key, name, this.#cli, spec, this.#emit, this.#dockerSocket);
   }
 
   async listSessions(installSlug: string): Promise<SessionSnapshot[]> {
@@ -203,7 +216,7 @@ export class DockerSessionDriver implements SessionDriver {
         const key: SessionKey = { installSlug, agentGroupId, sessionId };
         this.#remember(key);
         return {
-          handle: new DockerHandle(key, name, this.#cli, null, this.#emit),
+          handle: new DockerHandle(key, name, this.#cli, null, this.#emit, this.#dockerSocket),
           phase: dockerStatePhase(state),
         };
       });
@@ -455,6 +468,7 @@ class DockerHandle implements SessionHandle {
     /** Present only between prepare and start; null for an adopted handle. */
     private readonly pendingSpec: SessionSpec | null,
     private readonly emit: (event: SessionEvent) => void,
+    private readonly dockerSocket: () => string,
   ) {}
 
   async start(): Promise<void> {
@@ -546,6 +560,11 @@ class DockerHandle implements SessionHandle {
       argsTty: ['exec', '-it', this.name, ...command],
       argsPlain: ['exec', '-i', this.name, ...command],
     };
+  }
+
+  /** The same exec, held by the caller: created and hijacked through the daemon's API. */
+  execStream(command: string[], options: SessionExecOptions): Promise<SessionExecStream> {
+    return dockerExecStream(this.dockerSocket(), this.name, command, options);
   }
 }
 

--- a/src/drivers/session-events.ts
+++ b/src/drivers/session-events.ts
@@ -218,6 +218,10 @@ class HubHandle implements SupervisedHandle {
   execSpec(command: string[]): SessionExecSpec {
     return this.inner.execSpec(command);
   }
+  get execStream(): SessionHandle['execStream'] {
+    const inner = this.inner;
+    return inner.execStream ? (command, options) => inner.execStream!(command, options) : undefined;
+  }
   stop(reason: string): Promise<void> {
     this.hub.markStopIntent(this.inner.key);
     return this.inner.stop(reason);

--- a/src/drivers/types.ts
+++ b/src/drivers/types.ts
@@ -219,6 +219,32 @@ export interface SessionExecSpec {
   argsPlain: string[];
 }
 
+export interface SessionExecOptions {
+  /** Allocate a terminal for the command (one merged stream) or keep stdout and stderr apart. */
+  tty: boolean;
+  cols?: number;
+  rows?: number;
+  /** Extra `NAME=value` entries for the command's environment. */
+  env?: string[];
+}
+
+/**
+ * A command running interactively inside the session, its bytes held by the
+ * caller rather than a spawned client program — what a remote terminal the
+ * host relays needs. With a terminal the output is one raw stream and
+ * `resize` follows the far terminal; without one, stderr arrives apart.
+ */
+export interface SessionExecStream {
+  stdin: import('node:stream').Writable;
+  stdout: import('node:stream').Readable;
+  stderr?: import('node:stream').Readable;
+  resize(cols: number, rows: number): Promise<void>;
+  /** The command's exit code, once it ends. */
+  exited: Promise<number>;
+  /** Hang up: closes the stream; a command on a terminal is hung up. */
+  close(): void;
+}
+
 export interface SessionHandle {
   key: SessionKey;
   /** Stable runtime name for logs and operator commands. */
@@ -241,6 +267,13 @@ export interface SessionHandle {
    * not a lie from this layer.
    */
   execSpec(command: string[]): SessionExecSpec;
+  /**
+   * Run `command` interactively inside the live session and hand its stream
+   * to the caller — see `SessionExecStream`. Optional: a driver that only
+   * describes attaches (`execSpec`) still satisfies the contract; a caller
+   * that needs the stream and finds none reports that.
+   */
+  execStream?(command: string[], options: SessionExecOptions): Promise<SessionExecStream>;
 }
 
 export interface DriverCapabilities {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,10 @@ import './channels/index.js';
 // mailbox composition slot. Imported for side effects.
 import './modules/index.js';
 
+// Code mode — registers the group-flag migration; behavior changes only for
+// groups whose config sets code_mode.
+import './code-mode/index.js';
+
 // CLI command barrel — populates the `ncl` registry before the CLI server
 // accepts connections.
 import './cli/commands/index.js';

--- a/src/modules/approvals/code-boundary.test.ts
+++ b/src/modules/approvals/code-boundary.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Host half of the detached boundary confirm: request file → card → click →
+ * decision file; expiry denies before the hook's own ceiling; the restart
+ * sweep denies orphans; malformed requests fail closed.
+ */
+import fs from 'fs';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-code-boundary' };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-code-boundary';
+
+import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { createPendingApproval, createSession, getPendingApprovalsByAction, updateSession } from '../../db/sessions.js';
+import type { ChannelDeliveryAdapter } from '../../delivery.js';
+import { initSessionFolder, sessionDir } from '../../session-manager.js';
+import { upsertUser } from '../permissions/db/users.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { upsertUserDm } from '../permissions/db/user-dms.js';
+import { createMessagingGroup } from '../../db/messaging-groups.js';
+import { handleApprovalsResponse } from './response-handler.js';
+import { BOUNDARY_DECISIONS_SUBDIR } from '../../code-mode/permissions.js';
+import {
+  BOUNDARY_FILE_MAX_AGE_MS,
+  BOUNDARY_SUBDIR,
+  CODE_BOUNDARY_ACTION,
+  HOST_EXPIRY_MS,
+  scanCodeBoundaryRequests,
+  startCodeBoundaryWatcher,
+  stopCodeBoundaryWatcher,
+  sweepAgedBoundaryFiles,
+} from './code-boundary.js';
+
+const GID = 'ag-boundary';
+const SID = 'sess-boundary';
+const ADMIN = 'chat:admin-1';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function makeAdapter(): ChannelDeliveryAdapter & { deliver: ReturnType<typeof vi.fn> } {
+  return { deliver: vi.fn().mockResolvedValue('msg-1') } as unknown as ChannelDeliveryAdapter & {
+    deliver: ReturnType<typeof vi.fn>;
+  };
+}
+
+function boundaryDir(): string {
+  return path.join(sessionDir(GID, SID), BOUNDARY_SUBDIR);
+}
+
+function seedRequest(id: string, at: string = now()): string {
+  fs.mkdirSync(boundaryDir(), { recursive: true });
+  const file = path.join(boundaryDir(), `${id}.request.json`);
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      id,
+      toolName: 'Bash',
+      toolInput: { command: 'cat /workspace/code-mode-managed-settings.json' },
+      reason: 'custody path',
+      at,
+    }),
+  );
+  return file;
+}
+
+function decisionsDir(): string {
+  // The RO-mounted half: decisions land beside, never inside, the RW request
+  // dir — the agent reads them through the mount and can write neither.
+  return path.join(sessionDir(GID, SID), BOUNDARY_DECISIONS_SUBDIR);
+}
+
+function decisionFileFor(id: string): string {
+  return path.join(decisionsDir(), `${id}.decision.json`);
+}
+
+function readDecision(id: string): { decision: string; reason?: string } | null {
+  try {
+    return JSON.parse(fs.readFileSync(decisionFileFor(id), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+beforeEach(async () => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  await runMigrations(await initTestDb());
+
+  await createAgentGroup({
+    id: GID,
+    name: 'Boundary Agent',
+    folder: 'boundary',
+    agent_provider: null,
+    created_at: now(),
+  });
+  await createSession({
+    id: SID,
+    agent_group_id: GID,
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'running',
+    last_active: now(),
+    created_at: now(),
+  });
+  initSessionFolder(GID, SID);
+
+  // A clicking admin with a cached DM so pickApprovalDelivery resolves
+  // without a live platform.
+  await upsertUser({ id: ADMIN, kind: 'chat', display_name: 'Admin', created_at: now() });
+  await grantRole({ user_id: ADMIN, role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+  await createMessagingGroup({
+    id: 'mg-admin-dm',
+    channel_type: 'chat',
+    platform_id: 'D-admin',
+    name: 'dm',
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now(),
+  });
+  await upsertUserDm({ user_id: ADMIN, channel_type: 'chat', messaging_group_id: 'mg-admin-dm', resolved_at: now() });
+});
+
+afterEach(async () => {
+  stopCodeBoundaryWatcher();
+  await closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('request → card → click → decision file', () => {
+  it('allow: the click writes the decision the hook is polling for', async () => {
+    const adapter = makeAdapter();
+    startCodeBoundaryWatcher(adapter);
+    seedRequest('11111111-aaaa-bbbb-cccc-000000000001');
+    await scanCodeBoundaryRequests();
+
+    expect(adapter.deliver).toHaveBeenCalledTimes(1);
+    const card = JSON.parse(adapter.deliver.mock.calls[0][4] as string);
+    expect(card.type).toBe('ask_question');
+    expect(card.question).toContain('custody path');
+    expect(card.question).toContain('Boundary Agent');
+
+    const row = (await getPendingApprovalsByAction(CODE_BOUNDARY_ACTION))[0];
+    expect(row.session_id).toBe(SID);
+    expect(row.agent_group_id).toBe(GID);
+    // Expiry sits inside the hook's own ceiling, measured from the REQUEST stamp.
+    expect(Date.parse(row.expires_at!)).toBeLessThanOrEqual(Date.now() + HOST_EXPIRY_MS);
+
+    const claimed = await handleApprovalsResponse({
+      questionId: card.questionId,
+      value: 'approve',
+      userId: ADMIN,
+      channelType: 'chat',
+      platformId: 'D-admin',
+      threadId: null,
+    });
+    expect(claimed).toBe(true);
+    expect(readDecision('11111111-aaaa-bbbb-cccc-000000000001')).toEqual({
+      decision: 'allow',
+      reason: 'allow by approver',
+    });
+    expect(await getPendingApprovalsByAction(CODE_BOUNDARY_ACTION)).toEqual([]);
+  });
+
+  it('deny: any non-approve click is a deny', async () => {
+    const adapter = makeAdapter();
+    startCodeBoundaryWatcher(adapter);
+    seedRequest('11111111-aaaa-bbbb-cccc-000000000002');
+    await scanCodeBoundaryRequests();
+    const card = JSON.parse(adapter.deliver.mock.calls[0][4] as string);
+
+    await handleApprovalsResponse({
+      questionId: card.questionId,
+      value: 'deny',
+      userId: ADMIN,
+      channelType: 'chat',
+      platformId: 'D-admin',
+      threadId: null,
+    });
+    expect(readDecision('11111111-aaaa-bbbb-cccc-000000000002')?.decision).toBe('deny');
+  });
+
+  it('a request is routed exactly once across scans', async () => {
+    const adapter = makeAdapter();
+    startCodeBoundaryWatcher(adapter);
+    seedRequest('11111111-aaaa-bbbb-cccc-000000000003');
+    await scanCodeBoundaryRequests();
+    await scanCodeBoundaryRequests();
+    expect(adapter.deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it('sessions without a boundary dir (chat mode) are skipped untouched', async () => {
+    const adapter = makeAdapter();
+    startCodeBoundaryWatcher(adapter);
+    await scanCodeBoundaryRequests();
+    expect(adapter.deliver).not.toHaveBeenCalled();
+    // And a stopped session's dir is not scanned.
+    await updateSession(SID, { container_status: 'stopped' });
+    seedRequest('11111111-aaaa-bbbb-cccc-000000000004');
+    await scanCodeBoundaryRequests();
+    expect(adapter.deliver).not.toHaveBeenCalled();
+  });
+});
+
+describe('failing closed', () => {
+  it('an already-expired request gets an immediate deny and no card', async () => {
+    const adapter = makeAdapter();
+    startCodeBoundaryWatcher(adapter);
+    const staleAt = new Date(Date.now() - HOST_EXPIRY_MS - 1000).toISOString();
+    seedRequest('11111111-aaaa-bbbb-cccc-000000000005', staleAt);
+    await scanCodeBoundaryRequests();
+    expect(adapter.deliver).not.toHaveBeenCalled();
+    expect(readDecision('11111111-aaaa-bbbb-cccc-000000000005')?.decision).toBe('deny');
+  });
+
+  it('a malformed timestamp is denied; an id failing the charset is refused without a path build', async () => {
+    const adapter = makeAdapter();
+    startCodeBoundaryWatcher(adapter);
+    const requestFile = seedRequest('11111111-aaaa-bbbb-cccc-000000000006', 'not-a-time');
+    await scanCodeBoundaryRequests();
+    expect(readDecision('11111111-aaaa-bbbb-cccc-000000000006')?.decision).toBe('deny');
+    expect(adapter.deliver).not.toHaveBeenCalled();
+    // A refused request cannot resolve, so the host clears it — the hook only
+    // ever deletes requests it saw decided.
+    expect(fs.existsSync(requestFile)).toBe(false);
+
+    // Path-shaped id: never trusted, never written anywhere.
+    fs.writeFileSync(
+      path.join(boundaryDir(), 'evil.request.json'),
+      JSON.stringify({ id: '../../escape', toolName: 'Bash', toolInput: {}, reason: 'x', at: now() }),
+    );
+    await scanCodeBoundaryRequests();
+    expect(fs.existsSync(path.join(sessionDir(GID, SID), '..', '..', 'escape.decision.json'))).toBe(false);
+    expect(adapter.deliver).not.toHaveBeenCalled();
+  });
+
+  it('an unreadable request body still gets its deny, addressed by the filename id', async () => {
+    // The hook mints the filename from the same id it puts in the body
+    // (boundary.ts requestPath), so a corrupt body must not cost the blocked
+    // hook its explicit deny — silence would be the full-TTL wait the
+    // routeRequest comment promises against (found in review).
+    const adapter = makeAdapter();
+    startCodeBoundaryWatcher(adapter);
+    fs.mkdirSync(boundaryDir(), { recursive: true });
+    const requestFile = path.join(boundaryDir(), '11111111-aaaa-bbbb-cccc-00000000000a.request.json');
+    fs.writeFileSync(requestFile, '{"id": "11111');
+    await scanCodeBoundaryRequests();
+    expect(readDecision('11111111-aaaa-bbbb-cccc-00000000000a')?.decision).toBe('deny');
+    expect(adapter.deliver).not.toHaveBeenCalled();
+    expect(fs.existsSync(requestFile)).toBe(false);
+
+    // A filename failing the charset gets nothing — no id anywhere to trust.
+    const evil = path.join(boundaryDir(), 'no~such~id.request.json');
+    fs.writeFileSync(evil, '{"tor');
+    await scanCodeBoundaryRequests();
+    expect(fs.readdirSync(decisionsDir()).filter((f) => f.includes('no~such~id'))).toEqual([]);
+  });
+
+  it('the age sweep clears decisions the hook cannot delete and requests of dead hooks', () => {
+    // The hook cannot delete from the RO decisions mount, and a killed hook
+    // orphans its request — the sweep is the hygiene half of the pair.
+    fs.mkdirSync(boundaryDir(), { recursive: true });
+    fs.mkdirSync(decisionsDir(), { recursive: true });
+    const decision = decisionFileFor('11111111-aaaa-bbbb-cccc-00000000000b');
+    const request = path.join(boundaryDir(), '11111111-aaaa-bbbb-cccc-00000000000c.request.json');
+    fs.writeFileSync(decision, '{"decision":"deny"}');
+    fs.writeFileSync(request, '{}');
+    // Young files survive a sweep at the true clock…
+    sweepAgedBoundaryFiles(boundaryDir(), Date.now());
+    sweepAgedBoundaryFiles(decisionsDir(), Date.now());
+    expect(fs.existsSync(decision)).toBe(true);
+    expect(fs.existsSync(request)).toBe(true);
+    // …and age out past the ceiling.
+    const future = Date.now() + BOUNDARY_FILE_MAX_AGE_MS + 60_000;
+    sweepAgedBoundaryFiles(boundaryDir(), future);
+    sweepAgedBoundaryFiles(decisionsDir(), future);
+    expect(fs.existsSync(decision)).toBe(false);
+    expect(fs.existsSync(request)).toBe(false);
+  });
+
+  it('the expiry timer denies and edits the card', async () => {
+    vi.useFakeTimers();
+    try {
+      const adapter = makeAdapter();
+      startCodeBoundaryWatcher(adapter);
+      // Old enough that the timer lands at its 1s floor, young enough to route.
+      const nearlyOver = new Date(Date.now() - HOST_EXPIRY_MS + 5_000).toISOString();
+      seedRequest('11111111-aaaa-bbbb-cccc-000000000007', nearlyOver);
+      await scanCodeBoundaryRequests();
+      expect(adapter.deliver).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(readDecision('11111111-aaaa-bbbb-cccc-000000000007')?.decision).toBe('deny');
+      expect(await getPendingApprovalsByAction(CODE_BOUNDARY_ACTION)).toEqual([]);
+      // The card was edited to its terminal state.
+      const edit = JSON.parse(adapter.deliver.mock.calls[1][4] as string);
+      expect(edit.operation).toBe('edit');
+      expect(edit.terminalCard.resolution).toContain('Timed out');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('restart sweep', () => {
+  it('denies orphaned rows from a previous process and edits their cards', async () => {
+    fs.mkdirSync(decisionsDir(), { recursive: true }); // host-prepared at spawn
+    const decisionFile = decisionFileFor('11111111-aaaa-bbbb-cccc-000000000008');
+    await createPendingApproval({
+      approval_id: 'cb-orphan1',
+      session_id: SID,
+      request_id: '11111111-aaaa-bbbb-cccc-000000000008',
+      action: CODE_BOUNDARY_ACTION,
+      payload: JSON.stringify({ decisionFile }),
+      created_at: now(),
+      agent_group_id: GID,
+      channel_type: 'chat',
+      platform_id: 'D-admin',
+      platform_message_id: 'msg-old',
+      title: 'Sandbox Boundary',
+      question: 'q',
+      options_json: '[]',
+    });
+
+    const adapter = makeAdapter();
+    startCodeBoundaryWatcher(adapter);
+    await vi.waitFor(async () => {
+      expect(await getPendingApprovalsByAction(CODE_BOUNDARY_ACTION)).toEqual([]);
+    });
+    expect(JSON.parse(fs.readFileSync(decisionFile, 'utf8')).decision).toBe('deny');
+    const edit = JSON.parse(adapter.deliver.mock.calls[0][4] as string);
+    expect(edit.operation).toBe('edit');
+    expect(edit.terminalCard.resolution).toContain('host restarted');
+  });
+});

--- a/src/modules/approvals/code-boundary.ts
+++ b/src/modules/approvals/code-boundary.ts
@@ -1,0 +1,401 @@
+/**
+ * Code-boundary approval — the host half of the detached boundary confirm,
+ * in onecli-approvals' blocking shape (pending map + pending_approvals row +
+ * ask_question card + expiry timer + restart sweep). The difference is where
+ * the decision LANDS: OneCLI resolves an in-memory Promise held by an open
+ * HTTP callback; here the waiter is a hook subprocess inside the container
+ * polling a decision FILE, so resolution writes that file and the map holds
+ * only the expiry timer.
+ *
+ * Transport is a request/decision file pair under the session dir (the
+ * container's /workspace) — deliberately NOT the mailbox DBs: the two-DB
+ * surface is the mailbox's message transport, and a
+ * boundary confirm is a blocking decision with one writer per side (request:
+ * hook; decision: host), which the pair preserves. The two halves live in
+ * different dirs because "one writer per side" must be enforced, not stated:
+ * requests ride the RW `<sessDir>/code-boundary`, decisions land in
+ * `<sessDir>/code-boundary-decisions`, which the spawn nested-RO-mounts so
+ * the agent cannot mint its own allow (found in review; the mount is
+ * code-mode/permissions.ts boundaryDecisionMounts, the container half's
+ * trust check is code-runner/boundary.ts decisionsDirTrusted). The hook
+ * deletes the request it wrote once decided; it CANNOT delete decisions, so
+ * the age sweep below owns those.
+ *
+ * Discovery is a small poll over running sessions' dirs — v0 by design; the
+ * container-runner already tracks sessions, and a dir scan every few seconds
+ * against a 10-minute decision window costs nothing perceptible.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { pickApprovalDelivery, pickApprover } from './primitive.js';
+import { BOUNDARY_DECISIONS_SUBDIR } from '../../code-mode/permissions.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import {
+  createPendingApproval,
+  deletePendingApproval,
+  getPendingApprovalsByAction,
+  getRunningSessions,
+  updatePendingApprovalStatus,
+} from '../../db/sessions.js';
+import type { ChannelDeliveryAdapter } from '../../delivery.js';
+import { log } from '../../log.js';
+import { sessionDir } from '../../session-manager.js';
+import type { PendingApproval, Session } from '../../types.js';
+
+export const CODE_BOUNDARY_ACTION = 'code_boundary';
+
+/** The request half's home inside a session dir — mirrors code-runner/boundary.ts
+ *  BOUNDARY_DIR. The decision half lives in BOUNDARY_DECISIONS_SUBDIR (the RO
+ *  mount, code-mode/permissions.ts). */
+export const BOUNDARY_SUBDIR = 'code-boundary';
+
+/**
+ * Files older than this are swept from both halves' dirs on scan. Well past
+ * every rung of the deny ladder (host expiry 590s, hook poll ceiling 600s,
+ * settings kill 660s): by then a decision has been read or its reader is
+ * dead, and a request still sitting there belongs to a hook the CLI killed.
+ * The hour is pure margin — the sweep is hygiene, not semantics.
+ */
+export const BOUNDARY_FILE_MAX_AGE_MS = 3_600_000;
+
+/**
+ * Deny at 590s so the hook (whose own poll ceiling is 600s, settings kill
+ * 660s) reads an EXPLICIT deny rather than manufacturing one — every rung of
+ * the ladder under the next.
+ */
+export const HOST_EXPIRY_MS = 590_000;
+
+const SCAN_INTERVAL_MS = 5_000;
+
+type ExpiryReason = 'no response' | 'host restarted';
+
+interface PendingState {
+  timer: NodeJS.Timeout;
+}
+
+const pending = new Map<string, PendingState>();
+/** Request files already routed (or refused) this process — the scan is a poll, not a queue. */
+const routed = new Set<string>();
+let scanTimer: NodeJS.Timeout | null = null;
+let adapterRef: ChannelDeliveryAdapter | null = null;
+
+function shortApprovalId(): string {
+  // Same 10-byte shape as onecli-approvals and for the same reason: the id
+  // rides a Telegram callback_data field with a hard 64-byte limit.
+  return `cb-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function startCodeBoundaryWatcher(deliveryAdapter: ChannelDeliveryAdapter): void {
+  if (scanTimer) return;
+  adapterRef = deliveryAdapter;
+  sweepStaleBoundaryApprovals().catch((err) => log.error('Code-boundary sweep failed', { err }));
+  scanTimer = setInterval(() => {
+    scanCodeBoundaryRequests().catch((err) => log.error('Code-boundary scan failed', { err }));
+  }, SCAN_INTERVAL_MS);
+}
+
+export function stopCodeBoundaryWatcher(): void {
+  if (scanTimer) clearInterval(scanTimer);
+  scanTimer = null;
+  for (const state of pending.values()) clearTimeout(state.timer);
+  pending.clear();
+  routed.clear();
+  adapterRef = null;
+}
+
+/** One scan pass, exported so tests drive it without timers. */
+export async function scanCodeBoundaryRequests(): Promise<void> {
+  if (!adapterRef) return;
+  for (const session of await getRunningSessions()) {
+    const sessDir = sessionDir(session.agent_group_id, session.id);
+    const dir = path.join(sessDir, BOUNDARY_SUBDIR);
+    let files: string[];
+    try {
+      files = fs.readdirSync(dir).filter((f) => f.endsWith('.request.json'));
+    } catch {
+      files = []; // no request dir — not a code-mode session, or nothing asked yet
+    }
+    for (const file of files) {
+      const requestFile = path.join(dir, file);
+      if (routed.has(requestFile)) continue;
+      routed.add(requestFile);
+      await routeRequest(session, requestFile).catch((err) => {
+        log.error('Code-boundary request not routed', { requestFile, err });
+      });
+    }
+    // Hygiene: decisions outlive their readers (the hook cannot delete from
+    // the RO mount) and a killed hook orphans its request. Routing above ran
+    // first, so anything this old already got its explicit deny.
+    sweepAgedBoundaryFiles(dir, Date.now());
+    sweepAgedBoundaryFiles(path.join(sessDir, BOUNDARY_DECISIONS_SUBDIR), Date.now());
+  }
+}
+
+/** Remove pair files older than BOUNDARY_FILE_MAX_AGE_MS. Exported for tests. */
+export function sweepAgedBoundaryFiles(dir: string, nowMs: number): void {
+  let files: string[];
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith('.request.json') || f.endsWith('.decision.json'));
+  } catch {
+    return;
+  }
+  for (const file of files) {
+    const full = path.join(dir, file);
+    try {
+      if (nowMs - fs.statSync(full).mtimeMs > BOUNDARY_FILE_MAX_AGE_MS) {
+        fs.rmSync(full, { force: true });
+        routed.delete(full);
+      }
+    } catch {
+      // Raced away by the hook's own cleanup — already gone is the goal state.
+    }
+  }
+}
+
+interface BoundaryRequestFile {
+  id: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  reason: string;
+  at: string;
+}
+
+/** The exact charset of ids the hook mints — anything else fails closed. */
+const REQUEST_ID_RE = /^[0-9a-f-]{1,64}$/i;
+
+function writeDecision(decisionFile: string, decision: 'allow' | 'deny', reason: string): void {
+  // The decisions dir is host-prepared at spawn (boundaryDecisionMounts), but
+  // a session spawned before the mount landed still deserves its explicit deny.
+  fs.mkdirSync(path.dirname(decisionFile), { recursive: true });
+  // tmp+rename: the hook polls this path and must never parse a torn file.
+  const tmp = `${decisionFile}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify({ decision, reason }));
+  fs.renameSync(tmp, decisionFile);
+}
+
+async function routeRequest(session: Session, requestFile: string): Promise<void> {
+  if (!adapterRef) return;
+  const decisionsDir = path.join(sessionDir(session.agent_group_id, session.id), BOUNDARY_DECISIONS_SUBDIR);
+  const decisionFileFor = (id: string) => path.join(decisionsDir, `${id}.decision.json`);
+  // A refused request never resolves, so the file's own deletion falls to the
+  // host (the hook only clears requests it saw decided). Best-effort — a file
+  // that will not die still cannot re-route (`routed`) and ages into the sweep.
+  const refuseRequestFile = () => {
+    try {
+      fs.rmSync(requestFile, { force: true });
+    } catch (err) {
+      log.warn('Refused code-boundary request not removed', { requestFile, err });
+    }
+  };
+
+  // Refuse anything not exactly request-shaped by DENYING it — a malformed
+  // request has a hook blocked behind it, and silence would make that hook
+  // wait out its full TTL for a decision that can never come. An unreadable
+  // BODY still gets its deny: the hook mints the filename from the same id it
+  // puts in the body (boundary.ts requestPath), so the basename — under the
+  // same charset check as any other id — is enough to address the decision.
+  let request: BoundaryRequestFile;
+  try {
+    request = JSON.parse(fs.readFileSync(requestFile, 'utf8')) as BoundaryRequestFile;
+  } catch (error) {
+    log.warn('Code-boundary request unreadable — denying by its filename id', {
+      requestFile,
+      error: String(error),
+    });
+    const nameId = path.basename(requestFile).replace(/\.request\.json$/, '');
+    if (REQUEST_ID_RE.test(nameId)) {
+      writeDecision(decisionFileFor(nameId), 'deny', 'unreadable request (refused, fails closed)');
+    }
+    refuseRequestFile();
+    return;
+  }
+  if (typeof request.id !== 'string' || !REQUEST_ID_RE.test(request.id)) {
+    log.warn('Code-boundary request id fails the charset — refused', { requestFile });
+    refuseRequestFile();
+    return; // an id we cannot trust is an id we must not build a path from
+  }
+  const requestAtMs = Date.parse(request.at ?? '');
+  const decisionFile = decisionFileFor(request.id);
+  if (!Number.isFinite(requestAtMs)) {
+    writeDecision(decisionFile, 'deny', 'malformed request timestamp (refused, fails closed)');
+    refuseRequestFile();
+    return;
+  }
+
+  const expiresAtMs = requestAtMs + HOST_EXPIRY_MS;
+  if (expiresAtMs <= Date.now()) {
+    // Found too late (host was down): the hook has already denied itself or
+    // is about to — say so explicitly rather than raising an unanswerable card.
+    writeDecision(decisionFile, 'deny', 'approval window already over when the host saw the request');
+    refuseRequestFile();
+    return;
+  }
+
+  const group = await getAgentGroup(session.agent_group_id);
+  const approvers = await pickApprover(session.agent_group_id);
+  if (approvers.length === 0) {
+    writeDecision(decisionFile, 'deny', 'no eligible approver configured');
+    return;
+  }
+  const target = await pickApprovalDelivery(approvers, '');
+  if (!target) {
+    writeDecision(decisionFile, 'deny', 'no DM channel for any approver');
+    return;
+  }
+
+  const approvalId = shortApprovalId();
+  const title = 'Sandbox Boundary';
+  const question = buildQuestion(group?.name ?? session.agent_group_id, request);
+  const options = [
+    { label: 'Allow', selectedLabel: '✅ Allowed', value: 'approve', style: 'primary' as const },
+    { label: 'Deny', selectedLabel: '❌ Denied', value: 'deny', style: 'danger' as const },
+  ];
+
+  let platformMessageId: string | undefined;
+  try {
+    platformMessageId = await adapterRef.deliver(
+      target.messagingGroup.channel_type,
+      target.messagingGroup.platform_id,
+      null,
+      'chat-sdk',
+      JSON.stringify({ type: 'ask_question', questionId: approvalId, title, question, options }),
+    );
+  } catch (err) {
+    log.error('Code-boundary card not delivered — denying', { approvalId, requestFile, err });
+    writeDecision(decisionFile, 'deny', 'approval card could not be delivered');
+    return;
+  }
+
+  await createPendingApproval({
+    approval_id: approvalId,
+    session_id: session.id,
+    request_id: request.id,
+    action: CODE_BOUNDARY_ACTION,
+    payload: JSON.stringify({
+      requestId: request.id,
+      decisionFile,
+      requestFile,
+      toolName: request.toolName,
+      reason: request.reason,
+      approver: target.userId,
+    }),
+    created_at: new Date().toISOString(),
+    agent_group_id: session.agent_group_id,
+    approver_user_id: target.userId,
+    channel_type: target.messagingGroup.channel_type,
+    platform_id: target.messagingGroup.platform_id,
+    platform_message_id: platformMessageId ?? null,
+    expires_at: new Date(expiresAtMs).toISOString(),
+    status: 'pending',
+    title,
+    question,
+    options_json: JSON.stringify(options),
+  });
+
+  const timer = setTimeout(
+    () => {
+      if (!pending.delete(approvalId)) return;
+      try {
+        writeDecision(decisionFile, 'deny', 'no approval before the window closed (timeout is deny)');
+      } catch (err) {
+        log.error('Code-boundary expiry could not write the deny decision', { approvalId, decisionFile, err });
+      }
+      expireApproval(approvalId, 'no response').catch((err) =>
+        log.error('Failed to mark code-boundary approval expired', { approvalId, err }),
+      );
+    },
+    Math.max(1000, expiresAtMs - Date.now()),
+  );
+  pending.set(approvalId, { timer });
+  log.info('Code-boundary approval requested', { approvalId, requestFile, approver: target.userId });
+}
+
+/** Called from the approvals response handler when a card button is clicked. */
+export async function resolveCodeBoundaryApproval(approvalId: string, selectedOption: string): Promise<boolean> {
+  const state = pending.get(approvalId);
+  if (!state) return false;
+  pending.delete(approvalId);
+  clearTimeout(state.timer);
+
+  const row = (await getPendingApprovalsByAction(CODE_BOUNDARY_ACTION)).find((r) => r.approval_id === approvalId);
+  const decision = selectedOption === 'approve' ? 'allow' : 'deny';
+  if (row) {
+    try {
+      const payload = JSON.parse(row.payload) as { decisionFile?: string };
+      if (payload.decisionFile) {
+        writeDecision(payload.decisionFile, decision, `${decision} by approver`);
+      }
+    } catch (err) {
+      log.error('Code-boundary decision file not written', { approvalId, err });
+    }
+  }
+  await updatePendingApprovalStatus(approvalId, decision === 'allow' ? 'approved' : 'rejected');
+  await deletePendingApproval(approvalId);
+  log.info('Code-boundary approval resolved', { approvalId, decision });
+  return true;
+}
+
+async function expireApproval(approvalId: string, reason: ExpiryReason): Promise<void> {
+  const row = (await getPendingApprovalsByAction(CODE_BOUNDARY_ACTION)).find((r) => r.approval_id === approvalId);
+  if (!row) return;
+  await updatePendingApprovalStatus(approvalId, 'expired');
+  await editCardExpired(row, reason);
+  await deletePendingApproval(approvalId);
+  log.info('Code-boundary approval expired', { approvalId, reason });
+}
+
+async function editCardExpired(row: PendingApproval, reason: ExpiryReason): Promise<void> {
+  if (!adapterRef || !row.platform_message_id || !row.channel_type || !row.platform_id) return;
+  const resolution =
+    reason === 'no response'
+      ? '⏱️ Timed out — denied (no approval is a deny)'
+      : '⏱️ Timed out — host restarted before resolution (denied)';
+  try {
+    await adapterRef.deliver(
+      row.channel_type,
+      row.platform_id,
+      null,
+      'chat-sdk',
+      JSON.stringify({
+        operation: 'edit',
+        messageId: row.platform_message_id,
+        text: [row.title, row.question, resolution].filter(Boolean).join('\n\n'),
+        terminalCard: { title: row.title, question: row.question, resolution },
+      }),
+    );
+  } catch (err) {
+    log.warn('Failed to edit expired code-boundary card', { approvalId: row.approval_id, err });
+  }
+}
+
+/** Orphans from a previous process: the click can never land — deny and say so. */
+async function sweepStaleBoundaryApprovals(): Promise<void> {
+  const rows = await getPendingApprovalsByAction(CODE_BOUNDARY_ACTION);
+  if (rows.length === 0) return;
+  log.info('Sweeping stale code-boundary approvals from previous process', { count: rows.length });
+  for (const row of rows) {
+    try {
+      const payload = JSON.parse(row.payload) as { decisionFile?: string };
+      // Best-effort: the session (and its dir) may be gone; the hook that
+      // was waiting has long since denied itself at its own ceiling.
+      if (payload.decisionFile && fs.existsSync(path.dirname(payload.decisionFile))) {
+        writeDecision(payload.decisionFile, 'deny', 'host restarted before resolution');
+      }
+    } catch (err) {
+      log.warn('Stale code-boundary row without a usable decision path', { approvalId: row.approval_id, err });
+    }
+    await editCardExpired(row, 'host restarted');
+    await deletePendingApproval(row.approval_id);
+  }
+}
+
+function buildQuestion(agentName: string, request: BoundaryRequestFile): string {
+  const lines = [`*Agent:* ${agentName}`, `*Boundary:* ${request.reason}`];
+  const command = request.toolInput?.command;
+  const filePath = request.toolInput?.file_path;
+  if (typeof command === 'string' && command) lines.push('```', command.slice(0, 900), '```');
+  else if (typeof filePath === 'string' && filePath) lines.push(`*${request.toolName}:* ${filePath.slice(0, 900)}`);
+  else lines.push(`*Tool:* ${request.toolName}`);
+  return lines.join('\n');
+}

--- a/src/modules/approvals/response-handler.ts
+++ b/src/modules/approvals/response-handler.ts
@@ -27,6 +27,7 @@ import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
 import type { PendingApproval } from '../../types.js';
 import { hasAdminPrivilege, isGlobalAdmin, isOwner } from '../permissions/db/user-roles.js';
+import { CODE_BOUNDARY_ACTION, resolveCodeBoundaryApproval } from './code-boundary.js';
 import { finalizeReject } from './finalize.js';
 import { ONECLI_ACTION, resolveOneCLIApproval } from './onecli-approvals.js';
 import { getApprovalHandler, notifyApprovalResolved, REJECT_WITH_REASON_VALUE } from './primitive.js';
@@ -52,6 +53,16 @@ export async function handleApprovalsResponse(payload: ResponsePayload): Promise
     }
     // Row exists but the in-memory resolver is gone (timer fired or the process
     // was in a weird state). Nothing to do — just drop the row.
+    await deletePendingApproval(payload.questionId);
+    return true;
+  }
+
+  if (approval.action === CODE_BOUNDARY_ACTION) {
+    // Same in-memory shape as OneCLI, but resolution writes the container's
+    // decision FILE (the hook is polling it) instead of releasing a Promise.
+    if (await resolveCodeBoundaryApproval(payload.questionId, payload.value)) {
+      return true;
+    }
     await deletePendingApproval(payload.questionId);
     return true;
   }

--- a/src/router.ts
+++ b/src/router.ts
@@ -528,10 +528,16 @@ async function deliverToAgent(
   // AND adapter capability — resolveThreadPolicy at fanout): thread-enabled
   // wiring in a group chat → per-thread session regardless of wiring
   // session_mode. agent-shared preserved (it's a cross-channel directive the
-  // adapter doesn't know about). DMs collapse sub-threads to one session
-  // (is_group=0 short-circuit).
+  // adapter doesn't know about), and so is sandbox (the wiring IS the coding
+  // session's chat surface — there is exactly one session to land in). DMs
+  // collapse sub-threads to one session (is_group=0 short-circuit).
   let effectiveSessionMode = agent.session_mode;
-  if (threadsEnabled && effectiveSessionMode !== 'agent-shared' && mg.is_group !== 0) {
+  if (
+    threadsEnabled &&
+    effectiveSessionMode !== 'agent-shared' &&
+    effectiveSessionMode !== 'sandbox' &&
+    mg.is_group !== 0
+  ) {
     effectiveSessionMode = 'per-thread';
   }
 

--- a/src/seams.ts
+++ b/src/seams.ts
@@ -30,12 +30,7 @@ const refusals: SeamRefusal[] = [];
  * otherwise the refusal is logged and recorded, and the caller must drop the
  * registration.
  */
-export function seamAccepted(
-  registry: string,
-  registrant: string,
-  wanted: number,
-  got: number | undefined,
-): boolean {
+export function seamAccepted(registry: string, registrant: string, wanted: number, got: number | undefined): boolean {
   if (got === wanted) return true;
   const refusal: SeamRefusal = { registry, registrant, wanted, got };
   refusals.push(refusal);

--- a/src/seams.ts
+++ b/src/seams.ts
@@ -1,0 +1,68 @@
+/**
+ * Seam versions — how a registrar and the registry it plugs into agree on
+ * the shape between them.
+ *
+ * Every registry under code mode exports an integer (`SANDBOX_HOOKS_SEAM`,
+ * `SESSION_SURFACE_SEAM`, `RESOURCE_EXTENSION_SEAM`) and every registration
+ * passes `{ seam }`. A mismatch is a refusal, never an overwrite and never
+ * a crash: the registration is dropped, `log.error` says which one and why,
+ * and the refusal is kept so operator surfaces (`ncl sandboxes list`) can
+ * repeat it. The host still boots and everything else still works — a
+ * module built against an older shape costs itself, not the install.
+ *
+ * Bumped only on a breaking change to the shape the registrar depends on.
+ */
+import { log } from './log.js';
+
+export interface SeamRefusal {
+  /** Which registry refused (`sandbox-hooks`, `session-surface`, `resource-extension`). */
+  registry: string;
+  /** What tried to register (a hook name, a channel type, a verb). */
+  registrant: string;
+  wanted: number;
+  got: number | undefined;
+}
+
+const refusals: SeamRefusal[] = [];
+
+/**
+ * Check a registration's seam against the registry's. True when they agree;
+ * otherwise the refusal is logged and recorded, and the caller must drop the
+ * registration.
+ */
+export function seamAccepted(
+  registry: string,
+  registrant: string,
+  wanted: number,
+  got: number | undefined,
+): boolean {
+  if (got === wanted) return true;
+  const refusal: SeamRefusal = { registry, registrant, wanted, got };
+  refusals.push(refusal);
+  log.error('Registration refused: seam version mismatch', {
+    registry,
+    registrant,
+    expected: wanted,
+    received: got,
+  });
+  return false;
+}
+
+/** Every refusal this process recorded, oldest first. */
+export function seamRefusals(): readonly SeamRefusal[] {
+  return [...refusals];
+}
+
+/** One line per refusal, for an operator surface. */
+export function renderSeamRefusals(): string[] {
+  return refusals.map(
+    (r) =>
+      `warning: ${r.registry} refused '${r.registrant}' — seam ${r.wanted} expected, ` +
+      `${r.got === undefined ? 'none' : r.got} given (rebuild it against this host)`,
+  );
+}
+
+/** Test seam. */
+export function resetSeamRefusalsForTesting(): void {
+  refusals.length = 0;
+}

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -24,9 +24,9 @@ import {
   updateSession,
 } from './db/sessions.js';
 import { log } from './log.js';
-import { getAgentMailbox, type InboundMessage, type MailboxSession } from './mailbox/index.js';
+import { getAgentMailbox, type InboundMessage, type MailboxSession, type SessionRouting } from './mailbox/index.js';
 import { enqueueSessionReconcile } from './reconcile-feeds.js';
-import type { Session } from './types.js';
+import type { MessagingGroupAgent, Session } from './types.js';
 
 /** Root directory for all session data. */
 export function sessionsBaseDir(): string {
@@ -83,13 +83,16 @@ async function withSessionCreationLock<T>(key: string, fn: () => Promise<T>): Pr
   }
 }
 
+type SessionMode = MessagingGroupAgent['session_mode'];
+
 function sessionCreationKey(
   agentGroupId: string,
   messagingGroupId: string | null,
   threadId: string | null,
-  sessionMode: 'shared' | 'per-thread' | 'agent-shared',
+  sessionMode: SessionMode,
 ): string {
   if (sessionMode === 'agent-shared') return `agent\0${agentGroupId}`;
+  if (sessionMode === 'sandbox') return `system\0${agentGroupId}\0${SANDBOX_SYSTEM_THREAD_ID}`;
   return `route\0${agentGroupId}\0${messagingGroupId ?? ''}\0${sessionMode === 'shared' ? '' : (threadId ?? '')}`;
 }
 
@@ -101,15 +104,19 @@ function sessionCreationKey(
  * - 'per-thread': one session per (messaging group, thread)
  * - 'agent-shared': one session per agent group — all messaging groups
  *   wired with this mode share a single session (e.g. GitHub + Slack)
+ * - 'sandbox': the agent group's coding session (resolveSandboxSession) —
+ *   the wiring is a chat surface for that session, never a session of its
+ *   own; messaging group and thread are ignored
  */
 export async function resolveSession(
   agentGroupId: string,
   messagingGroupId: string | null,
   threadId: string | null,
-  sessionMode: 'shared' | 'per-thread' | 'agent-shared',
+  sessionMode: SessionMode,
 ): Promise<{ session: Session; created: boolean }> {
   const key = sessionCreationKey(agentGroupId, messagingGroupId, threadId, sessionMode);
   return withSessionCreationLock(key, async () => {
+    if (sessionMode === 'sandbox') return resolveSandboxSession(agentGroupId);
     // agent-shared: single session per agent group, regardless of messaging group
     if (sessionMode === 'agent-shared') {
       const existing = await findSessionByAgentGroup(agentGroupId);
@@ -259,24 +266,40 @@ export async function writeSessionRouting(agentGroupId: string, sessionId: strin
   const session = await getSession(sessionId);
   if (!session) return;
 
-  let channelType: string | null = null;
-  let platformId: string | null = null;
+  let routing: SessionRouting = { channelType: null, platformId: null, threadId: session.thread_id };
   if (session.messaging_group_id) {
     const mg = await getMessagingGroup(session.messaging_group_id);
-    if (mg) {
-      channelType = mg.channel_type;
-      platformId = mg.platform_id;
+    if (mg) routing = { ...routing, channelType: mg.channel_type, platformId: mg.platform_id };
+  } else {
+    // A session with no origin chat of its own may still have a chat surface
+    // (a coding session's): the module that bound it answers here.
+    for (const resolve of sessionRoutingResolvers) {
+      const resolved = await resolve(session);
+      if (resolved) {
+        routing = resolved;
+        break;
+      }
     }
   }
 
   await withMailboxSession(agentGroupId, sessionId, (mailbox) => {
-    mailbox.setRouting({
-      channelType,
-      platformId,
-      threadId: session.thread_id,
-    });
+    mailbox.setRouting(routing);
   });
-  log.debug('Session routing written', { sessionId, channelType, platformId, threadId: session.thread_id });
+  log.debug('Session routing written', { sessionId, ...routing });
+}
+
+/**
+ * Routing for a session that has no messaging group of its own — consulted by
+ * writeSessionRouting for system sessions (task, sandbox) so a module that
+ * gave such a session a chat surface can point its default outbound route at
+ * it. First non-null answer wins; null means "not mine".
+ */
+export type SessionRoutingResolver = (session: Session) => Promise<SessionRouting | null>;
+
+const sessionRoutingResolvers: SessionRoutingResolver[] = [];
+
+export function registerSessionRoutingResolver(resolver: SessionRoutingResolver): void {
+  sessionRoutingResolvers.push(resolver);
 }
 
 /**

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -14,6 +14,7 @@ import { ensureContainedInboxDir, isPathInside } from './inbox-safety.js';
 import { getMessagingGroup } from './db/messaging-groups.js';
 import { isUniqueViolation } from './db/errors.js';
 import {
+  SANDBOX_SYSTEM_THREAD_ID,
   createSession,
   findSystemSession,
   findSessionByAgentGroup,
@@ -198,6 +199,37 @@ export async function resolveTaskSession(
   });
 }
 
+/**
+ * Find or create a group's sandbox session (thread `system:sandbox`) — the
+ * session `ncl sandboxes new` lands in. Mirrors resolveTaskSession:
+ * messaging_group_id NULL keeps it invisible to chat routing
+ * (findSessionByAgentGroup filters system threads), and the explicit thread
+ * id keeps it from ever being adopted as an agent-shared channel session.
+ */
+export async function resolveSandboxSession(agentGroupId: string): Promise<{ session: Session; created: boolean }> {
+  const existing = await findSystemSession(agentGroupId, SANDBOX_SYSTEM_THREAD_ID);
+  if (existing) return { session: existing, created: false };
+
+  const id = generateId();
+  const session: Session = {
+    id,
+    agent_group_id: agentGroupId,
+    messaging_group_id: null,
+    thread_id: SANDBOX_SYSTEM_THREAD_ID,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: null,
+    created_at: new Date().toISOString(),
+  };
+
+  await createSession(session);
+  initSessionFolder(agentGroupId, id);
+  log.info('Sandbox session created', { id, agentGroupId });
+
+  return { session, created: true };
+}
+
 /** Create the workspace folders and synchronously prepare the registered mailbox. */
 export function initSessionFolder(agentGroupId: string, sessionId: string): void {
   const dir = sessionDir(agentGroupId, sessionId);
@@ -215,10 +247,8 @@ export async function destroySessionMailbox(agentGroupId: string, sessionId: str
 /**
  * Write the current chat/thread routing for a session into its inbound mailbox.
  *
- * The container reads this for tools that take no destination (`ask_user_question`,
- * `send_card`) and to detect a task session (`system:tasks:<id>` thread). Reply
- * threads are not resolved from here — thread_id is null for every session that
- * isn't per-thread — but from the latest messages_in row for the channel.
+ * The container uses this to preserve thread_id when an explicitly named
+ * destination resolves to the conversation this session is bound to.
  * Derived from session.messaging_group_id → messaging_groups row + session.thread_id.
  *
  * Called on every container wake alongside the agent-to-agent module's

--- a/src/templates/create-agent.ts
+++ b/src/templates/create-agent.ts
@@ -107,6 +107,9 @@ export async function createAgentFromTemplate(ref: string, opts?: CreateAgentOpt
   const group: AgentGroup = { id, name, folder, agent_provider: null, created_at: new Date().toISOString() };
   await createAgentGroup(group);
   await ensureContainerConfig(id);
+  if (tpl.codeMode !== undefined) {
+    await updateContainerConfigScalars(id, { code_mode: tpl.codeMode ? 1 : 0 });
+  }
   if (timezone) await updateContainerConfigScalars(id, { timezone });
 
   // group-init.ts owns the mkdir at first spawn, but it isn't called here — so we

--- a/src/templates/extension.ts
+++ b/src/templates/extension.ts
@@ -19,6 +19,7 @@ import { readTasks, type TemplateTask } from './tasks.js';
 export const NANOCLAW_EXTENSION_NS = 'ai.nanoco.nanoclaw';
 
 export interface NanoclawExtension {
+  codeMode?: boolean;
   /** Display name for the stamped agent group; folder-leaf fallback applies when absent. */
   agentName?: string;
   /** Persona from <ns>/context/instructions.md — optional by decision; registries may require it by policy. */
@@ -40,11 +41,18 @@ export function readNanoclawExtension(
   const report: string[] = [];
 
   let agentName: string | undefined;
+  let codeMode: boolean | undefined;
   const ours = manifestExtensions[NANOCLAW_EXTENSION_NS];
   if (ours !== undefined) {
     if (!isPlainObject(ours)) {
       report.push(`plugin.json: extensions["${NANOCLAW_EXTENSION_NS}"] is not an object; ignored`);
     } else {
+      if (ours.codeMode !== undefined) {
+        if (typeof ours.codeMode !== 'boolean') {
+          throw new Error('plugin.json: codeMode must be a boolean');
+        }
+        codeMode = ours.codeMode;
+      }
       const value = ours.agentName;
       if (value !== undefined) {
         if (typeof value === 'string' && value.trim()) agentName = value.trim();
@@ -54,7 +62,7 @@ export function readNanoclawExtension(
           );
       }
       for (const key of Object.keys(ours)) {
-        if (key !== 'agentName') {
+        if (key !== 'agentName' && key !== 'codeMode') {
           report.push(`plugin.json: extensions["${NANOCLAW_EXTENSION_NS}"].${key} is not recognized; ignored`);
         }
       }
@@ -74,6 +82,7 @@ export function readNanoclawExtension(
 
   return {
     ...(agentName === undefined ? {} : { agentName }),
+    ...(codeMode === undefined ? {} : { codeMode }),
     ...(instructions === undefined ? {} : { instructions }),
     contextExtras: readContextExtras(contextDir),
     tasks: readTasks(path.join(extDir, 'tasks'), `${NANOCLAW_EXTENSION_NS}/tasks`),

--- a/src/templates/parse.ts
+++ b/src/templates/parse.ts
@@ -24,6 +24,7 @@ export type { TemplateTask } from './tasks.js';
 
 /** A parsed plugin directory. */
 export interface Template {
+  codeMode?: boolean;
   /** The manifest's machine name — also the folder the plugin is stamped under. */
   name: string;
   /** Display name from extensions["ai.nanoco.nanoclaw"].agentName, when given. */
@@ -76,6 +77,7 @@ export function parseTemplate(dir: string): Template {
   return {
     name: manifest.name,
     ...(extension.agentName === undefined ? {} : { agentName: extension.agentName }),
+    ...(extension.codeMode === undefined ? {} : { codeMode: extension.codeMode }),
     mcpServers: servers,
     ...(extension.instructions === undefined ? {} : { instructions: extension.instructions }),
     contextExtras: extension.contextExtras,

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,13 @@ export interface MessagingGroupAgent {
   engage_pattern: string | null;
   sender_scope: SenderScope;
   ignored_message_policy: IgnoredMessagePolicy;
-  session_mode: 'shared' | 'per-thread' | 'agent-shared';
+  /**
+   * 'sandbox' routes the wiring into the agent group's coding session (the
+   * `system:sandbox` thread `ncl sandboxes new` lands in) instead of a chat
+   * session of its own — the chat surface bound to a coding session
+   * (src/code-mode/surface). Threads never apply to it.
+   */
+  session_mode: 'shared' | 'per-thread' | 'agent-shared' | 'sandbox';
   priority: number;
   /**
    * Per-wiring thread-policy override (migration 019). NULL = inherit the

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,11 @@ export interface ContainerConfigRow {
   cli_scope: string; // 'disabled' | 'group' | 'global'
   timezone: string | null; // IANA id; NULL = follow the install-global timezone
   speed: ContainerSpeed | null; // NULL = install/provider default
+  /** 0|1. Column added by the module:code-mode migration — absent (undefined) reads as off. */
+  code_mode?: number;
+  /** 'auto' | 'bypass' | NULL. Column added by the module:code-mode permission-mode
+   *  migration — NULL/absent means "follow the deployment default". */
+  permission_mode?: string | null;
   /**
    * Session isolation tier ('container' | 'vm') — see SessionSpec.runtimeTier.
    * Optional on the TS type because the trunk schema does not carry the


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Adds code mode: a group whose agent runs as a persistent coding session (Claude Code under tmux in the agent container) instead of the chat loop, with operator verbs to create, list and attach to sandboxes, a boundary confirm through the approvals card, and the platform-agnostic core of "a chat surface for a coding session".

- **Problem**: NanoClaw has one runner type, the chat loop; there is no way to give an agent a persistent, attachable terminal session with a durable workspace.
- **Fix**: a second runner in the same package and image (`start:code`), selected at spawn for groups with `code_mode` set, each session owning one Claude Code conversation it starts and resumes by id; `ncl sandboxes new | list | attach | status | diff | stop` (the diff read by git inside the running session container) and `ncl groups attach`; the agent's instruction surface stamped read-only from `container/code-mode/`; a host-owned permission posture; boundary crossings as approval cards; mailbox delivery into the session (`ncl inbox read`, `ncl outbox send`).
- **Seams**: lifecycle hooks (`onSandboxCreated/Bound/Removed/RemoteAccessChanged`), `extendResource` for extra `ncl sandboxes` sub-verbs, a `SessionSurfaceProvider` registry, `SessionHandle.execStream` on the driver contract, and an in-process sandbox API — each with a seam version that refuses a mismatched registration and logs it. Contract-test helpers for each.
- **Out of scope**: any remote terminal, any concrete chat-platform provider, dev environments. Those attach through the seams above in later PRs and skills.
- **Seams with no consumer in this PR** (by ruling): `onSandboxBound`/`onRemoteAccessChanged`, `extendResource`, `registerSessionSurface`, `execStream`, `archiveSandboxSurface`. PR B (stacked on this branch, opened together) is their first consumer: the remote terminal door and its `sandboxes remote …` verbs.
- **Chat groups see two small changes**: `<sessDir>/group` is created on every spawn (in every mode, so a group later flipped to code mode keeps a host-writable cwd), and `groups config get` shows two new keys (`code_mode`, `permission_mode`). Everything else is gated on `code_mode`.
- **Migrations**: two `ALTER TABLE container_configs` columns and one new table, all `module:code-mode:*`. SQLite hosts apply them at boot as usual; a host on a dialect where `auto` means validate runs `pnpm run migrate` first (the command now lists module migrations by name).

<details>
<summary>Commits, in order</summary>

1. 112e0173 `build: tmux in the agent image; container CI installs tmux`
2. 97165bb1 `feat(mailbox): release processing claims on the runner seam; module migrations listed by migrate`
3. bf87a524 `feat(code-mode): the code runner — persistent tmux session, mailbox delivery, boundary hook`
4. 02da3cca `feat(code-mode): code-mode groups — flag, permission posture, sandbox verbs, attach`
5. c4695625 `feat(approvals): sandbox boundary confirmation through the approvals card`
6. f416c78b `feat(drivers): interactive exec stream on the session handle (Docker Engine API)`
7. ed8b46b1 `feat(code-mode): lifecycle hooks, resource extension and seam versions`
8. 75ef7b95 `feat(code-mode): a session surface for each coding session — the core`
9. 0ab1f80f `feat(code-mode): the bundled instruction surface is loud when missing`
10. a9863ea5 `docs(code-mode): sandboxes, the agent's instruction surface, the session surface and the seams`

</details>

## Related work

No issue. Safe to review directly: every behaviour change is gated on a group's `code_mode` flag (default off); a chat group's mounts, entrypoint and env are byte-identical to before (pinned by `src/code-mode/compose.test.ts`).

## Change kind

- [ ] `kind/bug`
- [x] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm exec tsc --noEmit` -> clean; `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` -> clean; `pnpm build` -> clean.
- `pnpm exec vitest run` (tip, after the third pass) -> 228 files pass, 1 skipped, 2691 tests pass, 0 failed. In earlier runs `scripts/update/transaction.e2e.test.ts` (untouched) timed out at 5 s under full-suite load, and on a loaded machine `scripts/update-skills.test.ts` and `scripts/add-dial-tool-scope.test.ts` too; each passes alone.
- `bun test` in `container/agent-runner` (tmux installed) -> 669 pass, 3 skip, 0 fail (after the third review pass).
- `pnpm run format:check` -> clean; `pnpm lint` -> 0 errors, 208 warnings (the pre-existing `no-catch-all` set plus two in `diff-view.ts`: the exec wrapper maps a failed exec to an exit code, and the collector wraps a thrown exec as a `DiffCollectError`, both by design). An earlier draft of this note claimed 0 errors while four `no-useless-escape` errors were present in `groups-attach.test.ts`; fixed in commit 4.
- Every commit in the chain typechecks and builds on its own (host tsc, container tsc, `pnpm build`, verified per commit after the third pass); commit 3's container suite (669 pass) and commit 8's `src/code-mode` + `src/cli` suites (388 pass) are green at those commits.
- New or changed behaviour is covered by: `code-runner/*.test.ts` (incl. per-life argv, conversation id, attachments) and `term-audit/term-audit.test.ts` (real tmux), `cli/mailbox-verbs.test.ts`, `mailbox/sqlite/sqlite.test.ts` (release), `code-mode/{compose,permissions,template,hooks,contract}.test.ts`, `code-mode/surface/{mapper,diff-view,stop,registry,runtime,binding,routing}.test.ts`, `cli/resources/{sandboxes,sandboxes-surface,groups-attach,groups}.test.ts`, `cli/crud-extend.test.ts`, `cli/attach-exec.test.ts`, `modules/approvals/code-boundary.test.ts`, `drivers/docker-api.test.ts` (fake daemon on a unix socket), `db/db-v2.test.ts` (sandbox sessions), `channels/chat-sdk-bridge.test.ts` (conversationPlatformId).
- Manual path CI cannot cover: rebuild the image, `bin/ncl sandboxes new t1`, work in the terminal, `Ctrl-b d`, `bin/ncl sandboxes list` (running), wait for the idle lease, `list` (cold), `attach` wakes it.
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change

```release-note
Code mode: `ncl sandboxes new|list|attach|status|diff|stop` give an agent group a persistent Claude Code session under tmux in its container, with a durable workspace, mailbox delivery into the session, boundary confirms through the approvals card, and seams for a chat surface and a remote terminal. The agent image now includes tmux; pre-built images need a rebuild. See docs/code-mode.md.
```

## Security and trust boundaries

- The `ncl` socket is the auth boundary: every sandbox verb is `hostOnly` and refused for any container caller before its handler runs.
- The permission posture is host-owned: a managed-settings file mounted read-only at the CLI's admin tier and RO-covered at its workspace spelling; `bypass` must be selected explicitly per group or deployment.
- Boundary confirms fail closed: the decision dir is a nested read-only mount (the agent cannot write its own allow); the host denies at 590 s, before the hook's 600 s ceiling; a restart denies every orphaned request; malformed requests are refused. The approval row records the approver (`approver_user_id`).
- **Known limit of the transport**: the request file rides the RW workspace, so the agent can forge the card's CONTENT (describe a different action than the one its hook holds). Self-approval is blocked; a misleading card is not. Documented in docs/code-mode.md; an approver should read a boundary card as the agent's own message.
- The diff view is collected inside the session container through the driver's exec (`--no-ext-diff --no-textconv`, `core.fsmonitor=` off, bounded output, timeout); the host never runs git against the agent-writable tree, so a repository-local external diff driver or textconv filter cannot run on the host. A cold sandbox has no diff.
- The channel-transport MCP registration is written to a container-private file and passed with `--mcp-config`; the runner never writes a project `.mcp.json` into the developer's workspace.
- The instruction surface is stamped outside the RW workspace so the agent cannot edit the host-owned words through the back of the RO mount.
- Code-mode env (`NANOCLAW_CODE_ENV`) never enters the provider's credential lane and never overrides a set key; `validateSpec` still refuses secret-shaped env.
- `execStream` talks to the Docker daemon socket the driver already uses; no new listener, no new network exposure. The seam is optional on the driver contract.
- Seam-version mismatches refuse the registration and log; the host boots and existing adapters keep working.

## Skill delivery

- [x] Not a skill

## AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change  <!-- the lead ticks this after review -->

