### PR TITLE
feat(community-portal): opt-in remote terminal and a chat surface for each coding session

### DIFF
--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -155,6 +155,123 @@ the next healthy tick, three times, before that turn is given up with a
 log line. A clean tree is not a failure: it settles the turn with nothing
 sent.
 
+### Over the account service
+
+The community-portal module ships one provider: a remote implementation
+over the service that manages the host's chat app (the same service and
+install token the portal setup uses). It knows no chat platform. A
+platform's module registers its half with
+`registerSurfacePlatform(kind, { spell, botIdentity?, install? })` from
+`src/modules/community-portal/surface/`: how the adapter spells a
+conversation as a messaging-group row and, optionally, which bot this host
+is on the platform. For every registered platform with a managed install
+and a sign-in, the provider is registered under the platform's channel
+type at Host start. Whether a session actually gets a surface is the
+service's answer: a workspace or deployment that cannot open one leaves
+the sandbox plain, with a log line and nothing else.
+
+What the surface shows: the session's status (working, idle, suspended by
+the idle lease), the diff after each turn, messages both ways, a Stop that
+interrupts the turn, and — on a Host with remote terminal access — the
+sandbox's address, so a `/terminal` typed on the surface is answered from
+the member row. A sandbox created before remote access was enabled learns
+its address when `remote enable` runs.
+
+A surface opens automatically: when the account service offers one for a
+platform this Host serves, every `sandboxes new` gets a surface and the
+session's status and diffs are mirrored to it from then on. Remote terminal
+access is different — it is off until an operator runs `remote enable`
+(next section). `bin/ncl sandboxes surface disable` stops opening surfaces
+for new sandboxes on this Host, kept across restarts; surfaces already open
+are untouched, and `surface enable` turns it back on.
+
+```sh
+bin/ncl sandboxes surface status my-project
+bin/ncl sandboxes surface archive my-project --summary "Shipped the page."
+bin/ncl sandboxes surface disable
+bin/ncl sandboxes surface enable
+```
+
+Archiving is always explicit; neither a Stop nor deleting the sandbox
+archives the surface.
+
+## Remote terminal
+
+Remote terminal access lets an approved SSH key land in a sandbox on this
+Host from another machine. The Host runs its own SSH server, in-process, on
+loopback: its own host key, public keys only, any username (the key decides,
+not the login name), a terminal and nothing else — no shell, no forwarding,
+no file transfer, no password. Reachability comes from the account link,
+not from a listener of its own: the Host never listens on the network, and
+every stream that reaches the server was relayed by the Host itself (see
+[the community portal](community-portal.md#remote-terminal)). It lives in
+the community-portal module and is off until an operator enables it.
+
+### Enabling
+
+```sh
+bin/ncl sandboxes remote enable [--name my-machine]
+bin/ncl sandboxes remote status
+bin/ncl sandboxes remote disable
+```
+
+The name is a DNS label: 3–32 lowercase letters, digits and single hyphens,
+with a few common words reserved (the account service has the last word).
+It becomes this machine's address once the link relays terminals, and it
+names the default sandbox a remote terminal lands in. When the Host is
+signed in the account confirms or assigns the name (omit `--name` to let it
+choose) and the command prints the address to use; a name renamed later in
+the browser is reported as a changed address. Without a sign-in, pass
+`--name`. Enabling generates the host key once under `data/door/`, takes
+the first free loopback port in 33022–33121, starts the server inside the
+Host process, and keeps it running across Host restarts until you disable
+it. Disabling ends open sessions and keeps the host key and the approved
+keys. Nothing has to be installed on the Host for this: no OpenSSH server,
+no extra account, no system group, no native module. The terminal a
+session gets is the container runtime's own, opened through the same
+runtime API the Host already manages sessions with.
+
+### Keys and pairing
+
+Every key the server sees is admitted to exactly one program:
+
+- an approved key lands in a sandbox (next section);
+- an unknown key enters the waiting room, which prints the key's
+  fingerprint, where the connection came from, the time, the approval page
+  and (through the account link) a short approval code, then waits up to
+  ten minutes. Approve it from the Host or in the browser and the same
+  session continues into the sandbox without reconnecting. A machine holds
+  at most four waiting rooms at once and records at most ten pending keys
+  per ten minutes; beyond that the room says so and ends.
+
+```sh
+bin/ncl sandboxes remote keys add ~/.ssh/id_ed25519.pub --label laptop
+bin/ncl sandboxes remote keys list
+bin/ncl sandboxes remote keys approve SHA256:…
+bin/ncl sandboxes remote keys revoke SHA256:…
+```
+
+Fingerprints are the `SHA256:…` form `ssh-keygen -lf` prints. Revoking a
+key ends its open sessions and sends it back to the waiting room on its next
+connection. Keys approved in the browser reach the Host with the account's
+snapshot and are revoked there; `keys list` shows them separately. The
+approval page the waiting room shows is the enrolled portal's, or
+`NANOCLAW_TERMINAL_APPROVAL_URL` when set; a Host that never enrolled with
+a portal approves keys on the machine only.
+
+### Landing
+
+The Host records what each relayed stream is for. A stream for the account
+lands in the default sandbox named after the account, created on first use;
+a stream for a named sandbox attaches that sandbox, waking it if it went
+cold. `ssh <address> ls` prints the sandbox list instead of landing. Detach
+with **Ctrl-b, then d**; the session keeps running. A connection the Host
+did not relay (for example a direct loopback connection) is refused after
+authentication. While remote access is enabled, `sandboxes new` also
+registers the new sandbox's name with the account so it gets an address of
+its own (`<sandbox>.<name>.<zone>`), and deleting the group frees it; both
+are best effort and never get in the way of the sandbox itself.
+
 ## Configuration and dependencies
 
 Code mode uses the existing agent image, Claude Code installation, and
@@ -169,6 +286,11 @@ of typing it; unset, mail is typed into the terminal when the agent is
 idle. `NANOCLAW_CODE_ENV` is a JSON object of extra environment variables
 for code-mode containers; it never overrides the provider's credential
 lane.
+
+Remote terminal access needs an SSH client on the terminal machine; the
+Host side is the Host process itself (the `ssh2` protocol library, loaded
+only once remote access is enabled) and the container runtime's exec API,
+which the Host already uses to run sessions.
 
 Code mode currently supports the `claude` provider only.
 

--- a/docs/community-portal.md
+++ b/docs/community-portal.md
@@ -91,6 +91,32 @@ that stays silent for 65 seconds. Over the link the host receives only the accou
 snapshot and device presence; it sends nothing about your agents, messages or files. Foreground
 setup can hold the journal while the host stays connected; the service need not stop.
 
+## Remote terminal
+
+With remote terminal access enabled (`bin/ncl sandboxes remote enable`, see
+[code mode](code-mode.md#remote-terminal)), the same link carries terminals. The host announces
+the `ssh` capability, and every terminal the account relays arrives as one `ssh` channel: the
+host connects to its own loopback SSH server from a distinct source port, records which account
+or sandbox that port is for, and pipes bytes both ways in 16 KiB chunks under a 64 KiB
+per-direction window, acknowledging a chunk only once the server has taken it. The last bytes of
+a session are acknowledged before the stream closes; a dropped link tears every stream down, and
+the terminal reconnects into the same tmux session. Enabling or disabling remote access restarts
+the link so the capability is re-announced, the host renews its link ticket every ten minutes so
+streams outlive it, and at most eight streams are open at once.
+
+The door's state — enabled, its port, the fingerprints it honours — is reported to the portal
+(`PUT /api/v1/terminal/host`) on every start and disable and every fifteen minutes, and journaled
+under `terminal` in `data/community-portal.json`. Keys approved or revoked in the browser, a
+rename, and a disable reach the host inside the perks snapshot's `terminal` section. Public keys
+never travel down the link; fingerprints do. Sandboxes created while remote access is enabled
+are registered with the account (`POST /api/v1/terminal/sandboxes`) so each gets an address of
+its own; deleting the group frees it.
+
+A host that has a managed chat app also opens a chat surface for each coding session through the
+service that manages the app (`/v1/code-channels`, bearer = the install token); see
+[code mode](code-mode.md#a-chat-surface-for-a-coding-session). A sandbox's terminal address is
+reported on its surface's member row so the surface can answer `/terminal` itself.
+
 ## Signing a machine out
 
 Forget the machine under **Devices** in the portal. Its install token stops working at the

--- a/package.json
+++ b/package.json
@@ -40,12 +40,14 @@
     "chat": "4.29.0",
     "cron-parser": "5.5.0",
     "kleur": "^4.1.5",
+    "ssh2": "1.17.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.0",
+    "@types/ssh2": "1.15.6",
     "eslint": "^9.35.0",
     "eslint-plugin-no-catch-all": "^1.1.0",
     "globals": "^15.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
+      ssh2:
+        specifier: 1.17.0
+        version: 1.17.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -42,6 +45,9 @@ importers:
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.17
+      '@types/ssh2':
+        specifier: 1.15.6
+        version: 1.15.6
       eslint:
         specifier: ^9.35.0
         version: 9.39.4
@@ -441,8 +447,14 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/ssh2@1.15.6':
+    resolution: {integrity: sha512-oGdxhBqcRTwSTKFm+9EiKzkNVYRLEFkcW44lhguvBalGJbWfGnDt/ezwSUZc+SF9m9bMc3VyklNAtp7zICjS5w==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -558,6 +570,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -572,6 +587,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   better-sqlite3@13.0.3:
     resolution: {integrity: sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==}
     engines: {node: '>=22'}
@@ -582,6 +600,10 @@ packages:
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -625,6 +647,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   cron-parser@5.5.0:
     resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
@@ -1084,6 +1110,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1174,6 +1203,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -1196,6 +1228,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1243,6 +1279,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1258,6 +1297,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -1657,9 +1699,17 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/ssh2@1.15.6':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/unist@3.0.3': {}
 
@@ -1816,6 +1866,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   bail@2.0.2: {}
@@ -1823,6 +1877,10 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
 
   better-sqlite3@13.0.3:
     dependencies:
@@ -1836,6 +1894,9 @@ snapshots:
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
+
+  buildcheck@0.0.7:
+    optional: true
 
   callsites@3.1.0: {}
 
@@ -1871,6 +1932,12 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.28.0
+    optional: true
 
   cron-parser@5.5.0:
     dependencies:
@@ -2480,6 +2547,9 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nan@2.28.0:
+    optional: true
+
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
@@ -2584,6 +2654,8 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
+  safer-buffer@2.1.2: {}
+
   semver@7.7.4: {}
 
   shebang-command@2.0.0:
@@ -2597,6 +2669,14 @@ snapshots:
   sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.28.0
 
   stackback@0.0.2: {}
 
@@ -2635,6 +2715,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tweetnacl@0.14.5: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -2651,6 +2733,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 

--- a/src/community-portal/device-client.ts
+++ b/src/community-portal/device-client.ts
@@ -6,6 +6,16 @@ import type { InstallIdentity } from './install-identity.js';
 import type { CellTicket, LinkLog } from './link.js';
 import { readJson, writePrivate } from './private-file.js';
 import { processLock } from './process-lock.js';
+import type {
+  JournalTerminal,
+  TerminalEnableRequest,
+  TerminalEnableResult,
+  TerminalPendingRequest,
+  TerminalPendingResult,
+  TerminalReport,
+  TerminalReportResult,
+  TerminalSandboxResult,
+} from './terminal.js';
 
 /**
  * A checkout's client for the community portal's HTTP API. Every request
@@ -75,6 +85,8 @@ export interface Journal {
   slackSetup?: SlackSetup;
   reminders?: Partial<Record<string, boolean>>;
   reminderPending?: Partial<Record<string, boolean>>;
+  /** The loopback door's state, written by `remote enable|disable`; read by the running host. */
+  terminal?: JournalTerminal;
 }
 
 export interface DeviceRegistration {
@@ -240,6 +252,38 @@ export class DeviceClient {
   /** A short-lived ticket for the cell link, proved with the device key. */
   ticket(signal?: AbortSignal): Promise<CellTicket> {
     return this.call<CellTicket>('POST', '/api/v1/cell-ticket', { body: {}, signal, proof: true });
+  }
+
+  /** The door's state: on every door start, every fifteen minutes while enabled, and on disable. */
+  reportTerminal(report: TerminalReport, signal?: AbortSignal): Promise<TerminalReportResult> {
+    return this.call<TerminalReportResult>('PUT', '/api/v1/terminal/host', { body: report, signal });
+  }
+
+  /** Enable remote access, proved with the device key: the service confirms or assigns the name and the address. */
+  terminalEnable(request: TerminalEnableRequest, signal?: AbortSignal): Promise<TerminalEnableResult> {
+    return this.call<TerminalEnableResult>('POST', '/api/v1/terminal/enable', { body: request, signal, proof: true });
+  }
+
+  /** A key waiting in the door's waiting room: the service records it and mints the approval code. */
+  terminalPending(request: TerminalPendingRequest, signal?: AbortSignal): Promise<TerminalPendingResult> {
+    return this.call<TerminalPendingResult>('POST', '/api/v1/terminal/keys/pending', { body: request, signal });
+  }
+
+  /** A sandbox created while remote access is enabled: the service gives it an address of its own. */
+  terminalSandboxAdd(name: string, signal?: AbortSignal): Promise<TerminalSandboxResult> {
+    return this.call<TerminalSandboxResult>('POST', '/api/v1/terminal/sandboxes', { body: { name }, signal });
+  }
+
+  /** The reverse: the sandbox is gone and its address is freed. */
+  terminalSandboxRemove(name: string, signal?: AbortSignal): Promise<{ ok: boolean }> {
+    return this.call<{ ok: boolean }>('DELETE', `/api/v1/terminal/sandboxes/${encodeURIComponent(name)}`, {
+      signal,
+    });
+  }
+
+  /** The account's terminal section as the mirror carries it. */
+  terminalKeys(signal?: AbortSignal): Promise<unknown> {
+    return this.call<unknown>('GET', '/api/v1/terminal/keys', { signal });
   }
 
   protected async call<T>(

--- a/src/community-portal/frame-vectors.json
+++ b/src/community-portal/frame-vectors.json
@@ -43,7 +43,46 @@
       "frame": { "v": 1, "ch": 1, "seq": 3, "t": "error", "code": "unsupported" }
     },
     { "raw": "{\"v\":1,\"ch\":1,\"seq\":4,\"t\":\"end\"}", "frame": { "v": 1, "ch": 1, "seq": 4, "t": "end" } },
-    { "raw": "{\"v\":1,\"ch\":1,\"seq\":5,\"t\":\"close\"}", "frame": { "v": 1, "ch": 1, "seq": 5, "t": "close" } }
+    { "raw": "{\"v\":1,\"ch\":1,\"seq\":5,\"t\":\"close\"}", "frame": { "v": 1, "ch": 1, "seq": 5, "t": "close" } },
+    {
+      "raw": "{\"v\":1,\"ch\":0,\"seq\":1,\"t\":\"hello\",\"leg\":\"host\",\"caps\":[\"perks\",\"ssh\"]}",
+      "frame": { "v": 1, "ch": 0, "seq": 1, "t": "hello", "leg": "host", "caps": ["perks", "ssh"] }
+    },
+    {
+      "raw": "{\"v\":1,\"ch\":0,\"seq\":3,\"t\":\"renew\",\"ticket\":\"eyJhbGciOiJFUzI1NiJ9.e30.c2ln\"}",
+      "frame": { "v": 1, "ch": 0, "seq": 3, "t": "renew", "ticket": "eyJhbGciOiJFUzI1NiJ9.e30.c2ln" }
+    },
+    {
+      "raw": "{\"v\":1,\"ch\":0,\"seq\":6,\"t\":\"renewed\",\"exp\":1757600000}",
+      "frame": { "v": 1, "ch": 0, "seq": 6, "t": "renewed", "exp": 1757600000 }
+    },
+    {
+      "raw": "{\"v\":1,\"ch\":2,\"seq\":1,\"t\":\"open\",\"kind\":\"ssh\",\"stream\":\"q7Xk1m2n3o4p5r6s7t8u9v\",\"target\":{\"account\":\"alice\",\"sandbox\":\"api\"},\"source\":{\"ip\":\"2001:db8::1\",\"port\":54321},\"ticket\":\"jti_0123456789abcdef\"}",
+      "frame": {
+        "v": 1,
+        "ch": 2,
+        "seq": 1,
+        "t": "open",
+        "kind": "ssh",
+        "stream": "q7Xk1m2n3o4p5r6s7t8u9v",
+        "target": { "account": "alice", "sandbox": "api" },
+        "source": { "ip": "2001:db8::1", "port": 54321 },
+        "ticket": "jti_0123456789abcdef"
+      }
+    },
+    {
+      "raw": "{\"v\":1,\"ch\":2,\"seq\":2,\"t\":\"data\",\"off\":0,\"b64\":\"U1NILTIuMC1PcGVuU1NIXzkuOQ0K\"}",
+      "frame": { "v": 1, "ch": 2, "seq": 2, "t": "data", "off": 0, "b64": "U1NILTIuMC1PcGVuU1NIXzkuOQ0K" }
+    },
+    {
+      "raw": "{\"v\":1,\"ch\":2,\"seq\":3,\"t\":\"credit\",\"ack\":21}",
+      "frame": { "v": 1, "ch": 2, "seq": 3, "t": "credit", "ack": 21 }
+    },
+    { "raw": "{\"v\":1,\"ch\":2,\"seq\":4,\"t\":\"end\"}", "frame": { "v": 1, "ch": 2, "seq": 4, "t": "end" } },
+    {
+      "raw": "{\"v\":1,\"ch\":2,\"seq\":5,\"t\":\"close\",\"reason\":\"peer\"}",
+      "frame": { "v": 1, "ch": 2, "seq": 5, "t": "close", "reason": "peer" }
+    }
   ],
   "invalid": [
     "{not json",
@@ -64,6 +103,9 @@
     "{\"v\":1,\"ch\":2,\"seq\":1,\"t\":\"hello\"}",
     "{\"v\":1,\"ch\":2,\"seq\":1,\"t\":\"ping\"}",
     "{\"v\":1,\"ch\":2,\"seq\":1,\"t\":\"perks.changed\"}",
+    "{\"v\":1,\"ch\":2,\"seq\":1,\"t\":\"renew\",\"ticket\":\"t\"}",
+    "{\"v\":1,\"ch\":2,\"seq\":1,\"t\":\"renewed\",\"exp\":1}",
+    "{\"v\":1,\"ch\":0,\"seq\":1,\"t\":\"credit\",\"ack\":0}",
     "{\"type\":\"pong\"}",
     "{\"type\":\"perks.changed\"}"
   ]

--- a/src/community-portal/index.ts
+++ b/src/community-portal/index.ts
@@ -17,3 +17,4 @@ export * from './mux.js';
 export * from './private-file.js';
 export * from './process-lock.js';
 export * from './setup-client.js';
+export * from './terminal.js';

--- a/src/community-portal/link.test.ts
+++ b/src/community-portal/link.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, expect, it, vi } from 'vitest';
-import { CLOSE_FORBIDDEN, CellLink, computeBackoffDelay, type LinkSocket } from './link.js';
+import {
+  CLOSE_FORBIDDEN,
+  CellLink,
+  MAX_STREAMS,
+  computeBackoffDelay,
+  hostCaps,
+  parseSshOpen,
+  type LinkSocket,
+  type SshChannel,
+  type SshOpen,
+  type SshOpener,
+} from './link.js';
+import type { Frame } from './mux.js';
 
 type Listener = (event: { data: unknown; code?: number }) => void;
 
@@ -136,14 +148,35 @@ it('dials with the ticket as a subprotocol, says hello as the host leg first, an
   expect(link.connected).toBe(false);
 });
 
-it('refuses channel kinds it does not support and ignores their data', async () => {
+/** A stream opener the test drives by hand: records every open and the frames each channel receives. */
+function fakeOpener() {
+  const opened: { open: SshOpen; channel: SshChannel; frames: Frame[]; torn: number }[] = [];
+  const ssh: SshOpener = (open, channel) => {
+    const entry = { open, channel, frames: [] as Frame[], torn: 0 };
+    opened.push(entry);
+    return { onFrame: (frame) => entry.frames.push(frame), onTeardown: () => entry.torn++ };
+  };
+  return { ssh, opened };
+}
+const sshOpen = (stream: string, extra: Record<string, unknown> = {}): Record<string, unknown> => ({
+  kind: 'ssh',
+  stream,
+  target: { account: 'alice' },
+  source: { ip: '2001:db8::1', port: 4242 },
+  ...extra,
+});
+
+it('refuses channel kinds it does not support, ssh included while no opener is installed, and ignores their data', async () => {
   const { link, onSnapshot } = connect();
   link.start();
   await settle();
   const socket = FakeSocket.instances[0];
   socket.open();
-  socket.frame(2, 'open', { kind: 'ssh' });
+  expect(socket.frames()[0]).toMatchObject({ t: 'hello', caps: ['perks'] });
+  socket.frame(2, 'open', sshOpen('s1'));
   expect(socket.frames().at(-1)).toEqual({ v: 1, ch: 2, seq: 1, t: 'error', code: 'unsupported' });
+  socket.frame(3, 'open', { kind: 'files' });
+  expect(socket.frames().at(-1)).toEqual({ v: 1, ch: 3, seq: 1, t: 'error', code: 'unsupported' });
   socket.frame(2, 'data', { snapshot: {}, presence: [] });
   expect(onSnapshot).not.toHaveBeenCalled();
   socket.frame(1, 'open', { kind: 'perks' });
@@ -306,6 +339,139 @@ it('reconnects on 4401 and 4008/4009 (logging the latter as a bug) and stops on 
   link.start();
   await settle();
   expect(FakeSocket.instances).toHaveLength(4);
+});
+
+it('announces ssh with an opener installed and hands every ssh open to it with its target and source', async () => {
+  const { ssh, opened } = fakeOpener();
+  const { link, log } = connect({ ssh });
+  link.start();
+  await settle();
+  const socket = FakeSocket.instances[0];
+  socket.open();
+  expect(socket.frames()[0]).toEqual({ v: 1, ch: 0, seq: 1, t: 'hello', leg: 'host', caps: ['perks', 'ssh'] });
+  socket.frame(1, 'open', { kind: 'perks' });
+  socket.frame(2, 'open', sshOpen('s1', { target: { account: 'alice', sandbox: 'api' }, ticket: 'jti1' }));
+  expect(opened).toHaveLength(1);
+  expect(opened[0].open).toEqual({
+    stream: 's1',
+    target: { account: 'alice', sandbox: 'api' },
+    source: { ip: '2001:db8::1', port: 4242 },
+    ticket: 'jti1',
+  });
+  expect(opened[0].channel.ch).toBe(2);
+  expect(link.streams).toBe(1);
+  // Frames on the channel reach its handler untouched.
+  socket.frame(2, 'data', { off: 0, b64: 'AAECAw==' });
+  socket.frame(2, 'credit', { ack: 4 });
+  expect(opened[0].frames.map((f) => [f.t, f.off ?? f.ack])).toEqual([
+    ['data', 0],
+    ['credit', 4],
+  ]);
+  // The channel sends with the ssh allowance: a full 16 KiB chunk fits.
+  const chunk = Buffer.alloc(16_384, 1).toString('base64');
+  expect(opened[0].channel.send('data', { off: 0, b64: chunk })).toBe(true);
+  expect(socket.frames().at(-1)).toMatchObject({ ch: 2, seq: 1, t: 'data', off: 0 });
+  expect(opened[0].channel.send('credit', { ack: 4 })).toBe(true);
+  expect(socket.frames().at(-1)).toEqual({ v: 1, ch: 2, seq: 2, t: 'credit', ack: 4 });
+  // A second open on a channel already open is ignored.
+  socket.frame(2, 'open', sshOpen('s2'));
+  expect(opened).toHaveLength(1);
+  // release forgets the channel and tears its handler down exactly once; later frames go nowhere.
+  opened[0].channel.release();
+  opened[0].channel.release();
+  expect(opened[0].torn).toBe(1);
+  expect(link.streams).toBe(0);
+  socket.frame(2, 'data', { off: 4, b64: 'AA==' });
+  expect(opened[0].frames).toHaveLength(2);
+  // An open that is off the contract is refused with close protocol and never reaches the opener.
+  socket.frame(3, 'open', { kind: 'ssh', stream: 's3' });
+  expect(socket.frames().at(-1)).toEqual({ v: 1, ch: 3, seq: 1, t: 'close', reason: 'protocol' });
+  expect(log).toHaveBeenCalledWith({ event: 'stream_refused', reason: 'protocol' });
+  expect(opened).toHaveLength(1);
+  // A link drop tears every open stream down without sending anything.
+  socket.frame(4, 'open', sshOpen('s4'));
+  expect(opened).toHaveLength(2);
+  const sentBefore = socket.sent.length;
+  socket.lost();
+  expect(opened[1].torn).toBe(1);
+  expect(socket.sent).toHaveLength(sentBefore);
+  expect(link.streams).toBe(0);
+});
+
+it('refuses a ninth stream with close busy and accepts another once a slot frees', async () => {
+  const { ssh, opened } = fakeOpener();
+  const { link, log } = connect({ ssh });
+  link.start();
+  await settle();
+  const socket = FakeSocket.instances[0];
+  socket.open();
+  for (let ch = 2; ch < 2 + MAX_STREAMS; ch++) socket.frame(ch, 'open', sshOpen(`s${ch}`));
+  expect(opened).toHaveLength(MAX_STREAMS);
+  expect(link.streams).toBe(MAX_STREAMS);
+  socket.frame(20, 'open', sshOpen('s20'));
+  expect(socket.frames().at(-1)).toEqual({ v: 1, ch: 20, seq: 1, t: 'close', reason: 'busy' });
+  expect(log).toHaveBeenCalledWith({ event: 'stream_refused', reason: 'busy', stream: 's20' });
+  expect(opened).toHaveLength(MAX_STREAMS);
+  // The far end closes one stream; its pipe releases the channel and the slot is free again.
+  socket.frame(3, 'close', { reason: 'peer' });
+  expect(opened[1].frames.at(-1)).toMatchObject({ t: 'close', reason: 'peer' });
+  opened[1].channel.release();
+  expect(link.streams).toBe(MAX_STREAMS - 1);
+  socket.frame(21, 'open', sshOpen('s21'));
+  expect(opened).toHaveLength(MAX_STREAMS + 1);
+  expect(opened.at(-1)?.open.stream).toBe('s21');
+});
+
+it('renews its ticket into every socket and again after each renewed, leaving expiry as the failure path', async () => {
+  vi.useFakeTimers();
+  const { link, getTicket, log } = connect({ renewMs: 1_000, renewJitterMs: 0 });
+  link.start();
+  await settle();
+  const socket = FakeSocket.instances[0];
+  socket.open();
+  await vi.advanceTimersByTimeAsync(999);
+  expect(getTicket).toHaveBeenCalledTimes(1);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(getTicket).toHaveBeenCalledTimes(2);
+  expect(socket.frames().at(-1)).toEqual({ v: 1, ch: 0, seq: 2, t: 'renew', ticket: 'tkt.2' });
+  // Nothing more until the cell confirms.
+  await vi.advanceTimersByTimeAsync(2_000);
+  expect(getTicket).toHaveBeenCalledTimes(2);
+  socket.frame(0, 'renewed', { exp: 1_757_600_000 });
+  expect(log).toHaveBeenCalledWith({ event: 'renewed', exp: 1_757_600_000 });
+  await vi.advanceTimersByTimeAsync(1_000);
+  expect(getTicket).toHaveBeenCalledTimes(3);
+  expect(socket.frames().at(-1)).toEqual({ v: 1, ch: 0, seq: 3, t: 'renew', ticket: 'tkt.3' });
+  socket.frame(0, 'renewed', { exp: 1_757_600_900 });
+  // A ticket that cannot be fetched is logged; the socket stays up and the cell's expiry close redials.
+  getTicket.mockRejectedValueOnce(Object.assign(new Error('offline'), { code: 'ECONNREFUSED' }));
+  await vi.advanceTimersByTimeAsync(1_000);
+  expect(log).toHaveBeenCalledWith({ event: 'renew_failed', code: 'ECONNREFUSED' });
+  expect(socket.closed).toBe(false);
+  expect(socket.frames().filter((f) => f.t === 'renew')).toHaveLength(2);
+  // A socket that is gone is never renewed; stop clears the timer.
+  socket.frame(0, 'renewed', { exp: 1 });
+  link.stop();
+  await vi.advanceTimersByTimeAsync(5_000);
+  expect(getTicket).toHaveBeenCalledTimes(4);
+});
+
+it('jitters the renewal and keeps its caps explicit', () => {
+  expect(hostCaps()).toEqual(['perks']);
+  expect(hostCaps({ ssh: true })).toEqual(['perks', 'ssh']);
+  expect(hostCaps({ ssh: false })).toEqual(['perks']);
+  const frame = (fields: Record<string, unknown>): Frame => ({ v: 1, ch: 2, seq: 1, t: 'open', ...fields });
+  expect(parseSshOpen(frame(sshOpen('s1')))).toEqual({
+    stream: 's1',
+    target: { account: 'alice' },
+    source: { ip: '2001:db8::1', port: 4242 },
+  });
+  expect(parseSshOpen(frame(sshOpen('s1', { ticket: 7 })))?.ticket).toBeUndefined();
+  expect(parseSshOpen(frame(sshOpen('')))).toBeNull();
+  expect(parseSshOpen(frame(sshOpen('s1', { target: {} })))).toBeNull();
+  expect(parseSshOpen(frame(sshOpen('s1', { target: { account: 'alice', sandbox: '' } })))).toBeNull();
+  expect(parseSshOpen(frame(sshOpen('s1', { source: { ip: '::1' } })))).toBeNull();
+  expect(parseSshOpen(frame(sshOpen('s1', { source: { ip: 1, port: 2 } })))).toBeNull();
 });
 
 it('computes the jittered exponential backoff of the reference module', () => {

--- a/src/community-portal/link.ts
+++ b/src/community-portal/link.ts
@@ -1,5 +1,5 @@
 import { errorCode, portalError } from './errors.js';
-import { CONTROL_CHANNEL, MAX_CELL_FRAME_CHARS, Mux, type Frame } from './mux.js';
+import { CONTROL_CHANNEL, MAX_CELL_FRAME_CHARS, Mux, SSH_KIND, type ChannelHandler, type Frame } from './mux.js';
 
 /**
  * The host's link to its account cell (wss://<portal>/cell/link): the
@@ -7,11 +7,19 @@ import { CONTROL_CHANNEL, MAX_CELL_FRAME_CHARS, Mux, type Frame } from './mux.js
  * Node 22. Every dial asks for a fresh ticket, says hello as the host leg,
  * pings every 20 s, drops a socket that stays silent for 60 s or does not open
  * within 10 s, and reconnects with jittered exponential backoff (1 s base,
- * 30 s cap). The cell opens a `perks` data channel whose `data` frames carry
- * the perks snapshot and device presence; any other channel kind is refused
- * with `error unsupported`. The `data` frame is the source of truth and
- * `perks.changed` only a hint, acted on when no data frame preceded it. The
- * host sends nothing but hello, ping, and error/close on a data channel. A
+ * 30 s cap). Ten minutes into each socket the host asks for another ticket
+ * and sends `renew` on the control channel, so open streams outlive the
+ * ticket; the expiry close (4401) stays the failure path.
+ *
+ * The cell opens a `perks` data channel whose `data` frames carry the perks
+ * snapshot and device presence. With a stream opener installed (the host's
+ * loopback door is enabled) the host also announces the `ssh` cap and accepts
+ * `open { kind: "ssh" }`: each such channel is one relayed terminal stream,
+ * handed to the opener with its target and source; at most eight are open at
+ * once, a ninth is refused with `close busy`. Any other channel kind, and
+ * `ssh` while no opener is installed, is refused with `error unsupported`.
+ * The `data` frame on the perks channel is the source of truth and
+ * `perks.changed` only a hint, acted on when no data frame preceded it. A
  * close with 4403 (device forgotten) means "sign in required": the link stops
  * dialling until it is started again; 4008/4009 are the host's own protocol
  * bugs and are logged before the ordinary backoff. The socket constructor is
@@ -36,6 +44,30 @@ export interface PerksData {
   presence: unknown;
 }
 
+/** The cell's `open { kind: "ssh" }` payload: one terminal stream bound for the door. */
+export interface SshOpen {
+  /** The stream id the service minted (16 random bytes, base64url). */
+  stream: string;
+  /** The account name (not id) and, for a sandbox address, the sandbox. */
+  target: { account: string; sandbox?: string };
+  /** The terminal's public address as the relay saw it. */
+  source: { ip: string; port: number };
+  /** The admission ticket's id, for audit correlation only. */
+  ticket?: string;
+}
+
+/** The link's side of one open `ssh` channel, handed to the stream opener. */
+export interface SshChannel {
+  readonly ch: number;
+  /** Send `data`, `credit`, `end` or `close`; false when the frame exceeded the channel's allowance. */
+  send(t: 'data' | 'credit' | 'end' | 'close', fields?: Record<string, unknown>): boolean;
+  /** Forget the channel once `close` went out or came in; tears the handler down exactly once. */
+  release(): void;
+}
+
+/** Pipes one stream to the door; returns the handler that receives the channel's frames. */
+export type SshOpener = (open: SshOpen, channel: SshChannel) => ChannelHandler;
+
 export interface LinkSocket {
   readonly readyState: number;
   send(data: string): void;
@@ -48,7 +80,7 @@ export type LinkSocketConstructor = new (url: URL, protocols: string[]) => LinkS
 
 export interface CellLinkOptions {
   origin: string;
-  /** A fresh ticket for every dial. */
+  /** A fresh ticket for every dial and every renewal. */
   getTicket(signal: AbortSignal): Promise<CellTicket>;
   /** Every `data` frame on the perks channel: right after hello and on every mirror change. */
   onSnapshot?: (data: PerksData) => void;
@@ -56,12 +88,16 @@ export interface CellLinkOptions {
   onChange?: () => void;
   /** The cell closed with 4403: this device was forgotten. The link stays down until `start()`. */
   onForbidden?: () => void;
+  /** Accept `ssh` channels and announce the cap; absent while the door is disabled. */
+  ssh?: SshOpener;
   log?: LinkLog;
   caps?: string[];
   ver?: string;
   pingMs?: number;
   pongTimeoutMs?: number;
   handshakeMs?: number;
+  renewMs?: number;
+  renewJitterMs?: number;
   backoffBaseMs?: number;
   backoffCapMs?: number;
   Socket?: LinkSocketConstructor;
@@ -72,12 +108,18 @@ export interface CellLinkOptions {
 export const PING_INTERVAL_MS = 20_000;
 export const PONG_TIMEOUT_MS = 60_000;
 export const HANDSHAKE_TIMEOUT_MS = 10_000;
+/** The host renews its 15-minute ticket this far into every socket, give or take the jitter. */
+export const RENEW_INTERVAL_MS = 10 * 60_000;
+export const RENEW_JITTER_MS = 30_000;
 export const BACKOFF_BASE_MS = 1_000;
 export const BACKOFF_CAP_MS = 30_000;
 /** A socket that stayed open this long resets the backoff counter when it drops. */
 export const STABLE_RESET_MS = 30_000;
 export const CELL_PATH = '/cell/link';
 export const HOST_CAPS = ['perks'];
+export const SSH_CAP = SSH_KIND;
+/** Open `ssh` channels per account; the host refuses the next `open` with `close busy`. */
+export const MAX_STREAMS = 8;
 /** Close codes the cell uses (its WebSocket layer permits only 1000 and 3000–4999). */
 export const CLOSE_EXPIRED = 4401;
 export const CLOSE_FORBIDDEN = 4403;
@@ -85,6 +127,11 @@ export const CLOSE_PROTOCOL = 4008;
 export const CLOSE_OVERSIZE = 4009;
 
 const OPEN = 1;
+
+/** The caps a host announces: `ssh` only while its door accepts streams. */
+export function hostCaps({ ssh = false }: { ssh?: boolean } = {}): string[] {
+  return ssh ? [...HOST_CAPS, SSH_CAP] : [...HOST_CAPS];
+}
 
 /**
  * Jittered exponential backoff: the window is base * 2^attempt capped at
@@ -98,6 +145,22 @@ export function computeBackoffDelay(
   return Math.floor(window / 2 + random() * (window / 2));
 }
 
+/** The `open { kind: "ssh" }` fields the host relies on, or null when the payload is off-contract. */
+export function parseSshOpen(frame: Frame): SshOpen | null {
+  const target = frame.target as { account?: unknown; sandbox?: unknown } | undefined;
+  const source = frame.source as { ip?: unknown; port?: unknown } | undefined;
+  if (typeof frame.stream !== 'string' || !frame.stream) return null;
+  if (typeof target?.account !== 'string' || !target.account) return null;
+  if (target.sandbox !== undefined && (typeof target.sandbox !== 'string' || !target.sandbox)) return null;
+  if (typeof source?.ip !== 'string' || !Number.isInteger(source.port)) return null;
+  return {
+    stream: frame.stream,
+    target: { account: target.account, ...(target.sandbox === undefined ? {} : { sandbox: target.sandbox }) },
+    source: { ip: source.ip, port: source.port as number },
+    ...(typeof frame.ticket === 'string' ? { ticket: frame.ticket } : {}),
+  };
+}
+
 export class CellLink {
   connected = false;
   private readonly origin: string;
@@ -105,12 +168,15 @@ export class CellLink {
   private readonly onSnapshot: (data: PerksData) => void;
   private readonly onChange: () => void;
   private readonly onForbidden: () => void;
+  private readonly ssh?: SshOpener;
   private readonly log: LinkLog;
   private readonly caps: string[];
   private readonly ver?: string;
   private readonly pingMs: number;
   private readonly pongTimeoutMs: number;
   private readonly handshakeMs: number;
+  private readonly renewMs: number;
+  private readonly renewJitterMs: number;
   private readonly backoffBaseMs: number;
   private readonly backoffCapMs: number;
   private readonly Socket: LinkSocketConstructor;
@@ -128,6 +194,7 @@ export class CellLink {
   private abort = new AbortController();
   private pinger?: NodeJS.Timeout;
   private handshake?: NodeJS.Timeout;
+  private renewal?: NodeJS.Timeout;
   private reconnect?: NodeJS.Timeout;
 
   constructor({
@@ -136,12 +203,15 @@ export class CellLink {
     onSnapshot = () => {},
     onChange = () => {},
     onForbidden = () => {},
+    ssh,
     log = () => {},
-    caps = HOST_CAPS,
+    caps = hostCaps({ ssh: ssh !== undefined }),
     ver,
     pingMs = PING_INTERVAL_MS,
     pongTimeoutMs = PONG_TIMEOUT_MS,
     handshakeMs = HANDSHAKE_TIMEOUT_MS,
+    renewMs = RENEW_INTERVAL_MS,
+    renewJitterMs = RENEW_JITTER_MS,
     backoffBaseMs = BACKOFF_BASE_MS,
     backoffCapMs = BACKOFF_CAP_MS,
     Socket = globalThis.WebSocket as unknown as LinkSocketConstructor,
@@ -153,12 +223,15 @@ export class CellLink {
     this.onSnapshot = onSnapshot;
     this.onChange = onChange;
     this.onForbidden = onForbidden;
+    this.ssh = ssh;
     this.log = log;
     this.caps = caps;
     this.ver = ver;
     this.pingMs = pingMs;
     this.pongTimeoutMs = pongTimeoutMs;
     this.handshakeMs = handshakeMs;
+    this.renewMs = renewMs;
+    this.renewJitterMs = renewJitterMs;
     this.backoffBaseMs = backoffBaseMs;
     this.backoffCapMs = backoffCapMs;
     this.Socket = Socket;
@@ -181,6 +254,11 @@ export class CellLink {
     const socket = this.socket;
     this.detach();
     if (socket) closeQuietly(socket, 1000, 'shutdown');
+  }
+
+  /** Open terminal streams on the current socket. */
+  get streams(): number {
+    return this.mux?.channelsOfKind(SSH_KIND).length ?? 0;
   }
 
   private async connect(): Promise<void> {
@@ -238,6 +316,7 @@ export class CellLink {
       this.connected = true;
       mux.send(CONTROL_CHANNEL, 'hello', { leg: 'host', caps: this.caps, ...(this.ver ? { ver: this.ver } : {}) });
       this.pinger = setInterval(() => this.beat(socket, mux), this.pingMs);
+      this.scheduleRenewal(socket, mux);
       this.log({ event: 'connected' });
     });
     socket.addEventListener('message', (event) => {
@@ -263,28 +342,69 @@ export class CellLink {
     mux.send(CONTROL_CHANNEL, 'ping');
   }
 
+  private scheduleRenewal(socket: LinkSocket, mux: Mux): void {
+    clearTimeout(this.renewal);
+    const delay = Math.max(0, this.renewMs + (2 * this.random() - 1) * this.renewJitterMs);
+    this.renewal = setTimeout(() => void this.renew(socket, mux), delay);
+  }
+
+  /** A fresh ticket for the same device, sent as `renew`; the cell answers `renewed` and moves the expiry. */
+  private async renew(socket: LinkSocket, mux: Mux): Promise<void> {
+    try {
+      const { ticket } = await this.getTicket(this.abort.signal);
+      if (this.socket !== socket || socket.readyState !== OPEN) return;
+      mux.send(CONTROL_CHANNEL, 'renew', { ticket });
+    } catch (error) {
+      // The expiry close and the redial that follows it remain the failure path.
+      if (this.socket === socket) this.log({ event: 'renew_failed', code: errorCode(error) });
+    }
+  }
+
   private handleFrame(mux: Mux, frame: Frame): void {
     if (frame.ch === CONTROL_CHANNEL) {
       if (frame.t === 'pong') this.lastPong = this.now();
-      else if (frame.t === 'perks.changed') {
+      else if (frame.t === 'renewed') {
+        this.log({ event: 'renewed', ...(typeof frame.exp === 'number' ? { exp: frame.exp } : {}) });
+        if (this.socket) this.scheduleRenewal(this.socket, mux);
+      } else if (frame.t === 'perks.changed') {
         if (!this.snapshotSeen) this.onChange();
         this.snapshotSeen = false;
       } else if (frame.t === 'error') this.log({ event: 'cell_error', code: String(frame.code ?? 'unknown') });
       // hello, status (presence) and a ping need no host action; the cell answers
-      // anything but hello, ping and data-channel error/close with `read_only`.
+      // anything but hello, ping, renew and data-channel frames with `read_only`.
       return;
     }
     const handler = mux.handlerFor(frame.ch);
     if (frame.t === 'open') {
       if (handler) return;
-      if (frame.kind !== 'perks') {
-        mux.send(frame.ch, 'error', { code: 'unsupported' });
-        return;
-      }
-      mux.openChannel(frame.ch, { onFrame: (data) => this.perksFrame(mux, data), onTeardown: () => {} });
+      if (frame.kind === 'perks')
+        mux.openChannel(frame.ch, { onFrame: (data) => this.perksFrame(mux, data), onTeardown: () => {} }, 'perks');
+      else if (frame.kind === SSH_KIND && this.ssh) this.openStream(mux, frame, this.ssh);
+      else mux.send(frame.ch, 'error', { code: 'unsupported' });
       return;
     }
     handler?.onFrame(frame);
+  }
+
+  private openStream(mux: Mux, frame: Frame, opener: SshOpener): void {
+    const ch = frame.ch;
+    const open = parseSshOpen(frame);
+    if (!open) {
+      this.log({ event: 'stream_refused', reason: 'protocol' });
+      mux.send(ch, 'close', { reason: 'protocol' });
+      return;
+    }
+    if (mux.channelsOfKind(SSH_KIND).length >= MAX_STREAMS) {
+      this.log({ event: 'stream_refused', reason: 'busy', stream: open.stream });
+      mux.send(ch, 'close', { reason: 'busy' });
+      return;
+    }
+    const channel: SshChannel = {
+      ch,
+      send: (t, fields) => mux.send(ch, t, fields),
+      release: () => mux.closeChannel(ch),
+    };
+    mux.openChannel(ch, opener(open, channel), SSH_KIND);
   }
 
   private perksFrame(mux: Mux, frame: Frame): void {
@@ -323,8 +443,11 @@ export class CellLink {
   private detach(): void {
     clearInterval(this.pinger);
     clearTimeout(this.handshake);
+    clearTimeout(this.renewal);
     this.pinger = undefined;
     this.handshake = undefined;
+    this.renewal = undefined;
+    // Tears every channel down, so open streams destroy their door sockets.
     this.mux?.reset();
     this.mux = undefined;
     this.socket = undefined;

--- a/src/community-portal/mux.test.ts
+++ b/src/community-portal/mux.test.ts
@@ -4,10 +4,13 @@ import {
   CONTROL_CHANNEL,
   CONTROL_TYPES,
   DATA_TYPES,
+  MAX_CLIENT_FRAME_CHARS,
+  MAX_SSH_FRAME_CHARS,
   Mux,
   PROTOCOL_VERSION,
   decodeFrame,
   encodeFrame,
+  frameAllowance,
   validateFrame,
   type ChannelHandler,
   type Frame,
@@ -27,6 +30,27 @@ describe('frame encode/decode', () => {
     }
   });
 
+  it('pins the ssh channel frames: open with its target, data, credit, end, close, and the control renew pair', () => {
+    const types = vectors.valid.map(({ frame }) => `${frame.ch === CONTROL_CHANNEL ? 'control' : 'data'}:${frame.t}`);
+    for (const t of [
+      'data:open',
+      'data:data',
+      'data:credit',
+      'data:end',
+      'data:close',
+      'control:renew',
+      'control:renewed',
+    ])
+      expect(types).toContain(t);
+    const open = vectors.valid.find(({ frame }) => frame.t === 'open' && frame.kind === 'ssh')?.frame;
+    expect(open).toMatchObject({
+      stream: expect.stringMatching(/^[\w-]{22}$/),
+      target: { account: expect.any(String) },
+      source: { ip: expect.any(String), port: expect.any(Number) },
+      ticket: expect.any(String),
+    });
+  });
+
   it('drops every pinned invalid message, including the pre-cutover flat messages', () => {
     for (const raw of vectors.invalid) expect(decodeFrame(raw)).toBeNull();
   });
@@ -38,8 +62,8 @@ describe('frame encode/decode', () => {
   });
 
   it('validateFrame accepts every declared type on its channel class only', () => {
-    expect(CONTROL_TYPES).toEqual(['hello', 'status', 'ping', 'pong', 'perks.changed', 'error']);
-    expect(DATA_TYPES).toEqual(['open', 'data', 'end', 'error', 'close']);
+    expect(CONTROL_TYPES).toEqual(['hello', 'status', 'ping', 'pong', 'renew', 'renewed', 'perks.changed', 'error']);
+    expect(DATA_TYPES).toEqual(['open', 'data', 'credit', 'end', 'error', 'close']);
     for (const t of CONTROL_TYPES) {
       expect(validateFrame({ v: 1, ch: CONTROL_CHANNEL, seq: 1, t })).toBe(true);
       if (t !== 'error') expect(validateFrame({ v: 1, ch: 9, seq: 1, t })).toBe(false);
@@ -48,6 +72,12 @@ describe('frame encode/decode', () => {
       expect(validateFrame({ v: 1, ch: 9, seq: 1, t })).toBe(true);
       if (t !== 'error') expect(validateFrame({ v: 1, ch: CONTROL_CHANNEL, seq: 1, t })).toBe(false);
     }
+  });
+
+  it('allows 24 000 characters on an ssh channel and 4096 everywhere else', () => {
+    expect(frameAllowance('ssh')).toBe(MAX_SSH_FRAME_CHARS);
+    expect(frameAllowance('perks')).toBe(MAX_CLIENT_FRAME_CHARS);
+    expect(frameAllowance(undefined)).toBe(MAX_CLIENT_FRAME_CHARS);
   });
 });
 
@@ -63,6 +93,10 @@ describe('Mux', () => {
     }, log);
     return { mux, raws, frames, log };
   }
+  const idle: ChannelHandler = { onFrame: () => {}, onTeardown: () => {} };
+  /** A `pad` that makes the frame exactly `total` characters once the envelope is stamped. */
+  const padTo = (ch: number, seq: number, t: string, total: number): string =>
+    'x'.repeat(total - encodeFrame({ v: 1, ch, seq, t, pad: '' }).length);
 
   it('stamps per-channel outbound seq starting at 1', () => {
     const { mux, frames } = makeMux();
@@ -86,6 +120,40 @@ describe('Mux', () => {
     expect(frames[0]).toMatchObject({ v: 1, ch: 2, seq: 1, t: 'data', b64: 'AA==' });
   });
 
+  it('sends a 16 KiB chunk on an ssh channel and refuses that frame on any other channel', () => {
+    const { mux, raws, log } = makeMux();
+    mux.openChannel(1, idle, 'perks');
+    mux.openChannel(2, idle, 'ssh');
+    expect(mux.allowance(0)).toBe(4096);
+    expect(mux.allowance(1)).toBe(4096);
+    expect(mux.allowance(2)).toBe(24_000);
+    expect(mux.allowance(9)).toBe(4096);
+    const chunk = Buffer.alloc(16_384, 7).toString('base64');
+    expect(mux.send(2, 'data', { off: 0, b64: chunk })).toBe(true);
+    expect(raws.at(-1)?.length).toBeLessThanOrEqual(24_000);
+    expect(mux.send(1, 'data', { off: 0, b64: chunk })).toBe(false);
+    expect(mux.send(0, 'hello', { pad: chunk })).toBe(false);
+    expect(raws).toHaveLength(1);
+    const chunkFrame = encodeFrame({ off: 0, b64: chunk, v: 1, ch: 1, seq: 1, t: 'data' }).length;
+    expect(chunkFrame).toBeGreaterThan(21_848);
+    expect(log).toHaveBeenCalledWith({
+      event: 'dropped_oversize_frame',
+      ch: 1,
+      t: 'data',
+      chars: chunkFrame,
+      allowance: 4096,
+    });
+    expect(JSON.stringify(log.mock.calls)).not.toContain(chunk.slice(0, 32));
+    // The boundaries are inclusive.
+    expect(mux.send(2, 'data', { pad: padTo(2, 2, 'data', 24_000) })).toBe(true);
+    expect(mux.send(2, 'data', { pad: padTo(2, 3, 'data', 24_001) })).toBe(false);
+    expect(mux.send(1, 'close', { pad: padTo(1, 2, 'close', 4096) })).toBe(true);
+    expect(mux.send(1, 'close', { pad: padTo(1, 3, 'close', 4097) })).toBe(false);
+    expect(mux.send(0, 'ping', { pad: padTo(0, 2, 'ping', 4096) })).toBe(true);
+    expect(mux.send(0, 'ping', { pad: padTo(0, 3, 'ping', 4097) })).toBe(false);
+    expect(raws.map((raw) => raw.length)).toEqual([chunkFrame, 24_000, 4096, 4096]);
+  });
+
   it('receive returns decoded frames, tolerates seq gaps, and drops invalid frames without their payload', () => {
     const { mux, log } = makeMux();
     const a = mux.receive(JSON.stringify({ v: 1, ch: 5, seq: 1, t: 'open', kind: 'perks' }));
@@ -101,26 +169,55 @@ describe('Mux', () => {
     expect(JSON.stringify(log.mock.calls)).not.toContain('nonsense');
   });
 
-  it('channel registry: open/handlerFor/close with a single teardown', () => {
+  it('receive holds inbound ssh channel frames to their allowance and lets the cell send big perks frames', () => {
+    const { mux, log } = makeMux();
+    mux.openChannel(1, idle, 'perks');
+    mux.openChannel(2, idle, 'ssh');
+    const big = 'x'.repeat(30_000);
+    expect(mux.receive(JSON.stringify({ v: 1, ch: 1, seq: 1, t: 'data', snapshot: big }))?.t).toBe('data');
+    const raw = JSON.stringify({ v: 1, ch: 2, seq: 1, t: 'data', off: 0, b64: big });
+    expect(mux.receive(raw)).toBeNull();
+    expect(log).toHaveBeenCalledWith({
+      event: 'dropped_oversize_frame',
+      ch: 2,
+      t: 'data',
+      chars: raw.length,
+      allowance: 24_000,
+    });
+    expect(JSON.stringify(log.mock.calls)).not.toContain('xxxx');
+    const chunk = Buffer.alloc(16_384, 7).toString('base64');
+    expect(mux.receive(JSON.stringify({ v: 1, ch: 2, seq: 1, t: 'data', off: 0, b64: chunk }))?.t).toBe('data');
+  });
+
+  it('channel registry: open/handlerFor/close with a single teardown, kinds and counts', () => {
     const { mux } = makeMux();
     let teardowns = 0;
     const handler: ChannelHandler = { onFrame: () => {}, onTeardown: () => teardowns++ };
     mux.openChannel(3, handler);
     expect(mux.handlerFor(3)).toBe(handler);
+    expect(mux.kindOf(3)).toBeUndefined();
+    mux.openChannel(4, idle, 'ssh');
+    mux.openChannel(6, idle, 'ssh');
+    mux.openChannel(5, idle, 'perks');
+    expect(mux.channelsOfKind('ssh')).toEqual([4, 6]);
+    expect(mux.channelsOfKind('perks')).toEqual([5]);
     mux.closeChannel(3);
     expect(mux.handlerFor(3)).toBeUndefined();
     mux.closeChannel(3);
     expect(teardowns).toBe(1);
+    mux.closeChannel(4);
+    expect(mux.channelsOfKind('ssh')).toEqual([6]);
   });
 
   it('reset tears down all channels and restarts seq counters', () => {
     const { mux, frames } = makeMux();
     const torn: number[] = [];
     mux.openChannel(1, { onFrame: () => {}, onTeardown: () => torn.push(1) });
-    mux.openChannel(2, { onFrame: () => {}, onTeardown: () => torn.push(2) });
+    mux.openChannel(2, { onFrame: () => {}, onTeardown: () => torn.push(2) }, 'ssh');
     mux.send(1, 'data', { b64: 'AA==' });
     mux.reset();
     expect(torn.sort()).toEqual([1, 2]);
+    expect(mux.channelsOfKind('ssh')).toEqual([]);
     mux.send(1, 'data', { b64: 'AA==' });
     expect(frames[frames.length - 1].seq).toBe(1);
   });

--- a/src/community-portal/mux.ts
+++ b/src/community-portal/mux.ts
@@ -5,11 +5,17 @@
  *   { "v":1, "ch":<int>, "seq":<int>, "t":"<type>", ...fields }
  *
  * - ch 0 is the control channel: "hello", "status", "ping"/"pong",
- *   "perks.changed" and "error".
+ *   "renew"/"renewed", "perks.changed" and "error".
  * - ch > 0 are data channels, opened by the cell with "open" {kind, ...};
- *   "data", "end", "error" {code, msg} and "close" follow on the same ch.
+ *   "data", "credit", "end", "error" {code, msg} and "close" follow on the
+ *   same ch.
  * - seq is per channel, per sender, starts at 1, increments by 1. Receivers
  *   tolerate gaps.
+ *
+ * Frames a client leg sends are at most 4096 characters, except on an open
+ * `ssh` channel, where a 16 KiB chunk needs room: 24 000 characters. The mux
+ * knows each open channel's kind and refuses (logs and drops) anything the
+ * cell would close the socket for.
  *
  * Nothing in this file may log payload contents; envelope metadata only.
  */
@@ -17,13 +23,17 @@ export const PROTOCOL_VERSION = 1 as const;
 export const CONTROL_CHANNEL = 0;
 /** Frames from client legs are at most this long. */
 export const MAX_CLIENT_FRAME_CHARS = 4096;
+/** Frames on one of the socket's open `ssh` channels may be this long instead. */
+export const MAX_SSH_FRAME_CHARS = 24_000;
 /** The cell may send larger frames (a snapshot), up to this long. */
 export const MAX_CELL_FRAME_CHARS = 512_000;
+/** The channel kind that carries one relayed terminal stream. */
+export const SSH_KIND = 'ssh';
 
 /** Frame types valid on the control channel (ch 0). */
-export const CONTROL_TYPES = ['hello', 'status', 'ping', 'pong', 'perks.changed', 'error'] as const;
+export const CONTROL_TYPES = ['hello', 'status', 'ping', 'pong', 'renew', 'renewed', 'perks.changed', 'error'] as const;
 /** Frame types valid on data channels (ch > 0). */
-export const DATA_TYPES = ['open', 'data', 'end', 'error', 'close'] as const;
+export const DATA_TYPES = ['open', 'data', 'credit', 'end', 'error', 'close'] as const;
 
 export interface Frame {
   v: typeof PROTOCOL_VERSION;
@@ -34,6 +44,11 @@ export interface Frame {
 }
 
 export type MuxLog = (event: { event: string; [field: string]: unknown }) => void;
+
+/** How long a client frame may be on a channel of `kind` (`undefined`: the control channel). */
+export function frameAllowance(kind: string | undefined): number {
+  return kind === SSH_KIND ? MAX_SSH_FRAME_CHARS : MAX_CLIENT_FRAME_CHARS;
+}
 
 /** Serialize a frame to the single-JSON-text wire form. */
 export function encodeFrame(frame: Frame): string {
@@ -75,36 +90,58 @@ export interface ChannelHandler {
   onTeardown(): void;
 }
 
+interface Channel {
+  handler: ChannelHandler;
+  kind?: string;
+}
+
 /**
  * Per-connection multiplexer: outbound seq counters, inbound seq gap
- * tracking, and the registry of open data channels. One Mux per WebSocket;
- * throw it away (reset()) when the socket drops.
+ * tracking, and the registry of open data channels with their kinds. One Mux
+ * per WebSocket; throw it away (reset()) when the socket drops.
  */
 export class Mux {
   private readonly outSeq = new Map<number, number>();
   private readonly inSeq = new Map<number, number>();
-  private readonly channels = new Map<number, ChannelHandler>();
+  private readonly channels = new Map<number, Channel>();
 
   constructor(
     private readonly sendRaw: (raw: string) => void,
     private readonly log: MuxLog = () => {},
   ) {}
 
-  /** Send a frame on `ch`, stamping the next per-channel outbound seq. */
-  send(ch: number, t: string, fields: Record<string, unknown> = {}): void {
+  /**
+   * Send a frame on `ch`, stamping the next per-channel outbound seq. A frame
+   * longer than the channel's allowance is dropped and logged instead of sent
+   * (the cell would close the socket 4009); returns whether it went out.
+   */
+  send(ch: number, t: string, fields: Record<string, unknown> = {}): boolean {
     const seq = (this.outSeq.get(ch) ?? 0) + 1;
     this.outSeq.set(ch, seq);
-    this.sendRaw(encodeFrame({ ...fields, v: PROTOCOL_VERSION, ch, seq, t }));
+    const raw = encodeFrame({ ...fields, v: PROTOCOL_VERSION, ch, seq, t });
+    const allowance = this.allowance(ch);
+    if (raw.length > allowance) {
+      this.log({ event: 'dropped_oversize_frame', ch, t, chars: raw.length, allowance });
+      return false;
+    }
+    this.sendRaw(raw);
+    return true;
   }
 
   /**
    * Decode + seq-track one raw inbound message. Invalid frames are dropped
-   * (logged without payload). Seq gaps are tolerated but logged.
+   * (logged without payload), as is a frame on an `ssh` channel longer than
+   * that kind's allowance. Seq gaps are tolerated but logged.
    */
   receive(raw: unknown): Frame | null {
     const frame = decodeFrame(raw);
     if (frame === null) {
       this.log({ event: 'dropped_invalid_frame', bytes: typeof raw === 'string' ? raw.length : -1 });
+      return null;
+    }
+    const chars = (raw as string).length;
+    if (frame.ch !== CONTROL_CHANNEL && this.kindOf(frame.ch) === SSH_KIND && chars > MAX_SSH_FRAME_CHARS) {
+      this.log({ event: 'dropped_oversize_frame', ch: frame.ch, t: frame.t, chars, allowance: MAX_SSH_FRAME_CHARS });
       return null;
     }
     const last = this.inSeq.get(frame.ch) ?? 0;
@@ -114,19 +151,34 @@ export class Mux {
     return frame;
   }
 
-  openChannel(ch: number, handler: ChannelHandler): void {
-    this.channels.set(ch, handler);
+  /** Register a data channel the cell opened; `kind` decides its frame allowance. */
+  openChannel(ch: number, handler: ChannelHandler, kind?: string): void {
+    this.channels.set(ch, { handler, ...(kind === undefined ? {} : { kind }) });
   }
 
   handlerFor(ch: number): ChannelHandler | undefined {
-    return this.channels.get(ch);
+    return this.channels.get(ch)?.handler;
+  }
+
+  kindOf(ch: number): string | undefined {
+    return this.channels.get(ch)?.kind;
+  }
+
+  /** The open channels of one kind, in opening order. */
+  channelsOfKind(kind: string): number[] {
+    return [...this.channels].filter(([, channel]) => channel.kind === kind).map(([ch]) => ch);
+  }
+
+  /** The longest frame this end may send on `ch`. */
+  allowance(ch: number): number {
+    return ch === CONTROL_CHANNEL ? MAX_CLIENT_FRAME_CHARS : frameAllowance(this.kindOf(ch));
   }
 
   /** Remove + tear down one channel. Safe to call for unknown channels. */
   closeChannel(ch: number): void {
-    const handler = this.channels.get(ch);
+    const channel = this.channels.get(ch);
     this.channels.delete(ch);
-    handler?.onTeardown();
+    channel?.handler.onTeardown();
   }
 
   /** Tear down every channel and forget all seq state (socket dropped). */

--- a/src/community-portal/terminal-routes.test.ts
+++ b/src/community-portal/terminal-routes.test.ts
@@ -1,0 +1,243 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DeviceClient } from './device-client.js';
+import { DEVICE_PROOF_HEADER, ensureDeviceKey, verifyDeviceProof, type DeviceKey } from './device-key.js';
+import { errorCode, errorStatus } from './errors.js';
+
+/**
+ * The remote-terminal routes of the account service, pinned request by
+ * request: method, path, auth, body and answer, plus every error the host
+ * must recognise. A stand-in service replays scripted answers; nothing here
+ * talks to the real service.
+ */
+interface Seen {
+  method: string;
+  route: string;
+  authorization?: string;
+  proofValid?: boolean;
+  body: unknown;
+}
+let server: Server;
+let origin: string;
+let home: string;
+let key: DeviceKey;
+let client: DeviceClient;
+const seen: Seen[] = [];
+let answer: { status: number; body: unknown } = { status: 200, body: { ok: true } };
+
+async function serve(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  let text = '';
+  for await (const chunk of req) text += chunk;
+  const proof = req.headers[DEVICE_PROOF_HEADER];
+  seen.push({
+    method: req.method ?? '',
+    route: new URL(req.url ?? '/', origin).pathname,
+    authorization: req.headers.authorization,
+    ...(typeof proof === 'string' ? { proofValid: verifyDeviceProof(proof, key.publicKeyJwk).valid } : {}),
+    body: text ? JSON.parse(text) : undefined,
+  });
+  res.setHeader('content-type', 'application/json');
+  res.writeHead(answer.status);
+  res.end(JSON.stringify(answer.body));
+}
+
+/** The code and status the host sees for a refused call. */
+async function refused(call: Promise<unknown>): Promise<[number | undefined, string]> {
+  try {
+    await call;
+  } catch (error) {
+    return [errorStatus(error), errorCode(error)];
+  }
+  throw new Error('the call was accepted');
+}
+
+function refuse(status: number, code: string, extra: Record<string, unknown> = {}): void {
+  answer = { status, body: { error: code, ...extra } };
+}
+
+beforeEach(async () => {
+  home = await mkdtemp(path.join(os.tmpdir(), 'nc-terminal-routes-'));
+  seen.length = 0;
+  answer = { status: 200, body: { ok: true } };
+  server = createServer((req, res) => void serve(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no port');
+  origin = `http://127.0.0.1:${address.port}`;
+  key = ensureDeviceKey({ homeDir: home });
+  client = new DeviceClient({
+    origin,
+    file: path.join(home, 'journal.json'),
+    identity: { token: 'tok', accountId: 'acct-1', installId: 'inst-1' },
+    deviceKey: key,
+  });
+});
+afterEach(async () => {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await rm(home, { recursive: true, force: true });
+});
+
+describe('terminal routes', () => {
+  it('POST /api/v1/terminal/enable: bearer and device proof, an optional name and host key, the name and address back', async () => {
+    const hostKey = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGb6Yl9Sqj4H6E3yJx0V5Z9p2Q3o4c5r6s7t8u9v0w1x nanoclaw-door';
+    answer = {
+      status: 200,
+      body: { name: 'alice', address: '2600:1f18:aaaa:bbbb:5:12:3456:789a', hostKeyFingerprint: 'SHA256:h0stK3y' },
+    };
+    expect(await client.terminalEnable({ hostKey })).toEqual(answer.body);
+    expect(seen[0]).toEqual({
+      method: 'POST',
+      route: '/api/v1/terminal/enable',
+      authorization: 'Bearer tok',
+      proofValid: true,
+      body: { hostKey },
+    });
+    await client.terminalEnable({ name: 'alice', hostKey });
+    expect(seen[1].body).toEqual({ name: 'alice', hostKey });
+    await client.terminalEnable({});
+    expect(seen[2].body).toEqual({});
+    answer = {
+      status: 200,
+      body: { name: 'alice', address: '2600:1f18:aaaa:bbbb:5:12:3456:789a', hostKeyFingerprint: null },
+    };
+    expect((await client.terminalEnable({})).hostKeyFingerprint).toBeNull();
+    for (const [status, code, extra] of [
+      [400, 'invalid_name'],
+      [400, 'invalid_host_key'],
+      [409, 'terminal_bound', { deviceId: 'dev_other', label: 'another machine' }],
+      [409, 'name_taken'],
+      [409, 'busy'],
+      [502, 'dns_unavailable'],
+      [503, 'terminal_unconfigured'],
+    ] as [number, string, Record<string, unknown>?][]) {
+      refuse(status, code, extra);
+      expect(await refused(client.terminalEnable({ name: 'alice', hostKey }))).toEqual([status, code]);
+    }
+    // No device key: the proof cannot be made and nothing is sent.
+    const keyless = new DeviceClient({ origin, file: path.join(home, 'j2.json'), identity: client.identity });
+    expect(await refused(keyless.terminalEnable({ hostKey }))).toEqual([undefined, 'device_key_required']);
+    expect(seen).toHaveLength(11);
+  });
+
+  it('PUT /api/v1/terminal/host: bearer only, the door state with its port and honoured keys, the service view back', async () => {
+    answer = { status: 200, body: { ok: true, enabled: true } };
+    const report = {
+      enabled: true,
+      hostKey: 'ssh-ed25519 AAAA nanoclaw-door',
+      doorPort: 33022,
+      authorizedFingerprints: ['SHA256:a', 'SHA256:b'],
+    };
+    expect(await client.reportTerminal(report)).toEqual({ ok: true, enabled: true });
+    expect(seen[0]).toEqual({
+      method: 'PUT',
+      route: '/api/v1/terminal/host',
+      authorization: 'Bearer tok',
+      body: report,
+    });
+    answer = { status: 200, body: { ok: true, enabled: false } };
+    expect(await client.reportTerminal({ enabled: false, authorizedFingerprints: [] })).toEqual({
+      ok: true,
+      enabled: false,
+    });
+    expect(seen[1].body).toEqual({ enabled: false, authorizedFingerprints: [] });
+    for (const [status, code] of [
+      [400, 'invalid_report'],
+      [400, 'invalid_host_key'],
+      [403, 'terminal_not_bound'],
+    ] as [number, string][]) {
+      refuse(status, code);
+      expect(await refused(client.reportTerminal(report))).toEqual([status, code]);
+    }
+  });
+
+  it('POST /api/v1/terminal/keys/pending: the waiting key with its type, blob and source; the code, page and expiry back', async () => {
+    answer = {
+      status: 200,
+      body: { code: 'K7PQ-2M4Z', url: `${origin}/?approve=K7PQ2M4Z`, expiresAt: '2026-09-11T10:10:00.000Z' },
+    };
+    const request = {
+      fingerprint: 'SHA256:Z8c2Xa9bQeR7tYuIoPaSdFgHjKlZxCvBnMqWeRtYuIo',
+      keyType: 'ssh-ed25519',
+      publicKey: 'AAAAC3NzaC1lZDI1NTE5AAAAIGb6Yl9Sqj4H6E3yJx0V5Z9p2Q3o4c5r6s7t8u9v0w1x',
+      source: { ip: '2001:db8::9', port: 4242 },
+      at: '2026-09-11T10:00:00.000Z',
+    };
+    expect(await client.terminalPending(request)).toEqual(answer.body);
+    expect(seen[0]).toEqual({
+      method: 'POST',
+      route: '/api/v1/terminal/keys/pending',
+      authorization: 'Bearer tok',
+      body: request,
+    });
+    const { at: _at, ...withoutAt } = request;
+    await client.terminalPending(withoutAt);
+    expect(seen[1].body).toEqual(withoutAt);
+    for (const [status, code] of [
+      [400, 'invalid_key'],
+      [400, 'invalid_source'],
+      [403, 'terminal_not_bound'],
+      [409, 'disabled'],
+      [409, 'key_approved'],
+      [429, 'pending_limit'],
+    ] as [number, string][]) {
+      refuse(status, code);
+      expect(await refused(client.terminalPending(request))).toEqual([status, code]);
+    }
+  });
+
+  it('POST and DELETE /api/v1/terminal/sandboxes, and GET /api/v1/terminal/keys', async () => {
+    answer = {
+      status: 200,
+      body: { name: 'api', address: '2600:1f18:aaaa:bbbb:5:12:3456:789b', host: 'api.alice.example.test' },
+    };
+    expect(await client.terminalSandboxAdd('api')).toEqual(answer.body);
+    expect(seen[0]).toEqual({
+      method: 'POST',
+      route: '/api/v1/terminal/sandboxes',
+      authorization: 'Bearer tok',
+      body: { name: 'api' },
+    });
+    for (const [status, code] of [
+      [400, 'invalid_name'],
+      [409, 'name_taken'],
+      [409, 'name_reserved'],
+      [403, 'terminal_not_bound'],
+    ] as [number, string][]) {
+      refuse(status, code);
+      expect(await refused(client.terminalSandboxAdd('api'))).toEqual([status, code]);
+    }
+    answer = { status: 200, body: { ok: true } };
+    expect(await client.terminalSandboxRemove('api')).toEqual({ ok: true });
+    expect(seen.at(-1)).toEqual({
+      method: 'DELETE',
+      route: '/api/v1/terminal/sandboxes/api',
+      authorization: 'Bearer tok',
+      body: undefined,
+    });
+    await client.terminalSandboxRemove('odd name');
+    expect(seen.at(-1)?.route).toBe('/api/v1/terminal/sandboxes/odd%20name');
+    const terminal = {
+      enabled: true,
+      name: 'alice',
+      address: '2600:1f18:aaaa:bbbb:5:12:3456:789a',
+      deviceId: 'dev_1',
+      keys: [],
+      pending: [],
+      sandboxes: [
+        { name: 'api', address: '2600:1f18:aaaa:bbbb:5:12:3456:789b', createdAt: '2026-09-11T10:00:00.000Z' },
+      ],
+    };
+    answer = { status: 200, body: terminal };
+    expect(await client.terminalKeys()).toEqual(terminal);
+    expect(seen.at(-1)).toEqual({
+      method: 'GET',
+      route: '/api/v1/terminal/keys',
+      authorization: 'Bearer tok',
+      body: undefined,
+    });
+  });
+});

--- a/src/community-portal/terminal.test.ts
+++ b/src/community-portal/terminal.test.ts
@@ -1,0 +1,233 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { writePrivate } from './private-file.js';
+import { journalTerminalOf, reportTerminalState, terminalReportOf, terminalSnapshotOf } from './terminal.js';
+
+it('parses the terminal section of a snapshot and drops what is off-contract', () => {
+  expect(terminalSnapshotOf(undefined)).toBeUndefined();
+  expect(terminalSnapshotOf({ revision: 3 })).toBeUndefined();
+  expect(terminalSnapshotOf({ terminal: 'on' })).toBeUndefined();
+  expect(terminalSnapshotOf({ terminal: {} })).toEqual({ enabled: false, keys: [], pending: [], sandboxes: [] });
+  expect(
+    terminalSnapshotOf({
+      terminal: {
+        enabled: true,
+        name: 'alice',
+        address: '2001:db8::5:0:0:1',
+        deviceId: 'dev_1',
+        hostKeyFingerprint: 'SHA256:host',
+        updatedAt: '2026-09-11T10:00:00Z',
+        keys: [
+          {
+            fingerprint: 'SHA256:a',
+            keyType: 'ssh-ed25519',
+            label: 'laptop',
+            approvedAt: 't1',
+            installedAt: 't2',
+            source: { ip: '2001:db8::1', port: 5 },
+            publicKey: 'never',
+          },
+          { keyType: 'ssh-ed25519' },
+          'junk',
+        ],
+        pending: [
+          {
+            fingerprint: 'SHA256:p',
+            keyType: 'ssh-rsa',
+            code: 'ABCD-EFGH',
+            source: { ip: '::2', port: 7 },
+            at: 't3',
+            expiresAt: 't4',
+          },
+          { fingerprint: 9 },
+        ],
+        sandboxes: [{ name: 'api', address: '2001:db8::5:0:0:2', createdAt: 't5' }, { address: 'x' }],
+      },
+    }),
+  ).toEqual({
+    enabled: true,
+    name: 'alice',
+    address: '2001:db8::5:0:0:1',
+    deviceId: 'dev_1',
+    hostKeyFingerprint: 'SHA256:host',
+    updatedAt: '2026-09-11T10:00:00Z',
+    keys: [
+      {
+        fingerprint: 'SHA256:a',
+        keyType: 'ssh-ed25519',
+        label: 'laptop',
+        approvedAt: 't1',
+        installedAt: 't2',
+        source: { ip: '2001:db8::1' },
+      },
+    ],
+    pending: [
+      {
+        fingerprint: 'SHA256:p',
+        keyType: 'ssh-rsa',
+        code: 'ABCD-EFGH',
+        source: { ip: '::2', port: 7 },
+        at: 't3',
+        expiresAt: 't4',
+      },
+    ],
+    sandboxes: [{ name: 'api', address: '2001:db8::5:0:0:2', createdAt: 't5' }],
+  });
+});
+
+it('shapes the report and the journal entry from the door state', () => {
+  const state = {
+    enabled: true,
+    name: 'alice',
+    hostKey: 'ssh-ed25519 AAAA',
+    hostKeyFingerprint: 'SHA256:h',
+    doorPort: 33022,
+  };
+  expect(terminalReportOf(state)).toEqual({
+    enabled: true,
+    hostKey: 'ssh-ed25519 AAAA',
+    doorPort: 33022,
+    authorizedFingerprints: [],
+  });
+  expect(terminalReportOf({ ...state, authorizedFingerprints: ['SHA256:a'] }).authorizedFingerprints).toEqual([
+    'SHA256:a',
+  ]);
+  expect(terminalReportOf({ enabled: false })).toEqual({ enabled: false, authorizedFingerprints: [] });
+  expect(journalTerminalOf(state, () => 0)).toEqual({
+    enabled: true,
+    name: 'alice',
+    hostKeyFingerprint: 'SHA256:h',
+    doorPort: 33022,
+    updatedAt: '1970-01-01T00:00:00.000Z',
+  });
+  expect(journalTerminalOf({ enabled: false }, () => 0)).toEqual({
+    enabled: false,
+    updatedAt: '1970-01-01T00:00:00.000Z',
+  });
+});
+
+let server: Server;
+let origin: string;
+let root: string;
+let home: string;
+let status = 200;
+const seen: { method: string; route: string; authorization?: string; body: unknown }[] = [];
+
+async function serve(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  let text = '';
+  for await (const chunk of req) text += chunk;
+  seen.push({
+    method: req.method ?? '',
+    route: new URL(req.url ?? '/', origin).pathname,
+    authorization: req.headers.authorization,
+    body: text ? JSON.parse(text) : undefined,
+  });
+  res.setHeader('content-type', 'application/json');
+  res.writeHead(status);
+  res.end(JSON.stringify(status === 200 ? { ok: true } : { error: 'unavailable' }));
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), 'nc-terminal-'));
+  home = await mkdtemp(path.join(os.tmpdir(), 'nc-terminal-home-'));
+  seen.length = 0;
+  status = 200;
+  server = createServer((req, res) => void serve(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no port');
+  origin = `http://127.0.0.1:${address.port}`;
+});
+afterEach(async () => {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await rm(root, { recursive: true, force: true });
+  await rm(home, { recursive: true, force: true });
+});
+
+const journalFile = (): string => path.join(root, 'data/community-portal.json');
+const journal = async (): Promise<Record<string, unknown>> => JSON.parse(await readFile(journalFile(), 'utf8'));
+
+async function signIn(): Promise<void> {
+  await mkdir(path.join(home, '.config/nanoclaw'), { recursive: true, mode: 0o700 });
+  await writeFile(
+    path.join(home, '.config/nanoclaw/account.json'),
+    JSON.stringify({ version: 1, api: 'https://registry.example.test', account_id: 'acct-1', token: 'tok' }),
+    { mode: 0o600 },
+  );
+  await writeFile(path.join(home, '.config/nanoclaw/host-id'), 'install-1\n', { mode: 0o600 });
+}
+
+it('journals the door state and reports it over the bearer route', async () => {
+  await signIn();
+  await writePrivate(journalFile(), { origin, deviceId: 'dev_1', credentials: {}, operations: {} });
+  const log = vi.fn();
+  const state = {
+    enabled: true,
+    name: 'alice',
+    hostKey: 'ssh-ed25519 AAAA',
+    hostKeyFingerprint: 'SHA256:h',
+    doorPort: 33022,
+    authorizedFingerprints: ['SHA256:a'],
+  };
+  expect(await reportTerminalState(state, { root, homeDir: home, log, now: () => 0 })).toEqual({
+    journaled: true,
+    reported: true,
+  });
+  expect(seen).toEqual([
+    {
+      method: 'PUT',
+      route: '/api/v1/terminal/host',
+      authorization: 'Bearer tok',
+      body: { enabled: true, hostKey: 'ssh-ed25519 AAAA', doorPort: 33022, authorizedFingerprints: ['SHA256:a'] },
+    },
+  ]);
+  expect((await journal()).terminal).toEqual({
+    enabled: true,
+    name: 'alice',
+    hostKeyFingerprint: 'SHA256:h',
+    doorPort: 33022,
+    updatedAt: '1970-01-01T00:00:00.000Z',
+  });
+  expect(JSON.stringify(await journal())).not.toContain('AAAA');
+  // Disable: the journal keeps the port for the next enable; the service hears enabled false.
+  expect(
+    await reportTerminalState({ enabled: false, doorPort: 33022 }, { root, homeDir: home, now: () => 1000 }),
+  ).toEqual({ journaled: true, reported: true });
+  expect(seen.at(-1)?.body).toEqual({ enabled: false, doorPort: 33022, authorizedFingerprints: [] });
+  expect((await journal()).terminal).toEqual({
+    enabled: false,
+    doorPort: 33022,
+    updatedAt: '1970-01-01T00:00:01.000Z',
+  });
+  expect(log).not.toHaveBeenCalled();
+});
+
+it('comes back with a code instead of throwing when the checkout is not set up, signed out, or the service fails', async () => {
+  const log = vi.fn();
+  expect(await reportTerminalState({ enabled: true, doorPort: 1 }, { root, homeDir: home, log })).toEqual({
+    journaled: false,
+    reported: false,
+    code: 'installation_required',
+  });
+  await writePrivate(journalFile(), { origin, deviceId: 'dev_1', credentials: {}, operations: {} });
+  expect(await reportTerminalState({ enabled: true, doorPort: 1 }, { root, homeDir: home, log })).toEqual({
+    journaled: true,
+    reported: false,
+    code: 'installation_required',
+  });
+  expect((await journal()).terminal).toMatchObject({ enabled: true, doorPort: 1 });
+  expect(seen).toEqual([]);
+  await signIn();
+  status = 503;
+  expect(await reportTerminalState({ enabled: true, doorPort: 2 }, { root, homeDir: home, log })).toEqual({
+    journaled: true,
+    reported: false,
+    code: 'unavailable',
+  });
+  expect((await journal()).terminal).toMatchObject({ enabled: true, doorPort: 2 });
+  expect(log).toHaveBeenCalledWith({ event: 'terminal_report_failed', code: 'unavailable' });
+});

--- a/src/community-portal/terminal.ts
+++ b/src/community-portal/terminal.ts
@@ -1,0 +1,324 @@
+import path from 'node:path';
+import { DeviceClient, type Journal } from './device-client.js';
+import { readDeviceKey } from './device-key.js';
+import { errorCode } from './errors.js';
+import { readInstallIdentity } from './install-identity.js';
+import type { LinkLog } from './link.js';
+import { readJson } from './private-file.js';
+
+/**
+ * The remote-terminal section of the account contract, as the host speaks
+ * it: the door reports its state over a bearer route (`PUT
+ * /api/v1/terminal/host`) on every start, every fifteen minutes and on
+ * disable, and journals it under `terminal` in data/community-portal.json so
+ * the running host knows whether to announce the `ssh` cap and which loopback
+ * port to pipe streams to. Approvals and revocations come back down the link
+ * inside every perks snapshot's `terminal` section: the keys the door
+ * honours, the pairings still waiting and the sandboxes with an address.
+ * Public keys never travel here; fingerprints do.
+ */
+export interface TerminalKey {
+  fingerprint: string;
+  keyType?: string;
+  label?: string;
+  approvedAt?: string;
+  installedAt?: string;
+  source?: { ip?: string };
+}
+
+export interface TerminalPendingKey {
+  fingerprint: string;
+  keyType?: string;
+  code?: string;
+  source?: { ip?: string; port?: number };
+  at?: string;
+  expiresAt?: string;
+}
+
+export interface TerminalSandbox {
+  name: string;
+  address?: string;
+  createdAt?: string;
+}
+
+/** The mirror's `terminal` section; absent while the account never enabled remote access. */
+export interface TerminalSnapshot {
+  enabled: boolean;
+  name?: string;
+  /** Set for a while after a rename in the browser. */
+  previousName?: string;
+  renamedAt?: string;
+  address?: string;
+  deviceId?: string;
+  hostKeyFingerprint?: string;
+  updatedAt?: string;
+  keys: TerminalKey[];
+  pending: TerminalPendingKey[];
+  sandboxes: TerminalSandbox[];
+}
+
+/** What `remote enable|disable` journals (`terminal` in data/community-portal.json). */
+export interface JournalTerminal {
+  enabled: boolean;
+  name?: string;
+  hostKeyFingerprint?: string;
+  doorPort?: number;
+  updatedAt: string;
+}
+
+/** The door's state as its supervisor knows it. */
+export interface TerminalState {
+  enabled: boolean;
+  name?: string;
+  hostKey?: string;
+  hostKeyFingerprint?: string;
+  doorPort?: number;
+  /** The fingerprints the door currently honours. */
+  authorizedFingerprints?: string[];
+}
+
+/** Body of `PUT /api/v1/terminal/host`; the service answers with its own view of `enabled`. */
+export interface TerminalReport {
+  enabled: boolean;
+  hostKey?: string;
+  doorPort?: number;
+  authorizedFingerprints: string[];
+}
+
+export interface TerminalReportResult {
+  ok: boolean;
+  /** The service's view: `false` here disables; `true` never re-enables. */
+  enabled: boolean;
+}
+
+/**
+ * Body of `POST /api/v1/terminal/enable`. The name is omitted when the
+ * service should assign one, and ignored once the account has one; the host
+ * key is the door's public key line.
+ */
+export interface TerminalEnableRequest {
+  name?: string;
+  hostKey?: string;
+}
+
+export interface TerminalEnableResult {
+  /** The name the account now carries, assigned or confirmed by the service. */
+  name: string;
+  /** The machine's address. */
+  address?: string;
+  /** `SHA256:<base64 without padding>` of the host key the service holds; null when it holds none. */
+  hostKeyFingerprint?: string | null;
+  /** The host name to connect to, when the service composes it. */
+  host?: string;
+}
+
+/** Body of `POST /api/v1/terminal/keys/pending`: a key waiting in the door's waiting room and where it came from. */
+export interface TerminalPendingRequest {
+  /** `SHA256:<base64 without padding>`; must match the blob. */
+  fingerprint: string;
+  keyType: string;
+  /** The key blob as the server hands it to the door, or the full public key line. */
+  publicKey: string;
+  source: { ip: string; port: number };
+  at?: string;
+}
+
+export interface TerminalPendingResult {
+  /** The short code the approval page asks for, as `XXXX-XXXX`. */
+  code?: string;
+  url: string;
+  expiresAt: string;
+}
+
+/** Answer of `POST /api/v1/terminal/sandboxes`: the sandbox's own address. */
+export interface TerminalSandboxResult {
+  name: string;
+  address: string;
+  host?: string;
+}
+
+export interface ReportTerminalOptions {
+  root?: string;
+  homeDir?: string;
+  signal?: AbortSignal;
+  log?: LinkLog;
+  /** How long to wait for the journal lock held by a reconcile or the wizard. */
+  waitForLockMs?: number;
+  now?: () => number;
+}
+
+export interface ReportTerminalOutcome {
+  /** The journal's `terminal` section was written. */
+  journaled: boolean;
+  /** The service accepted the report. */
+  reported: boolean;
+  code?: string;
+}
+
+const str = (value: unknown): string | undefined => (typeof value === 'string' && value ? value : undefined);
+const opt = <T>(key: string, value: T | undefined): Record<string, T> =>
+  value === undefined ? {} : ({ [key]: value } as Record<string, T>);
+
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => typeof item === 'object' && item !== null)
+    : [];
+}
+
+function sourceOf(value: unknown): { ip?: string; port?: number } | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const { ip, port } = value as { ip?: unknown; port?: unknown };
+  return { ...opt('ip', str(ip)), ...opt('port', Number.isInteger(port) ? (port as number) : undefined) };
+}
+
+/** The `terminal` section of a perks snapshot, or undefined when the mirror carries none. */
+export function terminalSnapshotOf(snapshot: unknown): TerminalSnapshot | undefined {
+  const terminal = (snapshot as { terminal?: unknown } | null | undefined)?.terminal;
+  if (typeof terminal !== 'object' || terminal === null) return undefined;
+  const t = terminal as Record<string, unknown>;
+  const keys: TerminalKey[] = [];
+  for (const k of records(t.keys)) {
+    const fingerprint = str(k.fingerprint);
+    if (!fingerprint) continue;
+    const source = sourceOf(k.source);
+    keys.push({
+      fingerprint,
+      ...opt('keyType', str(k.keyType)),
+      ...opt('label', str(k.label)),
+      ...opt('approvedAt', str(k.approvedAt)),
+      ...opt('installedAt', str(k.installedAt)),
+      ...opt('source', source && { ...opt('ip', source.ip) }),
+    });
+  }
+  const pending: TerminalPendingKey[] = [];
+  for (const p of records(t.pending)) {
+    const fingerprint = str(p.fingerprint);
+    if (!fingerprint) continue;
+    pending.push({
+      fingerprint,
+      ...opt('keyType', str(p.keyType)),
+      ...opt('code', str(p.code)),
+      ...opt('source', sourceOf(p.source)),
+      ...opt('at', str(p.at)),
+      ...opt('expiresAt', str(p.expiresAt)),
+    });
+  }
+  const sandboxes: TerminalSandbox[] = [];
+  for (const s of records(t.sandboxes)) {
+    const name = str(s.name);
+    if (!name) continue;
+    sandboxes.push({ name, ...opt('address', str(s.address)), ...opt('createdAt', str(s.createdAt)) });
+  }
+  return {
+    enabled: t.enabled === true,
+    ...opt('name', str(t.name)),
+    ...opt('previousName', str(t.previousName)),
+    ...opt('renamedAt', str(t.renamedAt)),
+    ...opt('address', str(t.address)),
+    ...opt('deviceId', str(t.deviceId)),
+    ...opt('hostKeyFingerprint', str(t.hostKeyFingerprint)),
+    ...opt('updatedAt', str(t.updatedAt)),
+    keys,
+    pending,
+    sandboxes,
+  };
+}
+
+/** The report body for a door state. */
+export function terminalReportOf(state: TerminalState): TerminalReport {
+  return {
+    enabled: state.enabled,
+    ...opt('hostKey', state.hostKey),
+    ...opt('doorPort', state.doorPort),
+    authorizedFingerprints: [...(state.authorizedFingerprints ?? [])],
+  };
+}
+
+/** The journal entry for a door state. */
+export function journalTerminalOf(state: TerminalState, now: () => number = Date.now): JournalTerminal {
+  return {
+    enabled: state.enabled,
+    ...opt('name', state.name),
+    ...opt('hostKeyFingerprint', state.hostKeyFingerprint),
+    ...opt('doorPort', state.doorPort),
+    updatedAt: new Date(now()).toISOString(),
+  };
+}
+
+export interface CheckoutClientOptions {
+  root?: string;
+  homeDir?: string;
+  log?: LinkLog;
+  signal?: AbortSignal;
+}
+
+/**
+ * A bearer client for this checkout from its saved identity (the journal's
+ * origin and device id, the sign-in's install token, and the device key when
+ * the machine has one), or undefined while the checkout is not set up with
+ * the account service. Takes no journal lock: for requests, not for writes.
+ */
+export async function checkoutClient({
+  root = process.cwd(),
+  homeDir,
+  log = () => {},
+  signal,
+}: CheckoutClientOptions = {}): Promise<DeviceClient | undefined> {
+  const file = path.join(root, 'data/community-portal.json');
+  const journal = await readJson<Partial<Journal>>(file);
+  if (!journal?.origin || !journal.deviceId) return undefined;
+  const identity = await readInstallIdentity({ homeDir });
+  if (!identity) return undefined;
+  const deviceKey = readDeviceKey({ homeDir }) ?? undefined;
+  return new DeviceClient({ origin: journal.origin, file, identity, deviceKey, log, signal });
+}
+
+/**
+ * Journal the door's state, then report it to the account service with the
+ * install token. Never throws: a checkout that is not set up with the portal,
+ * a busy journal, or an unreachable service each come back as an outcome
+ * with a code, because the door must work locally regardless and the running
+ * host repeats the report on its own schedule.
+ */
+export async function reportTerminalState(
+  state: TerminalState,
+  {
+    root = process.cwd(),
+    homeDir,
+    signal,
+    log = () => {},
+    waitForLockMs = 5_000,
+    now = Date.now,
+  }: ReportTerminalOptions = {},
+): Promise<ReportTerminalOutcome> {
+  const file = path.join(root, 'data/community-portal.json');
+  const saved = await readJson<Partial<Journal>>(file);
+  if (!saved?.origin || !saved.deviceId) return { journaled: false, reported: false, code: 'installation_required' };
+  const identity = await readInstallIdentity({ homeDir });
+  const client = new DeviceClient({
+    origin: saved.origin,
+    file,
+    identity: identity ?? undefined,
+    exclusive: true,
+    existingOnly: true,
+    waitForLockMs,
+    signal,
+    log,
+  });
+  let journaled = false;
+  try {
+    await client.initialize();
+    client.local.terminal = journalTerminalOf(state, now);
+    await client.save();
+    journaled = true;
+    if (!identity) return { journaled, reported: false, code: 'installation_required' };
+    await client.reportTerminal(terminalReportOf(state), signal);
+    return { journaled, reported: true };
+  } catch (error) {
+    const code = errorCode(error);
+    log({ event: 'terminal_report_failed', code });
+    return { journaled, reported: false, code };
+  } finally {
+    await client.stop();
+  }
+}

--- a/src/modules/community-portal/door/approval-url.test.ts
+++ b/src/modules/community-portal/door/approval-url.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Where the waiting room sends a stranger to be approved: the configured
+ * page, else the enrolled portal's page, else nowhere (approval on the
+ * machine). No address is built into the host.
+ */
+import fs from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ROOT = vi.hoisted(() => `/tmp/nanoclaw-door-approval-${process.pid}`);
+
+vi.mock('../../../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../config.js')>();
+  return { ...actual, DATA_DIR: `${ROOT}/data` };
+});
+
+import { writePrivate } from '../../../community-portal/private-file.js';
+import { resolveApprovalUrl } from './index.js';
+
+beforeEach(() => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+  fs.mkdirSync(`${ROOT}/data`, { recursive: true });
+  vi.stubEnv('NANOCLAW_TERMINAL_APPROVAL_URL', '');
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  fs.rmSync(ROOT, { recursive: true, force: true });
+});
+
+describe('resolveApprovalUrl', () => {
+  it('is nothing on a checkout that never enrolled with a portal', async () => {
+    expect(await resolveApprovalUrl()).toBeUndefined();
+  });
+
+  it('is the enrolled portal origin, bare', async () => {
+    await writePrivate(`${ROOT}/data/community-portal.json`, {
+      origin: 'https://portal.example.test/',
+      deviceId: 'dev_1',
+      credentials: {},
+      operations: {},
+    });
+    expect(await resolveApprovalUrl()).toBe('https://portal.example.test');
+  });
+
+  it('is the configured page when one is set, whatever the journal says', async () => {
+    await writePrivate(`${ROOT}/data/community-portal.json`, { origin: 'https://portal.example.test' });
+    vi.stubEnv('NANOCLAW_TERMINAL_APPROVAL_URL', 'https://approve.example.test/keys');
+    expect(await resolveApprovalUrl()).toBe('https://approve.example.test/keys');
+  });
+
+  it('ignores a journal origin that is not a URL', async () => {
+    await writePrivate(`${ROOT}/data/community-portal.json`, { origin: 'not a url' });
+    expect(await resolveApprovalUrl()).toBeUndefined();
+  });
+});

--- a/src/modules/community-portal/door/authority.test.ts
+++ b/src/modules/community-portal/door/authority.test.ts
@@ -1,0 +1,167 @@
+/**
+ * The host-side authority: waiting-room caps and pending records, waiters
+ * released on approval from any source, revocation ending live sessions,
+ * and the browser mirror.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  addKey,
+  applyMirror,
+  approveKey,
+  authorizeStatus,
+  endSessions,
+  initAuthority,
+  isKeyApproved,
+  keyStore,
+  liveSessions,
+  openRoom,
+  openRooms,
+  registerSession,
+  resetAuthority,
+  revokeKey,
+  ROOM_LIMIT,
+  ROOM_TTL_MS,
+  waitForApproval,
+} from './authority.js';
+import { parsePublicKey, readKeyStore } from './keys.js';
+
+const DIR = `/tmp/nanoclaw-door-auth-${process.pid}`;
+const FILE = path.join(DIR, 'keys.json');
+const T0 = new Date('2026-09-11T12:00:00Z');
+
+function syntheticKey(index: number) {
+  const type = Buffer.from('ssh-ed25519');
+  const blob = Buffer.concat([
+    Buffer.from([0, 0, 0, type.length]),
+    type,
+    Buffer.from([0, 0, 0, 32]),
+    Buffer.alloc(32, index),
+  ]);
+  const parsed = parsePublicKey(`ssh-ed25519 ${blob.toString('base64')}`);
+  return { ...parsed, request: { fingerprint: parsed.fingerprint, keyType: parsed.type, publicKey: parsed.base64 } };
+}
+
+beforeEach(async () => {
+  fs.rmSync(DIR, { recursive: true, force: true });
+  fs.mkdirSync(DIR, { recursive: true, mode: 0o700 });
+  resetAuthority();
+  await initAuthority(FILE);
+});
+
+afterEach(() => {
+  resetAuthority();
+  fs.rmSync(DIR, { recursive: true, force: true });
+});
+
+describe('waiting rooms', () => {
+  it(`opens at most ${ROOM_LIMIT} rooms at once, refreshes a known key, and frees expired rooms`, async () => {
+    for (let i = 1; i <= ROOM_LIMIT; i++) {
+      expect(await openRoom(syntheticKey(i).request, { ip: '203.0.113.5', port: 1 }, T0)).toBe('ok');
+    }
+    expect(openRooms(T0.getTime())).toBe(ROOM_LIMIT);
+    expect(await openRoom(syntheticKey(ROOM_LIMIT + 1).request, undefined, T0)).toBe('limit');
+    expect(await openRoom(syntheticKey(1).request, undefined, new Date(T0.getTime() + 1000))).toBe('ok');
+    const later = new Date(T0.getTime() + ROOM_TTL_MS + 1);
+    expect(await openRoom(syntheticKey(ROOM_LIMIT + 1).request, undefined, later)).toBe('ok');
+    const pending = (await readKeyStore(FILE)).pending;
+    expect(pending.map((k) => k.fingerprint)).toContain(syntheticKey(1).fingerprint);
+    expect(pending.find((k) => k.fingerprint === syntheticKey(1).fingerprint)?.source).toBe('203.0.113.5');
+  });
+
+  it('accepts the full public key line as well as the bare blob', async () => {
+    const key = syntheticKey(9);
+    expect(await openRoom({ ...key.request, publicKey: key.publicKey }, undefined, T0)).toBe('ok');
+    expect(keyStore().pending[0].publicKey).toBe(key.publicKey);
+  });
+});
+
+describe('concurrent admissions', () => {
+  it('two unknown keys admitted at once both land as pending, on disk too', async () => {
+    const [a, b] = [syntheticKey(21), syntheticKey(22)];
+    const [first, second] = await Promise.all([openRoom(a.request, undefined, T0), openRoom(b.request, undefined, T0)]);
+    expect([first, second]).toEqual(['ok', 'ok']);
+    const pending = (await readKeyStore(FILE)).pending.map((k) => k.fingerprint).sort();
+    expect(pending).toEqual([a.fingerprint, b.fingerprint].sort());
+    expect(openRooms(T0.getTime())).toBe(2);
+  });
+});
+
+describe('approval', () => {
+  it('reports unknown / approved / disabled', async () => {
+    const key = syntheticKey(1);
+    expect(authorizeStatus(key.fingerprint, true)).toBe('unknown');
+    expect(authorizeStatus(key.fingerprint, false)).toBe('disabled');
+    await addKey(key, 'laptop');
+    expect(authorizeStatus(key.fingerprint, true)).toBe('approved');
+    expect((await readKeyStore(FILE)).approved[0].label).toBe('laptop');
+  });
+
+  it('releases a waiter when the key is approved on this machine', async () => {
+    const key = syntheticKey(2);
+    await openRoom(key.request, undefined, T0);
+    expect(await waitForApproval(key.fingerprint, 50)).toBe(false);
+    const waiting = waitForApproval(key.fingerprint, 5000);
+    const approved = await approveKey(key.fingerprint, 'phone');
+    expect(approved.fingerprint).toBe(key.fingerprint);
+    expect(await waiting).toBe(true);
+    expect(openRooms(T0.getTime())).toBe(0);
+    expect(keyStore().pending).toEqual([]);
+    expect(await waitForApproval(key.fingerprint, 0)).toBe(true);
+  });
+
+  it('releases a waiter when the browser approves it (mirror), and honours mirror fingerprints', async () => {
+    const key = syntheticKey(3);
+    const waiting = waitForApproval(key.fingerprint, 5000);
+    expect(await applyMirror({ keys: [{ fingerprint: key.fingerprint }] })).toEqual({
+      approved: [key.fingerprint],
+      revoked: [],
+    });
+    expect(await waiting).toBe(true);
+    expect(isKeyApproved(key.fingerprint)).toBe(true);
+    expect((await readKeyStore(FILE)).mirror?.fingerprints).toEqual([key.fingerprint]);
+    await expect(revokeKey(key.fingerprint)).rejects.toThrow(/approved in the browser/);
+  });
+});
+
+describe('revocation', () => {
+  it('ends live sessions when a local key is revoked, and forgets unregistered ones', async () => {
+    const key = syntheticKey(4);
+    await addKey(key, 'laptop');
+    const first = vi.fn();
+    const second = vi.fn();
+    const unregisterFirst = registerSession(key.fingerprint, first);
+    registerSession(key.fingerprint, second);
+    expect(liveSessions()).toBe(2);
+    unregisterFirst();
+    expect(liveSessions()).toBe(1);
+    await revokeKey(key.fingerprint);
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(isKeyApproved(key.fingerprint)).toBe(false);
+    expect(endSessions(key.fingerprint)).toBe(0);
+    expect(liveSessions()).toBe(0);
+    await expect(revokeKey(key.fingerprint)).rejects.toThrow(/no key/);
+  });
+
+  it('ends sessions of a fingerprint the browser revoked', async () => {
+    const a = syntheticKey(5);
+    const b = syntheticKey(6);
+    await applyMirror({ keys: [{ fingerprint: a.fingerprint }, { fingerprint: b.fingerprint }] });
+    const end = vi.fn();
+    registerSession(b.fingerprint, end);
+    expect(await applyMirror({ keys: [{ fingerprint: a.fingerprint }] })).toEqual({
+      approved: [],
+      revoked: [b.fingerprint],
+    });
+    expect(end).toHaveBeenCalledTimes(1);
+    expect(isKeyApproved(b.fingerprint)).toBe(false);
+    expect(isKeyApproved(a.fingerprint)).toBe(true);
+    // A key also approved here survives a browser revocation.
+    await addKey(a, 'local');
+    await applyMirror(undefined);
+    expect(isKeyApproved(a.fingerprint)).toBe(true);
+  });
+});

--- a/src/modules/community-portal/door/authority.ts
+++ b/src/modules/community-portal/door/authority.ts
@@ -1,0 +1,248 @@
+/**
+ * Who may land — the host-side authority the door's sessions ask.
+ *
+ * Two sources of approval are honoured: keys the operator approved on this
+ * machine (`data/door/keys.json`, with their public keys) and fingerprints
+ * the account service approved in the browser, which arrive with every
+ * snapshot push through `applyMirror()`. The authority also owns the
+ * waiting rooms (capped per machine, pending records rate-limited in the
+ * store), the waiters a room releases on approval, and the live sessions
+ * registered per fingerprint so a revocation ends them.
+ */
+import { EventEmitter } from 'node:events';
+
+import {
+  addApprovedKey,
+  admitKey,
+  approvePendingKey,
+  emptyKeyStore,
+  isApproved,
+  parsePublicKey,
+  readKeyStore,
+  revokeKey as revokeInStore,
+  writeKeyStore,
+  type ApprovedKey,
+  type KeyStore,
+  type ParsedPublicKey,
+} from './keys.js';
+import type { DoorSource } from './target-map.js';
+
+export type AuthorizeStatus = 'approved' | 'unknown' | 'disabled';
+
+export interface PendingRequest {
+  fingerprint: string;
+  keyType: string;
+  /** The key blob (base64) or the full `<type> <base64>` line. */
+  publicKey: string;
+}
+
+/** Waiting rooms open at once on this machine. */
+export const ROOM_LIMIT = 4;
+export const ROOM_TTL_MS = 10 * 60_000;
+
+export interface MirrorTerminal {
+  enabled?: boolean;
+  name?: string;
+  previousName?: string;
+  keys?: { fingerprint: string }[];
+}
+
+export interface MirrorDelta {
+  approved: string[];
+  revoked: string[];
+}
+
+let file: string | undefined;
+let store: KeyStore = emptyKeyStore();
+const rooms = new Map<string, number>();
+const sessions = new Map<string, Set<() => void>>();
+const changes = new EventEmitter();
+changes.setMaxListeners(0);
+/** Store mutations run one after another: two keys admitted at once must both land. */
+let mutation: Promise<unknown> = Promise.resolve();
+
+function serialized<T>(work: () => Promise<T>): Promise<T> {
+  const next = mutation.then(work, work);
+  mutation = next.catch(() => {});
+  return next;
+}
+
+export async function initAuthority(keyStoreFile: string): Promise<void> {
+  file = keyStoreFile;
+  store = await readKeyStore(file);
+}
+
+/** Tests only: forget everything in memory. */
+export function resetAuthority(): void {
+  mutation = Promise.resolve();
+  file = undefined;
+  store = emptyKeyStore();
+  rooms.clear();
+  sessions.clear();
+  changes.removeAllListeners();
+}
+
+async function persist(): Promise<void> {
+  if (file) await writeKeyStore(file, store);
+}
+
+export function keyStore(): KeyStore {
+  return structuredClone(store);
+}
+
+export function isKeyApproved(fingerprint: string): boolean {
+  return isApproved(store, fingerprint);
+}
+
+export function authorizeStatus(fingerprint: string, enabled: boolean): AuthorizeStatus {
+  if (!enabled) return 'disabled';
+  return isKeyApproved(fingerprint) ? 'approved' : 'unknown';
+}
+
+function pruneRooms(now: number): void {
+  for (const [fingerprint, expiresAt] of rooms) if (expiresAt <= now) rooms.delete(fingerprint);
+}
+
+/**
+ * Open (or refresh) a waiting room for an unknown key. `limit` when the
+ * machine already has its share of rooms or the store's pending rate limit
+ * is reached; the room then prints its message and ends.
+ */
+export function openRoom(
+  request: PendingRequest,
+  source?: DoorSource,
+  now: Date = new Date(),
+): Promise<'ok' | 'limit'> {
+  return serialized(async () => {
+    pruneRooms(now.getTime());
+    if (!rooms.has(request.fingerprint) && rooms.size >= ROOM_LIMIT) return 'limit';
+    const publicKey = request.publicKey.includes(' ') ? request.publicKey : `${request.keyType} ${request.publicKey}`;
+    const key = parsePublicKey(publicKey);
+    const result = admitKey(store, key, now, source?.ip);
+    if (result.verdict === 'refused') return 'limit';
+    store = result.store;
+    if (result.changed) await persist();
+    rooms.set(key.fingerprint, now.getTime() + ROOM_TTL_MS);
+    return 'ok';
+  });
+}
+
+/** Resolve true as soon as the fingerprint is approved, false after `waitMs`. */
+export function waitForApproval(fingerprint: string, waitMs: number): Promise<boolean> {
+  if (isKeyApproved(fingerprint)) return Promise.resolve(true);
+  if (waitMs <= 0) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    const onApproved = (approved: string): void => {
+      if (approved !== fingerprint) return;
+      clearTimeout(timer);
+      changes.off('approved', onApproved);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      changes.off('approved', onApproved);
+      resolve(false);
+    }, waitMs);
+    changes.on('approved', onApproved);
+  });
+}
+
+function released(fingerprint: string): void {
+  rooms.delete(fingerprint);
+  changes.emit('approved', fingerprint);
+}
+
+export function approveKey(fingerprint: string, label?: string): Promise<ApprovedKey> {
+  return serialized(async () => {
+    store = approvePendingKey(store, fingerprint, label);
+    await persist();
+    released(fingerprint);
+    return store.approved.find((k) => k.fingerprint === fingerprint)!;
+  });
+}
+
+export function addKey(key: ParsedPublicKey, label: string): Promise<ApprovedKey> {
+  return serialized(async () => {
+    store = addApprovedKey(store, key, label);
+    await persist();
+    released(key.fingerprint);
+    return store.approved.find((k) => k.fingerprint === key.fingerprint)!;
+  });
+}
+
+/** Remove a local approval (a browser approval can only be revoked in the browser) and end its sessions. */
+export function revokeKey(fingerprint: string): Promise<void> {
+  return serialized(async () => {
+    const mirrored = store.mirror?.fingerprints.includes(fingerprint) === true;
+    const local = store.approved.some((k) => k.fingerprint === fingerprint);
+    const pending = store.pending.some((k) => k.fingerprint === fingerprint);
+    if (!local && !pending) {
+      if (mirrored) throw new Error(`${fingerprint} was approved in the browser — revoke it there`);
+      throw new Error(`no key ${fingerprint}`);
+    }
+    store = revokeInStore(store, fingerprint);
+    await persist();
+    rooms.delete(fingerprint);
+    if (!mirrored) endSessions(fingerprint);
+  });
+}
+
+/**
+ * Apply the account service's view (fingerprints only). Newly approved
+ * fingerprints release their waiting rooms; fingerprints that left are
+ * revoked here and their live sessions are ended.
+ */
+export function applyMirror(terminal: MirrorTerminal | undefined): Promise<MirrorDelta> {
+  return serialized(async () => {
+    const next = new Set((terminal?.keys ?? []).map((k) => k.fingerprint));
+    const previous = new Set(store.mirror?.fingerprints ?? []);
+    const approved = [...next].filter((f) => !previous.has(f));
+    const revoked = [...previous].filter((f) => !next.has(f));
+    const hadMirror = store.mirror !== undefined;
+    // An account with nothing approved (no `terminal` section, or no keys)
+    // and a host that never saw a mirror leave the store untouched: nothing
+    // is written to disk on a host that has not opted in.
+    if (!hadMirror && next.size === 0) return { approved, revoked };
+    store = { ...store, mirror: { fingerprints: [...next], updatedAt: new Date().toISOString() } };
+    if (approved.length || revoked.length || !hadMirror) await persist();
+    for (const fingerprint of approved) released(fingerprint);
+    for (const fingerprint of revoked) {
+      if (!store.approved.some((k) => k.fingerprint === fingerprint)) endSessions(fingerprint);
+    }
+    return { approved, revoked };
+  });
+}
+
+/** Register a way to end a live session under its key; returns the unregister. */
+export function registerSession(fingerprint: string, end: () => void): () => void {
+  let ends = sessions.get(fingerprint);
+  if (!ends) sessions.set(fingerprint, (ends = new Set()));
+  ends.add(end);
+  return () => {
+    const current = sessions.get(fingerprint);
+    current?.delete(end);
+    if (current && current.size === 0) sessions.delete(fingerprint);
+  };
+}
+
+/** End every live session under the fingerprint; returns how many were ended. */
+export function endSessions(fingerprint: string): number {
+  const ends = sessions.get(fingerprint);
+  sessions.delete(fingerprint);
+  let ended = 0;
+  for (const end of ends ?? []) {
+    end();
+    ended += 1;
+  }
+  return ended;
+}
+
+export function liveSessions(): number {
+  let total = 0;
+  for (const ends of sessions.values()) total += ends.size;
+  return total;
+}
+
+export function openRooms(now: number = Date.now()): number {
+  pruneRooms(now);
+  return rooms.size;
+}

--- a/src/modules/community-portal/door/door.e2e.test.ts
+++ b/src/modules/community-portal/door/door.e2e.test.ts
@@ -1,0 +1,248 @@
+/**
+ * The real OpenSSH client against the in-process door, when `ssh` and
+ * `ssh-keygen` exist on this machine. The client connects the way the
+ * account link's pipe does — from a chosen loopback source port (a small
+ * ProxyCommand) that a stream was registered for — under a username that
+ * means nothing here. An unknown key gets the waiting room, an approval on
+ * the host releases it into the landing, which creates the account's
+ * default sandbox through the real `sandboxes new` path against a fake
+ * container driver whose exec stream prints a marker with the terminal size
+ * it was given. Then `ssh … ls` lists, a plain attach runs without a TTY,
+ * and password authentication is refused. Skips cleanly without the tools.
+ */
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const ROOT = vi.hoisted(() => `/tmp/nanoclaw-door-e2e-${process.pid}`);
+
+vi.mock('../../../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../config.js')>();
+  return { ...actual, DATA_DIR: `${ROOT}/data`, GROUPS_DIR: `${ROOT}/groups` };
+});
+vi.mock('../../../container-runner.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../../container-runner.js')>();
+  return { ...orig, wakeContainer: vi.fn(async (): Promise<boolean> => false) };
+});
+vi.mock('../../../drivers/index.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../../drivers/index.js')>();
+  return { ...orig, getSessionDriver: vi.fn() };
+});
+
+import { wakeContainer } from '../../../container-runner.js';
+import { closeDb, initTestDb, runMigrations } from '../../../db/index.js';
+import { getSessionDriver } from '../../../drivers/index.js';
+import type { SessionEventsDriver } from '../../../drivers/session-events.js';
+import type { SessionExecOptions, SessionExecStream, SessionHandle, SessionStatus } from '../../../drivers/types.js';
+import type { Session } from '../../../types.js';
+import { onRemoteAccessChanged, SANDBOX_HOOKS_SEAM, type RemoteAccessState } from '../../../code-mode/hooks.js';
+// Registers the code-mode migrations and the sandbox verbs the landing uses.
+import '../../../cli/resources/sandboxes.js';
+import '../../../code-mode/index.js';
+import { approveDoorKey, disableDoor, doorStatus, enableDoor, listDoorKeys, registerTarget } from './index.js';
+
+/** What other modules hear from the door. */
+const remoteAccess: RemoteAccessState[] = [];
+onRemoteAccessChanged('e2e', (state) => void remoteAccess.push(state), { seam: SANDBOX_HOOKS_SEAM });
+
+const hasTools = ['ssh', 'ssh-keygen'].every((tool) => {
+  try {
+    execFileSync('which', [tool], { stdio: 'ignore' });
+    return true;
+  } catch (error) {
+    if (error instanceof Error) return false;
+    throw error;
+  }
+});
+
+/** The fake driver's attach: an exec stream that prints a marker (with the size it got) and exits 0. */
+function handleFor(agentGroupId: string, sessionId: string, name: string): SessionHandle {
+  return {
+    key: { installSlug: 'test-install', agentGroupId, sessionId },
+    name,
+    start: async () => {},
+    status: async () => ({ phase: 'running' }) as SessionStatus,
+    stop: async () => {},
+    execSpec: (command) => ({
+      bin: 'docker',
+      argsTty: ['exec', '-it', name, ...command],
+      argsPlain: ['exec', '-i', name, ...command],
+    }),
+    execStream: async (command: string[], options: SessionExecOptions): Promise<SessionExecStream> => {
+      const stdout = new PassThrough();
+      const stdin = new PassThrough();
+      const exited = new Promise<number>((resolve) => stdout.on('end', () => resolve(0)));
+      setTimeout(() => {
+        stdout.end(
+          options.tty
+            ? `LANDED-TTY ${name} ${options.cols}x${options.rows} ${command.at(-1)}\r\n`
+            : `LANDED-PLAIN ${name} ${command.at(-1)}\n`,
+        );
+      }, 50);
+      return { stdin, stdout, resize: async () => {}, exited, close: () => stdout.end() };
+    },
+  };
+}
+
+function installDriver(handles: SessionHandle[]): void {
+  const driver = {
+    kind: 'fake-container',
+    listSessions: vi.fn(async () => handles.map((handle) => ({ handle, phase: 'running' as const }))),
+    watchSessions: () => ({ stop: () => {} }),
+  } as unknown as SessionEventsDriver;
+  vi.mocked(getSessionDriver).mockReturnValue(driver);
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const s = net.createServer();
+    s.listen(0, '127.0.0.1', () => {
+      const { port } = s.address() as net.AddressInfo;
+      s.close(() => resolve(port));
+    });
+  });
+}
+
+const PROXY = `
+const net = require('node:net');
+const [port, localPort] = process.argv.slice(2).map(Number);
+const socket = net.connect({ host: '127.0.0.1', port, localAddress: '127.0.0.1', localPort });
+process.stdin.pipe(socket);
+socket.pipe(process.stdout);
+socket.on('close', () => process.exit(0));
+socket.on('error', (error) => { process.stderr.write(String(error) + '\\n'); process.exit(1); });
+`;
+
+interface Run {
+  output: string;
+  code: number | null;
+}
+
+describe.skipIf(!hasTools)('door e2e (real ssh client)', () => {
+  const clientKey = path.join(ROOT, 'client_ed25519');
+  const proxy = path.join(ROOT, 'proxy.cjs');
+  let doorPort: number;
+
+  beforeAll(async () => {
+    fs.rmSync(ROOT, { recursive: true, force: true });
+    fs.mkdirSync(`${ROOT}/groups`, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(proxy, PROXY);
+    execFileSync('ssh-keygen', ['-q', '-t', 'ed25519', '-N', '', '-C', 'e2e', '-f', clientKey]);
+    await runMigrations(await initTestDb());
+    installDriver([]);
+    vi.mocked(wakeContainer).mockImplementation(async (session: Session) => {
+      installDriver([handleFor(session.agent_group_id, session.id, `ncl-${session.id}`)]);
+      return true;
+    });
+  });
+
+  afterAll(async () => {
+    await disableDoor();
+    await closeDb();
+    fs.rmSync(ROOT, { recursive: true, force: true });
+  });
+
+  /** Connect from a fresh registered source port; resolves when ssh exits. */
+  function ssh(
+    args: string[],
+    {
+      target = { account: 'e2e-box' },
+      onOutput,
+    }: { target?: { account: string; sandbox?: string }; onOutput?: (text: string) => void | Promise<void> } = {},
+  ): Promise<Run> & { kill: () => void } {
+    let output = '';
+    let child: ReturnType<typeof spawn> | undefined;
+    const done = (async (): Promise<Run> => {
+      const localPort = await freePort();
+      registerTarget(localPort, { target, source: { ip: '203.0.113.5', port: 4242 }, stream: 'e2e' });
+      child = spawn('ssh', [
+        '-o',
+        `ProxyCommand=${process.execPath} ${proxy} ${doorPort} ${localPort}`,
+        '-o',
+        'StrictHostKeyChecking=no',
+        '-o',
+        'UserKnownHostsFile=/dev/null',
+        '-o',
+        'IdentitiesOnly=yes',
+        '-o',
+        'LogLevel=ERROR',
+        '-i',
+        clientKey,
+        ...args,
+      ]);
+      child.stdout!.on('data', (chunk: Buffer) => {
+        output += chunk.toString();
+        void onOutput?.(output);
+      });
+      child.stderr!.on('data', (chunk: Buffer) => {
+        output += chunk.toString();
+        void onOutput?.(output);
+      });
+      const code = await new Promise<number | null>((resolve) => child!.on('exit', (c) => resolve(c)));
+      return { output, code };
+    })();
+    return Object.assign(done, { kill: () => child?.kill() });
+  }
+
+  it('admits an unknown key to the waiting room and lands it after approval, under any username', async () => {
+    const enabled = await enableDoor({ name: 'e2e-box' });
+    expect(enabled.enabled).toBe(true);
+    expect(enabled.door.running).toBe(true);
+    expect(enabled.hostKeyFingerprint).toMatch(/^SHA256:/);
+    // Standalone: no portal enrolled, so no approval page and no address.
+    expect(enabled.approvalUrl).toBeUndefined();
+    expect(remoteAccess).toEqual([{ enabled: true, name: 'e2e-box' }]);
+    doorPort = enabled.doorPort!;
+
+    const fingerprint = execFileSync('ssh-keygen', ['-lf', `${clientKey}.pub`], { encoding: 'utf8' }).split(' ')[1];
+    let approved = false;
+    const run = ssh(['-tt', 'someone-else@127.0.0.1'], {
+      onOutput: async (text) => {
+        if (approved || !/not approved for remote access yet/.test(text)) return;
+        approved = true;
+        expect((await listDoorKeys()).pending.map((k) => k.fingerprint)).toEqual([fingerprint]);
+        expect((await doorStatus()).door).toMatchObject({ running: true, sessions: 1 });
+        await approveDoorKey(fingerprint, 'e2e');
+      },
+    });
+    const result = await run;
+    expect(result.output).toContain(`key    ${fingerprint}`);
+    expect(result.output).toContain('from   203.0.113.5');
+    expect(result.output).toContain('Approved. Connecting');
+    expect(result.output).toContain('Creating sandbox e2e-box');
+    // The fake driver names its container after the session; the marker carries the size the exec was given.
+    expect(result.output).toMatch(/LANDED-TTY ncl-sess-\S+ \d+x\d+ agent/);
+    expect(result.code).toBe(0);
+    expect((await listDoorKeys()).approved.map((k) => k.label)).toEqual(['e2e']);
+  }, 60_000);
+
+  it('lists sandboxes for `ssh … ls`, attaches the existing default without a TTY, and refuses passwords', async () => {
+    const listing = await ssh(['-T', 'x@127.0.0.1', 'ls']);
+    expect(listing.code).toBe(0);
+    expect(listing.output).toContain('e2e-box');
+
+    const plain = await ssh(['-T', 'y@127.0.0.1']);
+    expect(plain.output).toContain('Attaching to sandbox e2e-box');
+    expect(plain.output).toMatch(/LANDED-PLAIN ncl-sess-/);
+    expect(plain.code).toBe(0);
+
+    const denied = await ssh([
+      '-o',
+      'PubkeyAuthentication=no',
+      '-o',
+      'PasswordAuthentication=yes',
+      '-o',
+      'BatchMode=yes',
+      'z@127.0.0.1',
+    ]);
+    expect(denied.code).toBe(255);
+    expect(denied.output).toMatch(/Permission denied|no supported authentication methods/i);
+
+    const off = await disableDoor();
+    expect(off.door.running).toBe(false);
+    expect(remoteAccess.at(-1)).toEqual({ enabled: false, name: 'e2e-box' });
+  }, 60_000);
+});

--- a/src/modules/community-portal/door/host-key.test.ts
+++ b/src/modules/community-portal/door/host-key.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The host key: generated once in-process, reused afterwards, readable when
+ * an earlier build made it with ssh-keygen, fingerprinted like ssh-keygen.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ensureHostKey } from './host-key.js';
+import { parsePublicKey } from './keys.js';
+import { doorFiles } from './paths.js';
+
+const DIR = `/tmp/nanoclaw-door-hk-${process.pid}`;
+const files = doorFiles(DIR);
+
+const hasKeygen = (() => {
+  try {
+    execFileSync('which', ['ssh-keygen'], { stdio: 'ignore' });
+    return true;
+  } catch (error) {
+    if (error instanceof Error) return false;
+    throw error;
+  }
+})();
+
+beforeEach(() => {
+  fs.rmSync(DIR, { recursive: true, force: true });
+});
+afterEach(() => fs.rmSync(DIR, { recursive: true, force: true }));
+
+describe('ensureHostKey', () => {
+  it('generates an ed25519 pair once (0600) and reuses it', async () => {
+    const first = await ensureHostKey(files);
+    expect(first.type).toBe('ssh-ed25519');
+    expect(first.publicKey).toMatch(/^ssh-ed25519 AAAA/);
+    expect(first.fingerprint).toMatch(/^SHA256:/);
+    expect(first.privateKey).toContain('PRIVATE KEY');
+    expect((fs.statSync(files.hostKey).mode & 0o777).toString(8)).toBe('600');
+    expect(fs.readFileSync(files.hostKeyPublic, 'utf8')).toContain(first.publicKey);
+    expect(parsePublicKey(first.publicKey).fingerprint).toBe(first.fingerprint);
+    const again = await ensureHostKey(files);
+    expect(again.fingerprint).toBe(first.fingerprint);
+    expect(again.privateKey).toBe(first.privateKey);
+  });
+
+  it.skipIf(!hasKeygen)('loads a key ssh-keygen generated and agrees with ssh-keygen -lf', async () => {
+    fs.mkdirSync(DIR, { recursive: true, mode: 0o700 });
+    execFileSync('ssh-keygen', ['-q', '-t', 'ed25519', '-N', '', '-C', 'earlier', '-f', files.hostKey]);
+    const key = await ensureHostKey(files);
+    const printed = execFileSync('ssh-keygen', ['-lf', files.hostKeyPublic], { encoding: 'utf8' }).split(' ')[1];
+    expect(key.fingerprint).toBe(printed);
+    expect(fs.readFileSync(files.hostKeyPublic, 'utf8')).toContain(key.publicKey);
+  });
+});

--- a/src/modules/community-portal/door/host-key.ts
+++ b/src/modules/community-portal/door/host-key.ts
@@ -1,0 +1,50 @@
+/**
+ * The door's host key: one ed25519 pair under the door directory, generated
+ * in-process the first time and kept across disable. A key an earlier build
+ * generated with ssh-keygen loads the same way (OpenSSH format either way).
+ * The fingerprint is the `SHA256:…` form `ssh-keygen -lf` prints, so what
+ * the account service shows and what the client's first-connect prompt
+ * shows are one and the same.
+ */
+import fs from 'node:fs';
+import type { ParsedKey } from 'ssh2';
+
+import { fingerprintOf } from './keys.js';
+import type { DoorFiles } from './paths.js';
+import { loadSsh2, type Ssh2 } from './ssh2.js';
+
+export interface HostKey {
+  /** The private key file's contents, as the server wants them. */
+  privateKey: string;
+  /** `<type> <base64>` — the public key line. */
+  publicKey: string;
+  fingerprint: string;
+  type: string;
+}
+
+function firstKey(parsed: ReturnType<Ssh2['utils']['parseKey']>): ParsedKey {
+  const key = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (key instanceof Error) throw new Error(`the door host key is unreadable: ${key.message}`, { cause: key });
+  if (!key) throw new Error('the door host key file holds no key');
+  return key;
+}
+
+export async function ensureHostKey(files: DoorFiles): Promise<HostKey> {
+  const { utils } = await loadSsh2();
+  await fs.promises.mkdir(files.dir, { recursive: true, mode: 0o700 });
+  if (!fs.existsSync(files.hostKey)) {
+    const pair = utils.generateKeyPairSync('ed25519', { comment: 'nanoclaw-door' });
+    const privateText = pair.private.endsWith('\n') ? pair.private : `${pair.private}\n`;
+    await fs.promises.writeFile(files.hostKey, privateText, { mode: 0o600 });
+    await fs.promises.writeFile(files.hostKeyPublic, `${pair.public}\n`, { mode: 0o644 });
+  }
+  const privateKey = await fs.promises.readFile(files.hostKey, 'utf8');
+  const key = firstKey(utils.parseKey(privateKey));
+  if (!key.isPrivateKey()) throw new Error('the door host key file holds a public key only');
+  const blob = key.getPublicSSH();
+  const publicKey = `${key.type} ${blob.toString('base64')}`;
+  if (!fs.existsSync(files.hostKeyPublic)) {
+    await fs.promises.writeFile(files.hostKeyPublic, `${publicKey} nanoclaw-door\n`, { mode: 0o644 });
+  }
+  return { privateKey, publicKey, fingerprint: fingerprintOf(blob), type: key.type };
+}

--- a/src/modules/community-portal/door/index.ts
+++ b/src/modules/community-portal/door/index.ts
@@ -1,0 +1,522 @@
+/**
+ * The door: an SSH server the host runs in-process on loopback so a remote
+ * terminal, relayed by the account link, lands in a code-mode sandbox.
+ *
+ * `ncl sandboxes remote enable [--name <name>]` generates the host key once,
+ * asks the account link to confirm or assign the name, takes a loopback
+ * port, starts the server and journals the decision; the host restarts the
+ * door on every start while it is enabled. Any username is accepted; the
+ * key decides. Approval has two sources — keys the operator approved here
+ * and fingerprints the service approved in the browser, applied from each
+ * snapshot — and an unknown key waits in-session until one of them arrives.
+ *
+ * The door lands a terminal through code mode's own sandbox API
+ * (code-mode/sandboxes.ts: find, list, create, attach) and holds the bytes
+ * itself over the session handle's exec stream; it never reaches into the
+ * CLI. Whenever remote access is turned on or off — here, or from the
+ * account in the browser — it fires code mode's `onRemoteAccessChanged`
+ * hook so other modules learn the host's address.
+ *
+ * The exported API is what the account link builds on: enableDoor /
+ * disableDoor / startDoor / stopDoor / doorStatus, the target map keyed by
+ * the loopback source port each relayed stream connects from, the mirror
+ * application and the seam. Nothing here imports link code.
+ */
+import fs from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  NEW_SANDBOX_WAKE_WAIT_MS,
+  sandboxVerbs,
+  type AttachTarget as SandboxAttachTarget,
+  type SandboxListRow,
+} from '../../../code-mode/sandboxes.js';
+import { fireRemoteAccessChanged, type RemoteAccessState } from '../../../code-mode/hooks.js';
+import type { Journal } from '../../../community-portal/device-client.js';
+import { readJson } from '../../../community-portal/private-file.js';
+import { DATA_DIR } from '../../../config.js';
+import { onHostStart, onHostShutdown } from '../../../host-lifecycle.js';
+import { log } from '../../../log.js';
+import * as authority from './authority.js';
+import { ensureHostKey } from './host-key.js';
+import { parsePublicKey, type ApprovedKey, type KeyStore } from './keys.js';
+import type { AttachTarget, SandboxVerbs } from './landing.js';
+import { validateAccountName } from './name.js';
+import { doorFiles } from './paths.js';
+import {
+  enableTerminal,
+  PENDING_APPROVAL_TTL_MS,
+  reportPendingKey,
+  reportTerminalState,
+  type TerminalState,
+} from './report.js';
+import { DoorServer, type DoorServerStatus } from './server.js';
+import { handleConnection, type SessionDeps } from './session.js';
+import { readDoorState, writeDoorState, type DoorState } from './state.js';
+import { lookupTarget } from './target-map.js';
+
+export {
+  registerTarget,
+  unregisterTarget,
+  lookupTarget,
+  type DoorSource,
+  type DoorStream,
+  type DoorTarget,
+} from './target-map.js';
+export {
+  setTerminalSeam,
+  type PendingKeyRequest,
+  type PendingKeyResult,
+  type TerminalEnableRequest,
+  type TerminalEnableResult,
+  type TerminalSeam,
+  type TerminalState,
+} from './report.js';
+export type { MirrorDelta, MirrorTerminal } from './authority.js';
+
+export const DOOR_DIR = path.join(DATA_DIR, 'door');
+const files = doorFiles(DOOR_DIR);
+
+/** The portal journal the setup wizard writes; its origin names the approval page. */
+const PORTAL_JOURNAL = path.join(DATA_DIR, 'community-portal.json');
+
+/** The door's loopback port range: the first free port in it is taken at enable and kept. */
+export const DOOR_PORT_RANGE: readonly [number, number] = [33022, 33121];
+
+let server: DoorServer | undefined;
+/** The journal the running door was brought up from; undefined while down. */
+let running: DoorState | undefined;
+let authorityReady = false;
+let liveSessions = 0;
+
+/** The shape the account link journals beside its own state. */
+export interface TerminalJournal {
+  enabled: boolean;
+  name?: string;
+  hostKeyFingerprint?: string;
+  doorPort?: number;
+  updatedAt: string;
+}
+
+export interface DoorSummary {
+  enabled: boolean;
+  name?: string;
+  address?: string;
+  host?: string;
+  previousName?: string;
+  doorPort?: number;
+  hostKey?: string;
+  hostKeyFingerprint?: string;
+  /** Absent on a checkout that is not enrolled with a portal. */
+  approvalUrl?: string;
+  terminal: TerminalJournal;
+  door: (DoorServerStatus & { sessions: number }) | { running: false };
+  keys: { approved: number; browser: number; pending: number; rooms: number };
+}
+
+/**
+ * The approval page: `NANOCLAW_TERMINAL_APPROVAL_URL` when set, else the
+ * portal origin this checkout enrolled with (the portal routes a signed-in
+ * user to the waiting key; the account link supplies the exact page and
+ * code when it can). A checkout that never enrolled has none — keys are
+ * then approved on the machine.
+ */
+export async function resolveApprovalUrl(): Promise<string | undefined> {
+  const configured = process.env.NANOCLAW_TERMINAL_APPROVAL_URL;
+  if (configured) return configured;
+  const journal = await readJson<Partial<Journal>>(PORTAL_JOURNAL);
+  const origin = journal?.origin;
+  if (!origin) return undefined;
+  try {
+    return new URL(origin).origin;
+  } catch (error) {
+    if (!(error instanceof TypeError)) throw error;
+    log.warn('Remote terminal: the portal origin in the journal is not a URL', { origin });
+    return undefined;
+  }
+}
+
+function portFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const listener = net.createServer();
+    listener.once('error', () => resolve(false));
+    listener.listen(port, '127.0.0.1', () => listener.close(() => resolve(true)));
+  });
+}
+
+async function freeDoorPort(): Promise<number> {
+  for (let port = DOOR_PORT_RANGE[0]; port <= DOOR_PORT_RANGE[1]; port++) {
+    if (await portFree(port)) return port;
+  }
+  throw new Error(`no free loopback port in ${DOOR_PORT_RANGE[0]}–${DOOR_PORT_RANGE[1]} for the door`);
+}
+
+/** Load the key store (a missing file is an empty store). Nothing is written until a key or the door is. */
+async function ensureAuthority(): Promise<void> {
+  if (authorityReady) return;
+  await authority.initAuthority(files.keyStore);
+  authorityReady = true;
+}
+
+function authorizedFingerprints(): string[] {
+  const store = authority.keyStore();
+  return [...new Set([...store.approved.map((k) => k.fingerprint), ...(store.mirror?.fingerprints ?? [])])];
+}
+
+async function terminalState(state: DoorState): Promise<TerminalState> {
+  await ensureAuthority();
+  return {
+    enabled: state.enabled,
+    ...(state.name ? { name: state.name } : {}),
+    ...(state.hostKeyFingerprint ? { hostKeyFingerprint: state.hostKeyFingerprint } : {}),
+    ...(state.doorPort ? { doorPort: state.doorPort } : {}),
+    authorizedFingerprints: authorizedFingerprints(),
+  };
+}
+
+function journal(state: DoorState): TerminalJournal {
+  return {
+    enabled: state.enabled,
+    ...(state.name ? { name: state.name } : {}),
+    ...(state.hostKeyFingerprint ? { hostKeyFingerprint: state.hostKeyFingerprint } : {}),
+    ...(state.doorPort ? { doorPort: state.doorPort } : {}),
+    updatedAt: state.updatedAt,
+  };
+}
+
+function baseState(): DoorState {
+  return { version: 1, enabled: false, updatedAt: new Date().toISOString() };
+}
+
+/** What other modules hear when remote access flips: on or off, and the host's name and address. */
+function remoteAccessState(state: DoorState): RemoteAccessState {
+  return {
+    enabled: state.enabled,
+    ...(state.name ? { name: state.name } : {}),
+    ...(state.host ? { host: state.host } : {}),
+  };
+}
+
+// --- the host's sandbox verbs, as the landing calls them --------------------
+
+const verbs = sandboxVerbs();
+
+function attachTarget(resolved: SandboxAttachTarget): AttachTarget {
+  const { handle } = resolved;
+  return {
+    containerName: resolved.containerName,
+    command: resolved.command,
+    ...(handle.execStream ? { execStream: (command, options) => handle.execStream!(command, options) } : {}),
+    alive: async () => (await handle.status()).phase === 'running',
+  };
+}
+
+/** The listing a remote `ls` prints: the same columns an operator sees, minus the ids. */
+export function renderSandboxListing(rows: SandboxListRow[]): string {
+  if (rows.length === 0) return 'no sandboxes yet — connect without a command to create the default one';
+  const header = ['SANDBOX', 'STATUS', 'LAST-ACTIVE'];
+  const cells = rows.map((r) => [r.sandbox, r.status, r.last_active ?? '-']);
+  const widths = header.map((h, i) => Math.max(h.length, ...cells.map((c) => c[i].length)));
+  const line = (c: string[]) =>
+    c
+      .map((v, i) => v.padEnd(widths[i]))
+      .join('  ')
+      .trimEnd();
+  return [line(header), ...cells.map(line)].join('\n');
+}
+
+async function findOrRefuse(name: string) {
+  const group = await verbs.find(name);
+  if (!group) throw new Error(`no sandbox '${name}' — create it: ncl sandboxes new --name ${name}`);
+  return group;
+}
+
+const landingVerbs: SandboxVerbs = {
+  async list() {
+    const rows = await verbs.list();
+    return { names: rows.map((row) => row.sandbox), human: renderSandboxListing(rows) };
+  },
+  attach: async (name) => attachTarget(await verbs.attach(await findOrRefuse(name))),
+  async create(name) {
+    // The creation half of `sandboxes new`, then the attach half held here:
+    // the door owns the terminal's bytes rather than a client. A brand-new
+    // sandbox's first spawn can take a while (image pull, cold runtime).
+    const { group, warnings } = await verbs.create({ name });
+    for (const warning of warnings) log.warn(warning, { sandbox: name, via: 'remote terminal' });
+    return attachTarget(await verbs.attach(group, { wakeWaitMs: NEW_SANDBOX_WAKE_WAIT_MS }));
+  },
+};
+
+const sessionDeps: SessionDeps = {
+  authority: {
+    status: (fingerprint) => authority.authorizeStatus(fingerprint, running?.enabled === true),
+    openRoom: (request, source) => authority.openRoom(request, source),
+    waitForApproval: (fingerprint, waitMs) => authority.waitForApproval(fingerprint, waitMs),
+    registerSession: (fingerprint, end) => authority.registerSession(fingerprint, end),
+  },
+  lookupTarget,
+  pending: async (request) => {
+    try {
+      return await reportPendingKey(request);
+    } catch (error) {
+      if (!(error instanceof Error)) throw error;
+      // The room still works with an approval from this machine.
+      log.warn('Pending terminal key could not be reported', { err: error });
+      return {
+        ...(request.approvalUrl ? { url: request.approvalUrl } : {}),
+        expiresAt: new Date(Date.now() + PENDING_APPROVAL_TTL_MS).toISOString(),
+      };
+    }
+  },
+  approvalUrl: () => running?.approvalUrl,
+  sandboxes: landingVerbs,
+  sessions: {
+    count: () => liveSessions,
+    track: () => {
+      liveSessions += 1;
+      let done = false;
+      return () => {
+        if (done) return;
+        done = true;
+        liveSessions -= 1;
+      };
+    },
+  },
+  log: (level, message, data) => log[level](message, data),
+};
+
+/** Listen, then journal from the current process: `enabled` is written only once the door is up. */
+async function bringUp(state: DoorState): Promise<DoorState> {
+  if (!state.doorPort) throw new Error('the door has no port; run ncl sandboxes remote enable');
+  await ensureAuthority();
+  const hostKey = await ensureHostKey(files);
+  const approvalUrl = await resolveApprovalUrl();
+  const refreshed: DoorState = {
+    ...state,
+    hostKey: hostKey.publicKey,
+    hostKeyFingerprint: hostKey.fingerprint,
+    ...(approvalUrl ? { approvalUrl } : {}),
+    updatedAt: new Date().toISOString(),
+  };
+  if (!approvalUrl) delete refreshed.approvalUrl;
+  running = refreshed;
+  server ??= new DoorServer({
+    port: state.doorPort,
+    hostKey: hostKey.privateKey,
+    onConnection: (client, info) => handleConnection(client, info, sessionDeps),
+    log: (level, message, data) => log[level](message, data),
+  });
+  try {
+    await server.start();
+  } catch (error) {
+    running = undefined;
+    server = undefined;
+    throw error;
+  }
+  await writeDoorState(files.state, refreshed);
+  return refreshed;
+}
+
+/**
+ * The port the door should be on: the live server's while it runs (a
+ * second `enable` keeps the listener, and the free-port probe would see
+ * that listener as taken and pick another), else the journaled port when it
+ * is still free, else the first free one in the range.
+ */
+async function doorPortFor(previous: DoorState | undefined): Promise<number> {
+  const live = server?.status();
+  if (live?.running) return live.port;
+  if (previous?.doorPort && (await portFree(previous.doorPort))) return previous.doorPort;
+  return freeDoorPort();
+}
+
+async function takeDown(): Promise<void> {
+  const current = server;
+  server = undefined;
+  running = undefined;
+  await current?.stop();
+}
+
+async function summarize(state: DoorState): Promise<DoorSummary> {
+  await ensureAuthority();
+  const store = authority.keyStore();
+  const status = server?.status();
+  return {
+    enabled: state.enabled,
+    ...(state.name ? { name: state.name } : {}),
+    ...(state.address ? { address: state.address } : {}),
+    ...(state.host ? { host: state.host } : {}),
+    ...(state.previousName ? { previousName: state.previousName } : {}),
+    ...(state.doorPort ? { doorPort: state.doorPort } : {}),
+    ...(state.hostKey ? { hostKey: state.hostKey } : {}),
+    ...(state.hostKeyFingerprint ? { hostKeyFingerprint: state.hostKeyFingerprint } : {}),
+    ...(state.approvalUrl ? { approvalUrl: state.approvalUrl } : {}),
+    terminal: journal(state),
+    door: status?.running ? { ...status, sessions: liveSessions } : { running: false },
+    keys: {
+      approved: store.approved.length,
+      browser: store.mirror?.fingerprints.length ?? 0,
+      pending: store.pending.length,
+      rooms: authority.openRooms(),
+    },
+  };
+}
+
+/**
+ * Enable remote access. The name is confirmed (or assigned, when omitted)
+ * by the account link through the seam and stored from its answer, never
+ * derived here; the door port is chosen once and kept.
+ */
+export async function enableDoor(options: { name?: string } = {}): Promise<DoorSummary> {
+  const requested = options.name === undefined ? undefined : validateAccountName(options.name);
+  const previous = await readDoorState(files.state);
+  const hostKey = await ensureHostKey(files);
+  const assigned = await enableTerminal({
+    ...(requested ? { name: requested } : {}),
+    hostKey: hostKey.publicKey,
+    hostKeyFingerprint: hostKey.fingerprint,
+  });
+  const name = validateAccountName(assigned.name);
+  const previousName = assigned.previousName ?? (previous?.name && previous.name !== name ? previous.name : undefined);
+  const now = new Date().toISOString();
+  const state = await bringUp({
+    ...baseState(),
+    enabled: true,
+    name,
+    ...(assigned.address ? { address: assigned.address } : {}),
+    ...(assigned.host ? { host: assigned.host } : {}),
+    ...(previousName ? { previousName } : {}),
+    doorPort: await doorPortFor(previous),
+    hostKey: hostKey.publicKey,
+    hostKeyFingerprint: hostKey.fingerprint,
+    enabledAt: previous?.enabled && previous.enabledAt ? previous.enabledAt : now,
+  });
+  await reportTerminalState(await terminalState(state));
+  await fireRemoteAccessChanged(remoteAccessState(state));
+  return summarize(state);
+}
+
+export async function disableDoor(): Promise<DoorSummary> {
+  await takeDown();
+  const previous = await readDoorState(files.state);
+  const state: DoorState = { ...(previous ?? baseState()), enabled: false, updatedAt: new Date().toISOString() };
+  await writeDoorState(files.state, state);
+  await reportTerminalState(await terminalState(state));
+  await fireRemoteAccessChanged(remoteAccessState(state));
+  return summarize(state);
+}
+
+/** Bring the door up from its journal without changing the decision (a restart). */
+export async function startDoor(): Promise<DoorSummary> {
+  const state = await readDoorState(files.state);
+  if (!state?.enabled) throw new Error('remote access is not enabled — run ncl sandboxes remote enable');
+  if (running) return summarize(running);
+  const started = await bringUp(state);
+  await reportTerminalState(await terminalState(started));
+  return summarize(started);
+}
+
+/** Take the door down without changing the journal; the next host start brings it back. */
+export async function stopDoor(): Promise<DoorSummary> {
+  await takeDown();
+  return summarize((await readDoorState(files.state)) ?? baseState());
+}
+
+export async function doorStatus(): Promise<DoorSummary> {
+  return summarize((await readDoorState(files.state)) ?? baseState());
+}
+
+/**
+ * Apply the account service's `terminal` section from a snapshot push:
+ * browser approvals release waiting rooms, revocations end sessions, a
+ * rename is journaled with the previous name, and `enabled: false` from the
+ * browser disables the door here.
+ */
+export async function applyTerminalMirror(
+  terminal: authority.MirrorTerminal | undefined,
+): Promise<authority.MirrorDelta> {
+  await ensureAuthority();
+  const delta = await authority.applyMirror(terminal);
+  if (delta.approved.length || delta.revoked.length) {
+    log.info('Remote terminal keys updated from the account', { approved: delta.approved, revoked: delta.revoked });
+  }
+  const state = await readDoorState(files.state);
+  if (state?.enabled && terminal) {
+    if (terminal.name && terminal.name !== state.name) {
+      // The host name follows the name: `<name>.<zone>`, the zone being what
+      // follows the old host name's first label.
+      const zone = state.host?.split('.').slice(1).join('.');
+      const renamed: DoorState = {
+        ...state,
+        previousName: terminal.previousName ?? state.name,
+        name: terminal.name,
+        ...(zone ? { host: `${terminal.name}.${zone}` } : {}),
+        updatedAt: new Date().toISOString(),
+      };
+      await writeDoorState(files.state, renamed);
+      if (running) {
+        running = {
+          ...running,
+          name: renamed.name,
+          previousName: renamed.previousName,
+          ...(renamed.host ? { host: renamed.host } : {}),
+        };
+      }
+      log.info('Remote terminal renamed', {
+        from: state.name,
+        to: terminal.name,
+        ...(renamed.host ? { host: renamed.host } : {}),
+      });
+      await fireRemoteAccessChanged(remoteAccessState(renamed));
+    }
+    if (terminal.enabled === false) {
+      log.info('Remote terminal access disabled from the account');
+      await disableDoor();
+    }
+  }
+  return delta;
+}
+
+export async function listDoorKeys(): Promise<KeyStore> {
+  await ensureAuthority();
+  return authority.keyStore();
+}
+
+/** `text` is a public key line or the path of a file holding one. */
+export async function addDoorKey(text: string, label?: string): Promise<ApprovedKey> {
+  await ensureAuthority();
+  let line = text.trim();
+  const candidate = line.startsWith('~/') ? path.join(os.homedir(), line.slice(2)) : line;
+  if (!/\s/.test(line) && fs.existsSync(candidate)) line = await readFile(candidate, 'utf8');
+  return authority.addKey(parsePublicKey(line), label ?? '');
+}
+
+export async function approveDoorKey(fingerprint: string, label?: string): Promise<ApprovedKey> {
+  await ensureAuthority();
+  return authority.approveKey(fingerprint, label);
+}
+
+export async function revokeDoorKey(fingerprint: string): Promise<{ fingerprint: string }> {
+  await ensureAuthority();
+  await authority.revokeKey(fingerprint);
+  return { fingerprint };
+}
+
+onHostStart(async () => {
+  // Inert until enabled: nothing is read or written for a host that never
+  // opted in, beyond the one journal read.
+  const state = await readDoorState(files.state);
+  if (!state?.enabled) return;
+  try {
+    await reportTerminalState(await terminalState(await bringUp(state)));
+  } catch (error) {
+    if (!(error instanceof Error)) throw error;
+    // The door is optional: a host must still come up without it.
+    log.error('Remote terminal door failed to start', { err: error });
+  }
+});
+
+onHostShutdown(() => takeDown());

--- a/src/modules/community-portal/door/keys.test.ts
+++ b/src/modules/community-portal/door/keys.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The approved-keys store: parsing and fingerprints against ssh-keygen
+ * vectors, the admission decision (approved / pending / refused past the
+ * rate limit), the authorized_keys line each verdict produces, and the
+ * operator verbs.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  addApprovedKey,
+  admitKey,
+  approvePendingKey,
+  emptyKeyStore,
+  isApproved,
+  parsePublicKey,
+  PENDING_LIMIT,
+  PENDING_RETENTION_MS,
+  PENDING_WINDOW_MS,
+  revokeKey,
+  type KeyStore,
+} from './keys.js';
+
+const ED25519 = {
+  line: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJcU4MBsyv98bPT4z2Ymq9wLqo52QUi0MKqgu7k5gfGV vector@test',
+  fingerprint: 'SHA256:gOakZC+YL189IEEAB60qLI8r+5H3H4lj4iMh5hlYOSo',
+};
+
+const RSA = {
+  line: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEBh7ErTcqszy++F+ZX1GtO056ohJedw7yLoqpJ9AfMlDGfKJHp5IoqypEBq6W37EPIXotnem31vs/daqcjlbrViX+Ufsz9WaJ9vQQxHNylYZOG4kndXscVhqFobh4L8KLvMqBi/8Yc16JQHjPWG8aQOVUG7T+FfqIemmdCwclr7I+pF+JaWB0aSr7pfpoh1lT05gb8w272Tg+VcB9v2LG14Qg3Hx975VvdLEAOOLfhNHSXUptZezP1L2jNjSlGWi5c8g1HocooUXUNDXuNy/twX7nwRfa6WW/42cBaziGq9/wnhzifMZBe0dg2h4s5iZQbN+MMr1N5eiNVVd+K26D rsa@test',
+  fingerprint: 'SHA256:xb8YsLkluMJDzQ5i1VlDnScktuE3TN/XWX7CtVPUh3c',
+};
+
+const T0 = new Date('2026-09-11T12:00:00Z');
+const at = (offsetMs: number): Date => new Date(T0.getTime() + offsetMs);
+
+/** A distinct, well-formed ed25519 key per index (the blob only has to carry its type). */
+function syntheticKey(index: number): { publicKey: string; fingerprint: string } {
+  const type = Buffer.from('ssh-ed25519');
+  const blob = Buffer.concat([
+    Buffer.from([0, 0, 0, type.length]),
+    type,
+    Buffer.from([0, 0, 0, 32]),
+    Buffer.alloc(32, index),
+  ]);
+  const parsed = parsePublicKey(`ssh-ed25519 ${blob.toString('base64')}`);
+  return { publicKey: parsed.publicKey, fingerprint: parsed.fingerprint };
+}
+
+describe('parsePublicKey', () => {
+  it('computes the same SHA256 fingerprint as ssh-keygen -lf', () => {
+    const ed = parsePublicKey(ED25519.line);
+    expect(ed.type).toBe('ssh-ed25519');
+    expect(ed.comment).toBe('vector@test');
+    expect(ed.publicKey).toBe(ED25519.line.split(' ').slice(0, 2).join(' '));
+    expect(ed.fingerprint).toBe(ED25519.fingerprint);
+    expect(parsePublicKey(RSA.line).fingerprint).toBe(RSA.fingerprint);
+  });
+
+  it('rejects unknown types, bad base64 and blobs of another type', () => {
+    expect(() => parsePublicKey('ssh-dss AAAA')).toThrow(/OpenSSH public key line/);
+    expect(() => parsePublicKey('ssh-ed25519 not*base64')).toThrow(/base64/);
+    const [, rsaBlob] = RSA.line.split(' ');
+    expect(() => parsePublicKey(`ssh-ed25519 ${rsaBlob}`)).toThrow(/declared type/);
+    expect(() => parsePublicKey('')).toThrow();
+  });
+});
+
+describe('admitKey', () => {
+  it('approves a stored key whose public key matches, refuses a fingerprint collision', () => {
+    const key = parsePublicKey(ED25519.line);
+    const store = addApprovedKey(emptyKeyStore(), key, 'laptop', T0);
+    expect(admitKey(store, key, T0).verdict).toBe('approved');
+    expect(admitKey(store, { fingerprint: key.fingerprint, publicKey: 'ssh-ed25519 AAAA' }, T0).verdict).toBe(
+      'refused',
+    );
+  });
+
+  it('records an unknown key as pending once, even when the server asks twice', () => {
+    const key = syntheticKey(1);
+    const first = admitKey(emptyKeyStore(), key, T0, '203.0.113.5');
+    expect(first.verdict).toBe('pending');
+    expect(first.changed).toBe(true);
+    expect(first.store.pending).toEqual([
+      {
+        fingerprint: key.fingerprint,
+        publicKey: key.publicKey,
+        firstSeenAt: T0.toISOString(),
+        lastSeenAt: T0.toISOString(),
+        source: '203.0.113.5',
+      },
+    ]);
+    const second = admitKey(first.store, key, at(500));
+    expect(second.verdict).toBe('pending');
+    expect(second.store.pending).toHaveLength(1);
+    expect(second.store.pending[0].lastSeenAt).toBe(at(500).toISOString());
+    expect(second.store.pending[0].firstSeenAt).toBe(T0.toISOString());
+  });
+
+  it(`refuses the ${PENDING_LIMIT + 1}th unknown key inside the window and admits again once it passes`, () => {
+    let store: KeyStore = emptyKeyStore();
+    for (let i = 1; i <= PENDING_LIMIT; i++) {
+      const result = admitKey(store, syntheticKey(i), at(i * 1000));
+      expect(result.verdict).toBe('pending');
+      store = result.store;
+    }
+    const refused = admitKey(store, syntheticKey(PENDING_LIMIT + 1), at(PENDING_LIMIT * 1000 + 1));
+    expect(refused.verdict).toBe('refused');
+    expect(refused.store.pending).toHaveLength(PENDING_LIMIT);
+    // A key that is already pending is never refused by the limit.
+    expect(admitKey(store, syntheticKey(1), at(PENDING_LIMIT * 1000 + 2)).verdict).toBe('pending');
+    // Once the window has passed, new keys are admitted again.
+    const later = admitKey(store, syntheticKey(PENDING_LIMIT + 1), at(PENDING_WINDOW_MS + 2000));
+    expect(later.verdict).toBe('pending');
+    expect(later.store.pending).toHaveLength(PENDING_LIMIT + 1);
+  });
+
+  it('forgets pending keys nobody approved after the retention period', () => {
+    const stale = admitKey(emptyKeyStore(), syntheticKey(1), T0).store;
+    const result = admitKey(stale, syntheticKey(2), at(PENDING_RETENTION_MS + 1));
+    expect(result.store.pending.map((k) => k.fingerprint)).toEqual([syntheticKey(2).fingerprint]);
+  });
+});
+
+describe('operator verbs', () => {
+  const key = parsePublicKey(ED25519.line);
+
+  it('approves a pending key by fingerprint, labels it by its source, and clears it from pending', () => {
+    const pending = admitKey(emptyKeyStore(), key, T0, '203.0.113.5').store;
+    const store = approvePendingKey(pending, key.fingerprint, undefined, at(1000));
+    expect(store.pending).toEqual([]);
+    expect(store.approved).toEqual([
+      {
+        fingerprint: key.fingerprint,
+        publicKey: key.publicKey,
+        label: '203.0.113.5',
+        approvedAt: at(1000).toISOString(),
+      },
+    ]);
+    expect(isApproved(store, key.fingerprint)).toBe(true);
+    expect(() => approvePendingKey(emptyKeyStore(), 'SHA256:nope')).toThrow(/no pending key/);
+  });
+
+  it('counts a fingerprint the browser approved (mirror) as approved', () => {
+    const store: KeyStore = { ...emptyKeyStore(), mirror: { fingerprints: ['SHA256:browser'], updatedAt: 't' } };
+    expect(isApproved(store, 'SHA256:browser')).toBe(true);
+    expect(isApproved(store, 'SHA256:other')).toBe(false);
+  });
+
+  it('adds a key directly with the comment as the default label, and revokes by fingerprint', () => {
+    const store = addApprovedKey(emptyKeyStore(), key, '', T0);
+    expect(store.approved[0].label).toBe('vector@test');
+    const revoked = revokeKey(store, key.fingerprint);
+    expect(revoked.approved).toEqual([]);
+    expect(() => revokeKey(revoked, key.fingerprint)).toThrow(/no key/);
+  });
+});

--- a/src/modules/community-portal/door/keys.ts
+++ b/src/modules/community-portal/door/keys.ts
@@ -1,0 +1,207 @@
+/**
+ * The approved-keys store the host owns (`data/door/keys.json`): keys the
+ * operator approved on this machine (with their public keys), fingerprints
+ * the account service approved in the browser (mirrored from snapshots),
+ * and the pending record of unknown keys that entered the waiting room.
+ *
+ * Every presented key is admitted to exactly one program: an approved
+ * fingerprint lands in a sandbox, an unknown one enters the waiting room.
+ * The waiting room is the only surface a stranger reaches behind the SSH
+ * handshake, so pending records are rate-limited; past the limit the room is
+ * refused.
+ */
+import { createHash } from 'node:crypto';
+
+import { readJson, writePrivate } from '../../../community-portal/private-file.js';
+
+export interface ApprovedKey {
+  fingerprint: string;
+  publicKey: string;
+  label: string;
+  approvedAt: string;
+}
+
+export interface PendingKey {
+  fingerprint: string;
+  publicKey: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  source?: string;
+}
+
+export interface KeyStore {
+  version: 1;
+  approved: ApprovedKey[];
+  pending: PendingKey[];
+  /** Fingerprints approved in the browser, as the account service last reported them. */
+  mirror?: { fingerprints: string[]; updatedAt: string };
+}
+
+export interface ParsedPublicKey {
+  type: string;
+  base64: string;
+  comment: string;
+  /** `<type> <base64>` — the two fields the server compares. */
+  publicKey: string;
+  /** `SHA256:<base64 without padding>` — the server's default fingerprint format. */
+  fingerprint: string;
+}
+
+/** Pending keys admitted per window before further unknown keys are refused. */
+export const PENDING_LIMIT = 10;
+export const PENDING_WINDOW_MS = 10 * 60_000;
+/** A pending key nobody approved is forgotten after this long. */
+export const PENDING_RETENTION_MS = 24 * 60 * 60_000;
+
+const KEY_TYPES = new Set([
+  'ssh-ed25519',
+  'ssh-rsa',
+  'ecdsa-sha2-nistp256',
+  'ecdsa-sha2-nistp384',
+  'ecdsa-sha2-nistp521',
+  'sk-ssh-ed25519@openssh.com',
+  'sk-ecdsa-sha2-nistp256@openssh.com',
+]);
+
+export function emptyKeyStore(): KeyStore {
+  return { version: 1, approved: [], pending: [] };
+}
+
+/** Parse one OpenSSH public key line (`<type> <base64> [comment]`) and compute its fingerprint. */
+export function parsePublicKey(text: string): ParsedPublicKey {
+  const fields = text.trim().split(/\s+/);
+  const [type, base64] = fields;
+  if (!type || !base64 || !KEY_TYPES.has(type)) {
+    throw new Error('expected an OpenSSH public key line: "<type> <base64> [comment]"');
+  }
+  const blob = Buffer.from(base64, 'base64');
+  if (blob.length < 8 || blob.toString('base64').replace(/=+$/, '') !== base64.replace(/=+$/, '')) {
+    throw new Error('public key is not valid base64');
+  }
+  const typeLength = blob.readUInt32BE(0);
+  if (blob.subarray(4, 4 + typeLength).toString('utf8') !== type) {
+    throw new Error('public key blob does not match its declared type');
+  }
+  return {
+    type,
+    base64,
+    comment: fields.slice(2).join(' '),
+    publicKey: `${type} ${base64}`,
+    fingerprint: fingerprintOf(blob),
+  };
+}
+
+export function fingerprintOf(blob: Buffer): string {
+  return `SHA256:${createHash('sha256').update(blob).digest('base64').replace(/=+$/, '')}`;
+}
+
+export async function readKeyStore(file: string): Promise<KeyStore> {
+  const store = await readJson<KeyStore>(file);
+  if (!store || store.version !== 1 || !Array.isArray(store.approved) || !Array.isArray(store.pending)) {
+    return emptyKeyStore();
+  }
+  if (store.mirror && !Array.isArray(store.mirror.fingerprints)) delete store.mirror;
+  return store;
+}
+
+export function writeKeyStore(file: string, store: KeyStore): Promise<void> {
+  return writePrivate(file, store);
+}
+
+export type Admission = 'approved' | 'pending' | 'refused';
+
+export interface AdmissionResult {
+  verdict: Admission;
+  store: KeyStore;
+  changed: boolean;
+}
+
+/**
+ * Decide what a presented key is admitted to and record it. Pure over the
+ * store value: the caller persists `store` when `changed` is set. The server
+ * asks twice per login (a query, then the signed attempt), so an already
+ * pending key only refreshes its `lastSeenAt` and never counts twice.
+ */
+export function admitKey(
+  store: KeyStore,
+  key: Pick<ParsedPublicKey, 'publicKey' | 'fingerprint'>,
+  now: Date = new Date(),
+  source?: string,
+): AdmissionResult {
+  const approved = store.approved.find((k) => k.fingerprint === key.fingerprint);
+  if (approved) {
+    return { verdict: approved.publicKey === key.publicKey ? 'approved' : 'refused', store, changed: false };
+  }
+  const nowIso = now.toISOString();
+  const pending = store.pending.filter((k) => now.getTime() - Date.parse(k.firstSeenAt) < PENDING_RETENTION_MS);
+  const known = pending.find((k) => k.fingerprint === key.fingerprint);
+  if (known) {
+    known.lastSeenAt = nowIso;
+    if (source && !known.source) known.source = source;
+    return { verdict: 'pending', store: { ...store, pending }, changed: true };
+  }
+  const recent = pending.filter((k) => now.getTime() - Date.parse(k.firstSeenAt) < PENDING_WINDOW_MS).length;
+  if (recent >= PENDING_LIMIT) {
+    return { verdict: 'refused', store: { ...store, pending }, changed: pending.length !== store.pending.length };
+  }
+  pending.push({
+    fingerprint: key.fingerprint,
+    publicKey: key.publicKey,
+    firstSeenAt: nowIso,
+    lastSeenAt: nowIso,
+    ...(source ? { source } : {}),
+  });
+  return { verdict: 'pending', store: { ...store, pending }, changed: true };
+}
+
+// --- operator verbs over the store ------------------------------------------
+
+export function addApprovedKey(store: KeyStore, key: ParsedPublicKey, label: string, now: Date = new Date()): KeyStore {
+  const entry: ApprovedKey = {
+    fingerprint: key.fingerprint,
+    publicKey: key.publicKey,
+    label: label || key.comment || 'terminal',
+    approvedAt: now.toISOString(),
+  };
+  return {
+    ...store,
+    approved: [...store.approved.filter((k) => k.fingerprint !== key.fingerprint), entry],
+    pending: store.pending.filter((k) => k.fingerprint !== key.fingerprint),
+  };
+}
+
+export function approvePendingKey(
+  store: KeyStore,
+  fingerprint: string,
+  label?: string,
+  now: Date = new Date(),
+): KeyStore {
+  const pending = store.pending.find((k) => k.fingerprint === fingerprint);
+  if (!pending) {
+    if (store.approved.some((k) => k.fingerprint === fingerprint)) return store;
+    throw new Error(`no pending key ${fingerprint} — connect once so it appears, or add its public key directly`);
+  }
+  return addApprovedKey(
+    store,
+    { ...parsePublicKey(pending.publicKey), comment: '' },
+    label ?? pending.source ?? '',
+    now,
+  );
+}
+
+export function revokeKey(store: KeyStore, fingerprint: string): KeyStore {
+  const approved = store.approved.filter((k) => k.fingerprint !== fingerprint);
+  const pending = store.pending.filter((k) => k.fingerprint !== fingerprint);
+  if (approved.length === store.approved.length && pending.length === store.pending.length) {
+    throw new Error(`no key ${fingerprint}`);
+  }
+  return { ...store, approved, pending };
+}
+
+/** Approved on this machine or in the browser. */
+export function isApproved(store: KeyStore, fingerprint: string): boolean {
+  return (
+    store.approved.some((k) => k.fingerprint === fingerprint) ||
+    store.mirror?.fingerprints.includes(fingerprint) === true
+  );
+}

--- a/src/modules/community-portal/door/landing-decision.ts
+++ b/src/modules/community-portal/door/landing-decision.ts
@@ -1,0 +1,44 @@
+/**
+ * Where an approved connection lands — pure, so the table is testable:
+ *
+ *   stream                         → decision
+ *   none                           → refuse (the door only admits streams the host relays)
+ *   target { sandbox }             → attach that sandbox (cold ones wake on attach; a missing
+ *                                     one fails with "no longer exists")
+ *   target { account }, exists     → attach the account's default sandbox
+ *   target { account }, missing    → create it through `sandboxes new`, which lands attached
+ *
+ * `SSH_ORIGINAL_COMMAND` `ls` or `list` prints the sandbox list instead; any
+ * other command is refused with usage.
+ */
+import type { DoorStream } from './target-map.js';
+
+export type LandingDecision =
+  | { verb: 'attach' | 'new'; name: string }
+  | { verb: 'list' }
+  | { verb: 'refuse'; reason: string; code: 1 | 2 };
+
+export const LANDING_USAGE = 'usage: ssh <address> [ls]  — no command lands in the sandbox; "ls" lists sandboxes';
+
+export function decideLanding(
+  stream: DoorStream | undefined,
+  existingSandboxes: readonly string[],
+  originalCommand?: string,
+): LandingDecision {
+  if (!stream) {
+    return {
+      verb: 'refuse',
+      reason: 'This connection has no target; the door only admits streams the host relays.',
+      code: 1,
+    };
+  }
+  const command = originalCommand?.trim();
+  if (command) {
+    if (command === 'ls' || command === 'list') return { verb: 'list' };
+    return { verb: 'refuse', reason: LANDING_USAGE, code: 2 };
+  }
+  const { account, sandbox } = stream.target;
+  if (sandbox) return { verb: 'attach', name: sandbox };
+  if (!account) return { verb: 'refuse', reason: 'This connection names no account.', code: 1 };
+  return existingSandboxes.includes(account) ? { verb: 'attach', name: account } : { verb: 'new', name: account };
+}

--- a/src/modules/community-portal/door/landing.test.ts
+++ b/src/modules/community-portal/door/landing.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The landing decision table and the landing around it, with the host's
+ * sandbox verbs and the terminal hand-over faked.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { decideLanding } from './landing-decision.js';
+import { runLanding, type AttachTarget, type LandingIo, type SandboxVerbs } from './landing.js';
+import type { DoorStream, DoorTarget } from './target-map.js';
+
+const streamFor = (target: DoorTarget): DoorStream => ({ target, openedAt: '2026-09-11T12:00:00.000Z' });
+const targetFor = (name: string): AttachTarget => ({ containerName: `ncl-${name}`, command: ['tmux', 'attach'] });
+
+interface Fakes {
+  io: LandingIo;
+  out: string[];
+  err: string[];
+  sandboxes: SandboxVerbs;
+  run: (target: AttachTarget) => Promise<number>;
+}
+
+function fakes(names: string[] = [], failAttach?: string): Fakes {
+  const f: Fakes = {
+    out: [],
+    err: [],
+    io: undefined as unknown as LandingIo,
+    sandboxes: undefined as unknown as SandboxVerbs,
+    run: vi.fn(async (_target: AttachTarget) => 7),
+  };
+  f.io = { write: (t) => f.out.push(t), fail: (t) => f.err.push(t) };
+  f.sandboxes = {
+    list: vi.fn(async () => ({ names, human: `SANDBOX\n${names.join('\n')}` })),
+    attach: vi.fn(async (name: string) => {
+      if (failAttach) throw new Error(failAttach);
+      return targetFor(name);
+    }),
+    create: vi.fn(async (name: string) => targetFor(name)),
+  };
+  return f;
+}
+
+describe('decideLanding', () => {
+  it.each([
+    [undefined, ['alice'], 'refuse'],
+    [{ account: 'alice', sandbox: 'demo' }, [], 'attach:demo'],
+    [{ account: 'alice', sandbox: 'demo' }, ['alice', 'demo'], 'attach:demo'],
+    [{ account: 'alice' }, ['alice'], 'attach:alice'],
+    [{ account: 'alice' }, ['other'], 'new:alice'],
+    [{ account: '' }, [], 'refuse'],
+  ] as const)('%j with sandboxes %j → %s', (target, existing, expected) => {
+    const decision = decideLanding(target && streamFor(target as DoorTarget), existing);
+    expect(
+      decision.verb === 'refuse' || decision.verb === 'list' ? decision.verb : `${decision.verb}:${decision.name}`,
+    ).toBe(expected);
+  });
+
+  it('turns `ls`/`list` into a listing and refuses any other command with usage (exit 2)', () => {
+    const stream = streamFor({ account: 'alice' });
+    expect(decideLanding(stream, [], 'ls')).toEqual({ verb: 'list' });
+    expect(decideLanding(stream, [], ' list ')).toEqual({ verb: 'list' });
+    expect(decideLanding(stream, [], 'bash')).toMatchObject({ verb: 'refuse', code: 2 });
+    expect(decideLanding(undefined, [], 'ls')).toMatchObject({ verb: 'refuse', code: 1 });
+  });
+});
+
+describe('runLanding', () => {
+  it('attaches a named sandbox target and hands the terminal over', async () => {
+    const f = fakes();
+    expect(await runLanding({ stream: streamFor({ account: 'alice', sandbox: 'demo' }), ...f })).toBe(7);
+    expect(f.sandboxes.list).not.toHaveBeenCalled();
+    expect(f.sandboxes.attach).toHaveBeenCalledWith('demo');
+    expect(f.run).toHaveBeenCalledWith(targetFor('demo'));
+    expect(f.out.join('')).toContain('Attaching to sandbox demo');
+  });
+
+  it('creates the account default sandbox on first use, attaches it afterwards', async () => {
+    const first = fakes([]);
+    expect(await runLanding({ stream: streamFor({ account: 'alice' }), ...first })).toBe(7);
+    expect(first.sandboxes.create).toHaveBeenCalledWith('alice');
+    expect(first.out.join('')).toContain('Creating sandbox alice');
+
+    const again = fakes(['alice']);
+    expect(await runLanding({ stream: streamFor({ account: 'alice' }), ...again })).toBe(7);
+    expect(again.sandboxes.attach).toHaveBeenCalledWith('alice');
+    expect(again.sandboxes.create).not.toHaveBeenCalled();
+  });
+
+  it('refuses a connection the host has no stream for, without touching the host', async () => {
+    const f = fakes(['alice']);
+    expect(await runLanding({ stream: undefined, ...f })).toBe(1);
+    expect(f.err.join('')).toMatch(/no target/);
+    expect(f.sandboxes.list).not.toHaveBeenCalled();
+    expect(f.run).not.toHaveBeenCalled();
+  });
+
+  it('lists for `ls` and refuses other commands with usage', async () => {
+    const ls = fakes(['alice', 'demo']);
+    expect(await runLanding({ stream: streamFor({ account: 'alice', sandbox: 'demo' }), command: 'ls', ...ls })).toBe(
+      0,
+    );
+    expect(ls.out.join('')).toBe('SANDBOX\nalice\ndemo\n');
+    expect(ls.run).not.toHaveBeenCalled();
+
+    const other = fakes(['alice']);
+    expect(await runLanding({ stream: streamFor({ account: 'alice' }), command: 'bash -i', ...other })).toBe(2);
+    expect(other.err.join('')).toMatch(/usage/);
+  });
+
+  it('reports a vanished sandbox, other attach errors, and a listing failure', async () => {
+    const gone = fakes([], "no sandbox 'gone' — create it");
+    expect(await runLanding({ stream: streamFor({ account: 'alice', sandbox: 'gone' }), ...gone })).toBe(1);
+    expect(gone.err.join('')).toBe('sandbox gone no longer exists\n');
+
+    const cold = fakes([], 'container did not come up');
+    expect(await runLanding({ stream: streamFor({ account: 'alice', sandbox: 'demo' }), ...cold })).toBe(1);
+    expect(cold.err.join('')).toContain('container did not come up');
+
+    const down = fakes();
+    vi.mocked(down.sandboxes.list).mockRejectedValue(new Error('ECONNREFUSED'));
+    expect(await runLanding({ stream: streamFor({ account: 'alice' }), ...down })).toBe(1);
+    expect(down.err.join('')).toMatch(/could not list.*ECONNREFUSED/);
+  });
+});

--- a/src/modules/community-portal/door/landing.ts
+++ b/src/modules/community-portal/door/landing.ts
@@ -1,0 +1,93 @@
+/**
+ * The landing — what an approved connection does once it is in.
+ *
+ * The relayed stream behind the connection's source port says where it is
+ * for; the host's own sandbox verbs do the rest: `sandboxes attach` for an
+ * existing sandbox (cold ones wake), `sandboxes new` for an account whose
+ * default sandbox does not exist yet, and the terminal is handed to the
+ * attach command inside the session's container. `ls` lists the sandboxes
+ * instead. There is no shell on this path; detach is tmux's Ctrl-b then d.
+ */
+import type { SessionExecOptions, SessionExecStream } from '../../../drivers/types.js';
+import { decideLanding } from './landing-decision.js';
+import type { DoorStream } from './target-map.js';
+
+/** A live session and the attach command to run inside it (cli/attach-resolve.ts). */
+export interface AttachTarget {
+  containerName: string;
+  command: string[];
+  /** Absent when the session's runtime can only describe attaches, not hold their stream. */
+  execStream?: (command: string[], options: SessionExecOptions) => Promise<SessionExecStream>;
+  /** Whether the session's runtime still runs — to say why a terminal ended. Absent: unknown. */
+  alive?: () => Promise<boolean>;
+}
+
+export interface SandboxListing {
+  names: string[];
+  /** The host's rendered table. */
+  human: string;
+}
+
+/** The host's sandbox verbs as the door calls them; errors carry the verb's own message. */
+export interface SandboxVerbs {
+  list(): Promise<SandboxListing>;
+  attach(name: string): Promise<AttachTarget>;
+  create(name: string): Promise<AttachTarget>;
+}
+
+export interface LandingIo {
+  write(text: string): void;
+  fail(text: string): void;
+}
+
+export interface LandingDeps {
+  stream: DoorStream | undefined;
+  /** The exec command, when the client sent one instead of asking for a shell. */
+  command?: string;
+  sandboxes: SandboxVerbs;
+  io: LandingIo;
+  /** Hand the terminal to the attach command; resolves with its exit code. */
+  run(target: AttachTarget): Promise<number>;
+}
+
+export async function runLanding(deps: LandingDeps): Promise<number> {
+  const { stream, command, sandboxes, io } = deps;
+  // Only an account target (or a listing) needs the sandbox list; no stream
+  // and a named sandbox decide without it.
+  let listing: SandboxListing | undefined;
+  if (stream && (!stream.target.sandbox || command)) {
+    try {
+      listing = await sandboxes.list();
+    } catch (error) {
+      if (!(error instanceof Error)) throw error;
+      io.fail(`The host could not list sandboxes: ${error.message}\n`);
+      return 1;
+    }
+  }
+  const decision = decideLanding(stream, listing?.names ?? [], command);
+  if (decision.verb === 'refuse') {
+    io.fail(`${decision.reason}\n`);
+    return decision.code;
+  }
+  if (decision.verb === 'list') {
+    io.write(`${listing?.human ?? ''}\n`);
+    return 0;
+  }
+  io.write(
+    decision.verb === 'new'
+      ? `Creating sandbox ${decision.name} — detach with Ctrl-b then d.\n`
+      : `Attaching to sandbox ${decision.name} — detach with Ctrl-b then d.\n`,
+  );
+  let target: AttachTarget;
+  try {
+    target = decision.verb === 'attach' ? await sandboxes.attach(decision.name) : await sandboxes.create(decision.name);
+  } catch (error) {
+    if (!(error instanceof Error)) throw error;
+    const text = error.message;
+    io.fail(
+      `${decision.verb === 'attach' && /^no sandbox /.test(text) ? `sandbox ${decision.name} no longer exists` : text}\n`,
+    );
+    return 1;
+  }
+  return deps.run(target);
+}

--- a/src/modules/community-portal/door/lifecycle.test.ts
+++ b/src/modules/community-portal/door/lifecycle.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The door's journal and lifecycle without a client: inert until enabled
+ * (no files for an enrolled host that never opted in), the journal says
+ * enabled only once the door listens, the journaled port is reused only
+ * while it is free, and a rename from the account recomposes the host name
+ * for the status line and the hook.
+ */
+import fs from 'node:fs';
+import net from 'node:net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ROOT = vi.hoisted(() => `/tmp/nanoclaw-door-lifecycle-${process.pid}`);
+
+vi.mock('../../../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../config.js')>();
+  return { ...actual, DATA_DIR: `${ROOT}/data`, GROUPS_DIR: `${ROOT}/groups` };
+});
+
+import {
+  onRemoteAccessChanged,
+  resetSandboxHooksForTesting,
+  SANDBOX_HOOKS_SEAM,
+  type RemoteAccessState,
+} from '../../../code-mode/hooks.js';
+import { writePrivate } from '../../../community-portal/private-file.js';
+import { getHostStartCallbacks } from '../../../host-lifecycle.js';
+import type { DbDriver } from '../../../db/driver.js';
+import { applyTerminalMirror, disableDoor, doorStatus, enableDoor, setTerminalSeam } from './index.js';
+import { DoorServer } from './server.js';
+
+const heard: RemoteAccessState[] = [];
+
+/** Hold a port; one already held by another process (a parallel door test) is just as taken. */
+async function occupy(port: number): Promise<net.Server | null> {
+  const server = net.createServer();
+  return new Promise<net.Server | null>((resolve, reject) => {
+    server.once('error', (error: NodeJS.ErrnoException) =>
+      error.code === 'EADDRINUSE' ? resolve(null) : reject(error),
+    );
+    server.listen(port, '127.0.0.1', () => resolve(server));
+  });
+}
+
+beforeEach(async () => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+  fs.mkdirSync(`${ROOT}/data`, { recursive: true });
+  await writePrivate(`${ROOT}/data/community-portal.json`, {
+    origin: 'https://portal.example.test',
+    deviceId: 'dev_1',
+  });
+  heard.length = 0;
+  resetSandboxHooksForTesting();
+  onRemoteAccessChanged('test', (state) => void heard.push(state), { seam: SANDBOX_HOOKS_SEAM });
+  setTerminalSeam({
+    enable: async (request) => ({ name: request.name ?? 'alice', host: `${request.name ?? 'alice'}.example.test` }),
+    report: async () => {},
+  });
+});
+
+afterEach(async () => {
+  await disableDoor().catch(() => {});
+  setTerminalSeam({});
+  resetSandboxHooksForTesting();
+  fs.rmSync(ROOT, { recursive: true, force: true });
+});
+
+describe('inert until enabled', () => {
+  it('creates no door files on an enrolled host that never enabled remote access', async () => {
+    const start = getHostStartCallbacks();
+    for (const cb of start) await cb({ db: {} as DbDriver, signal: new AbortController().signal });
+    expect((await doorStatus()).enabled).toBe(false);
+    await applyTerminalMirror(undefined);
+    await applyTerminalMirror({ enabled: false, keys: [] });
+    expect(fs.existsSync(`${ROOT}/data/door`)).toBe(false);
+  });
+});
+
+describe('enable', () => {
+  it('journals enabled only once the door listens, and reuses the journaled port only while it is free', async () => {
+    const first = await enableDoor({ name: 'alice' });
+    expect(first.door.running).toBe(true);
+    const port = first.doorPort!;
+    expect(JSON.parse(fs.readFileSync(`${ROOT}/data/door/state.json`, 'utf8'))).toMatchObject({
+      enabled: true,
+      doorPort: port,
+    });
+    expect(heard.at(-1)).toEqual({ enabled: true, name: 'alice', host: 'alice.example.test' });
+    await disableDoor();
+    expect(heard.at(-1)).toEqual({ enabled: false, name: 'alice', host: 'alice.example.test' });
+
+    // The journaled port is taken by someone else: the door moves on.
+    const squatter = await occupy(port);
+    try {
+      const again = await enableDoor({ name: 'alice' });
+      expect(again.doorPort).not.toBe(port);
+      expect(again.door.running).toBe(true);
+    } finally {
+      squatter?.close();
+    }
+    await disableDoor();
+
+    // A second enable while the door runs keeps the listener and its port:
+    // the journal, the report and the summary all name the live one.
+    const reported: number[] = [];
+    setTerminalSeam({
+      enable: async (request) => ({ name: request.name ?? 'alice', host: `${request.name ?? 'alice'}.example.test` }),
+      report: async (state) => {
+        if (state.doorPort) reported.push(state.doorPort);
+      },
+    });
+    const running = await enableDoor({ name: 'alice' });
+    const repeated = await enableDoor({ name: 'alice' });
+    expect(repeated.doorPort).toBe(running.doorPort);
+    expect(repeated.door).toMatchObject({ running: true, port: running.doorPort });
+    expect(JSON.parse(fs.readFileSync(`${ROOT}/data/door/state.json`, 'utf8')).doorPort).toBe(running.doorPort);
+    expect(reported.at(-1)).toBe(running.doorPort);
+    await disableDoor();
+
+    // The listen fails: the journal never says enabled.
+    const start = vi.spyOn(DoorServer.prototype, 'start').mockRejectedValueOnce(new Error('listen failed'));
+    try {
+      await expect(enableDoor({ name: 'alice' })).rejects.toThrow(/listen failed/);
+      expect(JSON.parse(fs.readFileSync(`${ROOT}/data/door/state.json`, 'utf8')).enabled).toBe(false);
+    } finally {
+      start.mockRestore();
+    }
+  });
+});
+
+describe('a rename from the account', () => {
+  it('recomposes the host name from the new name and the old zone, for the status and the hook', async () => {
+    await enableDoor({ name: 'alice' });
+    heard.length = 0;
+    await applyTerminalMirror({ enabled: true, name: 'bob', previousName: 'alice', keys: [] });
+    const status = await doorStatus();
+    expect(status).toMatchObject({ name: 'bob', previousName: 'alice', host: 'bob.example.test' });
+    expect(heard).toEqual([{ enabled: true, name: 'bob', host: 'bob.example.test' }]);
+  });
+});

--- a/src/modules/community-portal/door/name.ts
+++ b/src/modules/community-portal/door/name.ts
@@ -1,0 +1,87 @@
+/**
+ * The account name chosen at `ncl sandboxes remote enable --name <name>`.
+ *
+ * It becomes a DNS label once the network side allocates an address for it,
+ * and the default sandbox created on first landing is named after it — so it
+ * must satisfy both grammars: a DNS label (lowercase letters, digits and
+ * hyphens, 3–32 characters, no leading, trailing or double hyphen) that is
+ * also a legal sandbox name, and not a word the address space keeps for
+ * itself.
+ */
+export const ACCOUNT_NAME_MIN = 3;
+export const ACCOUNT_NAME_MAX = 32;
+
+const ACCOUNT_NAME = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+/**
+ * Names refused before the account service is asked. The service's own
+ * reserved list is authoritative — its answer at `remote enable` decides,
+ * and it may refuse more than this — but the words every address space
+ * keeps for itself, and the ones this host's own layout uses, are refused
+ * here so the operator hears it at once, link or no link.
+ */
+export const RESERVED_ACCOUNT_NAMES: ReadonlySet<string> = new Set([
+  // the group folder layout
+  'global',
+  // common service labels
+  'access',
+  'account',
+  'admin',
+  'api',
+  'app',
+  'apps',
+  'auth',
+  'dashboard',
+  'dev',
+  'docs',
+  'help',
+  'login',
+  'mail',
+  'registry',
+  'relay',
+  'smtp',
+  'sso',
+  'staging',
+  'status',
+  'test',
+  'vault',
+  'www',
+  // the terminal address space and its verbs
+  'approve',
+  'attach',
+  'cell',
+  'demo',
+  'door',
+  'ipv6',
+  'list',
+  'ls',
+  'nanoclaw',
+  'new',
+  'ns1',
+  'ns2',
+  'portal',
+  'remote',
+  'rename',
+  'sandbox',
+  'sandboxes',
+  'ssh',
+  'terminal',
+  'v6',
+]);
+
+export function accountNameError(name: string): string | undefined {
+  if (name.length < ACCOUNT_NAME_MIN || name.length > ACCOUNT_NAME_MAX) {
+    return `name must be ${ACCOUNT_NAME_MIN}–${ACCOUNT_NAME_MAX} characters`;
+  }
+  if (!ACCOUNT_NAME.test(name) || name.includes('--')) {
+    return 'name must use lowercase letters, digits and single hyphens only, and cannot start or end with a hyphen';
+  }
+  if (RESERVED_ACCOUNT_NAMES.has(name)) return `'${name}' is reserved`;
+  return undefined;
+}
+
+export function validateAccountName(name: string): string {
+  const problem = accountNameError(name);
+  if (problem) throw new Error(`invalid account name "${name}" — ${problem}`);
+  return name;
+}

--- a/src/modules/community-portal/door/paths.test.ts
+++ b/src/modules/community-portal/door/paths.test.ts
@@ -1,0 +1,38 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { doorFiles } from './paths.js';
+import { accountNameError, validateAccountName } from './name.js';
+
+describe('door paths', () => {
+  it('keeps every door file in one directory', () => {
+    const files = doorFiles('/srv/host/data/door');
+    expect(Object.values(files).every((f) => f.startsWith('/srv/host/data/door'))).toBe(true);
+    expect(path.basename(files.keyStore)).toBe('keys.json');
+    expect(path.basename(files.hostKey)).toBe('host_ed25519');
+    expect(path.basename(files.hostKeyPublic)).toBe('host_ed25519.pub');
+    expect(path.basename(files.state)).toBe('state.json');
+  });
+});
+
+describe('account names', () => {
+  it('accepts DNS labels of 3–32 lowercase characters', () => {
+    for (const ok of ['abc', 'my-machine', 'a1b2', 'x'.repeat(32)]) expect(accountNameError(ok)).toBeUndefined();
+    expect(validateAccountName('alice')).toBe('alice');
+  });
+
+  it('rejects length, case, punctuation, edge hyphens and the reserved folder name', () => {
+    expect(accountNameError('ab')).toMatch(/3–32/);
+    expect(accountNameError('x'.repeat(33))).toMatch(/3–32/);
+    expect(accountNameError('MyBox')).toMatch(/lowercase/);
+    expect(accountNameError('my_box')).toMatch(/lowercase/);
+    expect(accountNameError('-abc')).toMatch(/hyphen/);
+    expect(accountNameError('abc-')).toMatch(/hyphen/);
+    expect(accountNameError('ab--cd')).toMatch(/hyphen/);
+    expect(accountNameError('www')).toMatch(/reserved/);
+    expect(accountNameError('sandbox')).toMatch(/reserved/);
+    expect(accountNameError('a.b.c')).toMatch(/lowercase/);
+    expect(accountNameError('global')).toMatch(/reserved/);
+    expect(() => validateAccountName('Nope')).toThrow(/invalid account name "Nope"/);
+  });
+});

--- a/src/modules/community-portal/door/paths.ts
+++ b/src/modules/community-portal/door/paths.ts
@@ -1,0 +1,24 @@
+/**
+ * Door file layout. Everything the door owns lives in one directory
+ * (`data/door` on the host): the host key pair, the approved-keys store and
+ * the state journal.
+ */
+import path from 'node:path';
+
+export interface DoorFiles {
+  dir: string;
+  hostKey: string;
+  hostKeyPublic: string;
+  keyStore: string;
+  state: string;
+}
+
+export function doorFiles(dir: string): DoorFiles {
+  return {
+    dir,
+    hostKey: path.join(dir, 'host_ed25519'),
+    hostKeyPublic: path.join(dir, 'host_ed25519.pub'),
+    keyStore: path.join(dir, 'keys.json'),
+    state: path.join(dir, 'state.json'),
+  };
+}

--- a/src/modules/community-portal/door/report.ts
+++ b/src/modules/community-portal/door/report.ts
@@ -1,0 +1,105 @@
+/**
+ * The seam between the door and the host's account link.
+ *
+ * The door never talks to the account service itself; it calls these three
+ * functions, and the link replaces their bodies with `setTerminalSeam()` when
+ * it can carry them (naming and address allocation at enable, the state
+ * report on every start/disable, and pending-key registration that mints the
+ * approval code). Until then the defaults keep the door usable on its own:
+ * an explicit `--name`, a log line, and the approval page the door knows.
+ */
+import { log } from '../../../log.js';
+import type { DoorSource } from './target-map.js';
+
+export interface TerminalState {
+  enabled: boolean;
+  name?: string;
+  hostKeyFingerprint?: string;
+  doorPort?: number;
+  /** Fingerprints the door currently honours. */
+  authorizedFingerprints: string[];
+}
+
+export interface TerminalEnableRequest {
+  /** Omitted when the account service is expected to assign one. */
+  name?: string;
+  hostKey: string;
+  hostKeyFingerprint: string;
+}
+
+export interface TerminalEnableResult {
+  /** The name the account now carries — assigned or confirmed by the service. */
+  name: string;
+  /** The machine's address and host name, once the network side allocates them. */
+  address?: string;
+  host?: string;
+  /** Set when the account was renamed since the last enable. */
+  previousName?: string;
+}
+
+export interface PendingKeyRequest {
+  fingerprint: string;
+  keyType: string;
+  publicKey: string;
+  source?: DoorSource;
+  at: string;
+  /** The door's approval page, for the default answer; absent when the checkout has none. */
+  approvalUrl?: string;
+}
+
+export interface PendingKeyResult {
+  /** The short code the approval page asks for, when the service minted one. */
+  code?: string;
+  /** The page to approve at; absent when neither the service nor the door has one. */
+  url?: string;
+  expiresAt: string;
+}
+
+export interface TerminalSeam {
+  enable: (request: TerminalEnableRequest) => Promise<TerminalEnableResult>;
+  report: (state: TerminalState) => Promise<void>;
+  pending: (request: PendingKeyRequest) => Promise<PendingKeyResult>;
+}
+
+export const PENDING_APPROVAL_TTL_MS = 10 * 60_000;
+
+const defaults: TerminalSeam = {
+  async enable(request) {
+    if (!request.name) {
+      throw new Error(
+        'no account link carries terminal names yet — pass --name <account-name> to ncl sandboxes remote enable',
+      );
+    }
+    return { name: request.name };
+  },
+  async report(state) {
+    log.info('Remote terminal state', { ...state });
+  },
+  async pending(request) {
+    const expiresAt = new Date(Date.parse(request.at) + PENDING_APPROVAL_TTL_MS).toISOString();
+    return { ...(request.approvalUrl ? { url: request.approvalUrl } : {}), expiresAt };
+  },
+};
+
+let seam: TerminalSeam = { ...defaults };
+
+/** Replace part of the seam (the link does this at wiring time); `undefined` restores a default. */
+export function setTerminalSeam(partial: Partial<TerminalSeam>): void {
+  seam = {
+    enable: partial.enable ?? defaults.enable,
+    report: partial.report ?? defaults.report,
+    pending: partial.pending ?? defaults.pending,
+  };
+}
+
+export function enableTerminal(request: TerminalEnableRequest): Promise<TerminalEnableResult> {
+  return seam.enable(request);
+}
+
+export function reportTerminalState(state: TerminalState): Promise<void> {
+  return seam.report(state);
+}
+
+export function reportPendingKey(request: PendingKeyRequest): Promise<PendingKeyResult> {
+  return seam.pending(request);
+}

--- a/src/modules/community-portal/door/report.ts
+++ b/src/modules/community-portal/door/report.ts
@@ -6,8 +6,10 @@
  * it can carry them (naming and address allocation at enable, the state
  * report on every start/disable, and pending-key registration that mints the
  * approval code). Until then the defaults keep the door usable on its own:
- * an explicit `--name`, a log line, and the approval page the door knows.
+ * an explicit `--name`, the journal entry (and the report, when the
+ * checkout is signed in), and the approval page the door knows.
  */
+import { reportTerminalState as reportToAccount } from '../../../community-portal/terminal.js';
 import { log } from '../../../log.js';
 import type { DoorSource } from './target-map.js';
 
@@ -74,6 +76,9 @@ const defaults: TerminalSeam = {
   },
   async report(state) {
     log.info('Remote terminal state', { ...state });
+    // Journals the `terminal` section and reports to the account service in
+    // one place; the link's wiring adds only the wake-up of its runtime.
+    await reportToAccount(state);
   },
   async pending(request) {
     const expiresAt = new Date(Date.parse(request.at) + PENDING_APPROVAL_TTL_MS).toISOString();

--- a/src/modules/community-portal/door/server.ts
+++ b/src/modules/community-portal/door/server.ts
@@ -1,0 +1,99 @@
+/**
+ * The door's SSH server: in-process, loopback only, host key from the door
+ * directory, public keys only. The protocol is ssh2's (curve25519 key
+ * exchange, chacha20 / aes-gcm ciphers, ed25519 host key by default);
+ * everything a connection may do is decided per connection by the session
+ * handler. Stopping the server ends every connection with it.
+ */
+import type { ClientInfo, Connection, Server as SshServer } from 'ssh2';
+
+import { loadSsh2 } from './ssh2.js';
+
+export type DoorLogLevel = 'debug' | 'info' | 'warn' | 'error';
+export type DoorLog = (level: DoorLogLevel, message: string, data?: Record<string, unknown>) => void;
+
+export interface DoorServerOptions {
+  port: number;
+  /** The private host key, as the file holds it. */
+  hostKey: string;
+  onConnection: (client: Connection, info: ClientInfo) => void;
+  log: DoorLog;
+  keepaliveInterval?: number;
+  keepaliveCountMax?: number;
+}
+
+export interface DoorServerStatus {
+  running: boolean;
+  port: number;
+  /** Connections that completed the handshake and are still open. */
+  connections: number;
+  startedAt?: string;
+}
+
+export const KEEPALIVE_INTERVAL_MS = 20_000;
+export const KEEPALIVE_COUNT_MAX = 3;
+
+export class DoorServer {
+  private server?: SshServer;
+  private startedAt?: string;
+  private readonly clients = new Set<Connection>();
+
+  constructor(private readonly options: DoorServerOptions) {}
+
+  async start(): Promise<void> {
+    if (this.server) return;
+    const { port, hostKey, log } = this.options;
+    // The library is loaded here, on the first listen, never at import.
+    const { Server } = await loadSsh2();
+    const server = new Server(
+      {
+        hostKeys: [hostKey],
+        keepaliveInterval: this.options.keepaliveInterval ?? KEEPALIVE_INTERVAL_MS,
+        keepaliveCountMax: this.options.keepaliveCountMax ?? KEEPALIVE_COUNT_MAX,
+      },
+      (client, info) => {
+        this.clients.add(client);
+        client.once('close', () => this.clients.delete(client));
+        client.on('error', (error) => log('debug', 'Remote terminal connection error', { from: info.ip, err: error }));
+        this.options.onConnection(client, info);
+      },
+    );
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', (error: NodeJS.ErrnoException) =>
+        reject(
+          error.code === 'EADDRINUSE'
+            ? new Error(`127.0.0.1:${port} is already in use; the door cannot listen there`, { cause: error })
+            : error,
+        ),
+      );
+      server.listen(port, '127.0.0.1', () => {
+        server.removeAllListeners('error');
+        server.on('error', (error: Error) => log('error', 'Remote terminal server error', { err: error }));
+        resolve();
+      });
+    });
+    this.server = server;
+    this.startedAt = new Date().toISOString();
+    log('info', 'Remote terminal door listening', { port });
+  }
+
+  /** Close the listener and end every connection (their sessions end with them). */
+  async stop(): Promise<void> {
+    const server = this.server;
+    this.server = undefined;
+    this.startedAt = undefined;
+    if (!server) return;
+    for (const client of this.clients) client.end();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    this.clients.clear();
+  }
+
+  status(): DoorServerStatus {
+    return {
+      running: this.server !== undefined,
+      port: this.options.port,
+      connections: this.clients.size,
+      ...(this.startedAt ? { startedAt: this.startedAt } : {}),
+    };
+  }
+}

--- a/src/modules/community-portal/door/session.test.ts
+++ b/src/modules/community-portal/door/session.test.ts
@@ -1,0 +1,637 @@
+/**
+ * One connection through the session handler with ssh2's objects faked:
+ * the authentication decisions (public key only, any username, signatures
+ * checked, unknown keys admitted), the session requests (PTY, resize,
+ * shell, exec, refused forwarding and subsystems), the waiting room in
+ * session, the session cap, revocation ending a live session, and the
+ * terminal put back in order (with a word why) when the exec ends under the
+ * client. The container runtime's exec stream is faked with a pair of streams.
+ */
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import ssh2, { type ClientInfo, type Connection, type ParsedKey, type Session } from 'ssh2';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { SessionExecOptions, SessionExecStream } from '../../../drivers/types.js';
+import { fingerprintOf } from './keys.js';
+import type { AttachTarget } from './landing.js';
+import { handleConnection, MAX_SESSIONS, type SessionDeps } from './session.js';
+import { loadSsh2 } from './ssh2.js';
+import type { DoorStream } from './target-map.js';
+import { TERMINAL_RESET, terminalEnded } from './terminal-reset.js';
+
+const { utils } = ssh2;
+
+// The server loads the library before it accepts a connection; here the
+// handler is driven directly, so load it first.
+beforeAll(() => loadSsh2());
+
+class FakeChannel extends EventEmitter {
+  out = '';
+  err = '';
+  exitCode: number | undefined;
+  ended = false;
+  stderr = {
+    write: (data: Buffer | string): boolean => {
+      this.err += String(data);
+      return true;
+    },
+  };
+  write(data: Buffer | string): boolean {
+    this.out += String(data);
+    return true;
+  }
+  exit(code: number): void {
+    this.exitCode = code;
+  }
+  end(): void {
+    this.ended = true;
+  }
+}
+
+class FakeClient extends EventEmitter {
+  ended = false;
+  end(): void {
+    this.ended = true;
+    this.emit('close');
+  }
+}
+
+/** A fake runtime exec: what the command "prints" goes into `stdout`, what the session sends lands in `input`. */
+class FakeExec implements SessionExecStream {
+  stdin = new PassThrough();
+  stdout = new PassThrough();
+  stderr?: PassThrough;
+  input = '';
+  resized: [number, number][] = [];
+  closed = false;
+  private finish!: (code: number) => void;
+  private fail!: (error: Error) => void;
+  exited = new Promise<number>((resolve, reject) => {
+    this.finish = resolve;
+    this.fail = reject;
+  });
+  constructor(tty: boolean) {
+    if (!tty) this.stderr = new PassThrough();
+    this.stdin.on('data', (data: Buffer) => (this.input += data.toString()));
+  }
+  resize = vi.fn(async (cols: number, rows: number) => {
+    this.resized.push([cols, rows]);
+  });
+  close(): void {
+    this.closed = true;
+    this.finish(129);
+  }
+  exit(code: number): void {
+    this.finish(code);
+  }
+  /** The stream broke: no exit code will ever be known. */
+  break(): void {
+    this.fail(new Error('stream broke'));
+  }
+}
+
+const INFO: ClientInfo = { ip: '127.0.0.1', port: 50562, family: 'IPv4', header: {} as ClientInfo['header'] };
+
+function keyPair(): { key: ParsedKey; blob: Buffer; fingerprint: string } {
+  const pair = utils.generateKeyPairSync('ed25519');
+  const parsed = utils.parseKey(pair.private);
+  const key = (Array.isArray(parsed) ? parsed[0] : parsed) as ParsedKey;
+  const blob = key.getPublicSSH();
+  return { key, blob, fingerprint: fingerprintOf(blob) };
+}
+
+function authContext(method: string, username: string, key?: ReturnType<typeof keyPair>, sign = true) {
+  const blob = Buffer.from('session-id-and-request');
+  return {
+    method,
+    username,
+    service: 'ssh-connection',
+    key: key ? { algo: 'ssh-ed25519', data: key.blob } : undefined,
+    signature: key && sign ? key.key.sign(blob) : undefined,
+    blob: key && sign ? blob : undefined,
+    hashAlgo: undefined,
+    accept: vi.fn(),
+    reject: vi.fn(),
+  };
+}
+
+function deps(
+  overrides: Partial<SessionDeps> & {
+    approved?: string[];
+    streams?: Record<number, DoorStream>;
+    noStream?: boolean;
+    /** The runtime's answer to whether the session still runs, once its exec ended. */
+    alive?: () => Promise<boolean>;
+  } = {},
+) {
+  const approved = new Set(overrides.approved ?? []);
+  const ends = new Map<string, () => void>();
+  const execs: { exec: FakeExec; command: string[]; options: SessionExecOptions }[] = [];
+  const logs: { level: string; message: string; data?: Record<string, unknown> }[] = [];
+  let live = 0;
+  let waiters: ((approved: boolean) => void)[] = [];
+  const targetFor = (name: string): AttachTarget => ({
+    containerName: `ncl-${name}`,
+    command: ['tmux', 'attach', name],
+    ...(overrides.noStream
+      ? {}
+      : {
+          execStream: async (command: string[], options: SessionExecOptions) => {
+            const exec = new FakeExec(options.tty);
+            execs.push({ exec, command, options });
+            return exec;
+          },
+        }),
+    ...(overrides.alive ? { alive: overrides.alive } : {}),
+  });
+  const d: SessionDeps = {
+    authority: {
+      status: (fp) => (approved.has(fp) ? 'approved' : 'unknown'),
+      openRoom: vi.fn(async () => 'ok' as const),
+      waitForApproval: vi.fn(
+        (fp) =>
+          new Promise<boolean>((resolve) => {
+            if (approved.has(fp)) return resolve(true);
+            waiters.push(resolve);
+          }),
+      ),
+      registerSession: vi.fn((fp, end) => {
+        ends.set(fp, end);
+        return () => ends.delete(fp);
+      }),
+    },
+    lookupTarget: (port) => overrides.streams?.[port],
+    pending: vi.fn(async (request) => ({ url: request.approvalUrl, expiresAt: 'x', code: 'ABCD-EFGH' })),
+    approvalUrl: () => 'https://example.test/terminals',
+    sandboxes: {
+      list: vi.fn(async () => ({ names: ['alice'], human: 'SANDBOX\nalice' })),
+      attach: vi.fn(async (name: string) => targetFor(name)),
+      create: vi.fn(async (name: string) => targetFor(name)),
+    },
+    sessions: {
+      count: () => live,
+      track: () => {
+        live += 1;
+        return () => {
+          live -= 1;
+        };
+      },
+    },
+    log: (level, message, data) => logs.push({ level, message, data }),
+    ...overrides,
+  };
+  return {
+    deps: d,
+    approve: (fp: string) => {
+      approved.add(fp);
+      const pending = waiters;
+      waiters = [];
+      for (const resolve of pending) resolve(true);
+    },
+    ends,
+    execs,
+    logs,
+    live: () => live,
+  };
+}
+
+/** Connect, authenticate with a signed public key, and open a session. */
+function connect(d: SessionDeps, username = 'anyname', key = keyPair()) {
+  const client = new FakeClient();
+  handleConnection(client as unknown as Connection, INFO, d);
+  const ctx = authContext('publickey', username, key);
+  client.emit('authentication', ctx);
+  client.emit('ready');
+  const session = new EventEmitter();
+  client.emit('session', () => session as unknown as Session, vi.fn());
+  return { client, session, key, ctx };
+}
+
+function shell(session: EventEmitter, pty = true): FakeChannel {
+  if (pty)
+    session.emit('pty', vi.fn(), vi.fn(), {
+      term: 'xterm-256color',
+      cols: 120,
+      rows: 40,
+      width: 0,
+      height: 0,
+      modes: {},
+    });
+  const channel = new FakeChannel();
+  session.emit('shell', () => channel, vi.fn());
+  return channel;
+}
+
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('the pre-auth deadline', () => {
+  it('ends a connection that has not authenticated in time, and leaves one that has alone', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const f = deps({ authDeadlineMs: 1_000 });
+      const idle = new FakeClient();
+      handleConnection(idle as unknown as Connection, INFO, f.deps);
+      await vi.advanceTimersByTimeAsync(999);
+      expect(idle.ended).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(idle.ended).toBe(true);
+      expect(f.logs.at(-1)).toMatchObject({ message: expect.stringMatching(/not authenticated in time/) });
+
+      const { client } = connect(f.deps);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(client.ended).toBe(false);
+      // A client that left before the deadline is not touched again.
+      const gone = new FakeClient();
+      handleConnection(gone as unknown as Connection, INFO, f.deps);
+      gone.end();
+      const endedOnce = gone.ended;
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(gone.ended).toBe(endedOnce);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('authentication', () => {
+  it('offers public key only and ignores the username', () => {
+    const f = deps();
+    const client = new FakeClient();
+    handleConnection(client as unknown as Connection, INFO, f.deps);
+    for (const method of ['none', 'password', 'keyboard-interactive']) {
+      const ctx = authContext(method, 'root');
+      client.emit('authentication', ctx);
+      expect(ctx.reject).toHaveBeenCalledWith(['publickey']);
+      expect(ctx.accept).not.toHaveBeenCalled();
+    }
+    const key = keyPair();
+    for (const username of ['alice', 'root', 'anything-at-all']) {
+      const ctx = authContext('publickey', username, key);
+      client.emit('authentication', ctx);
+      expect(ctx.accept).toHaveBeenCalledTimes(1);
+      expect(ctx.reject).not.toHaveBeenCalled();
+    }
+    client.emit('ready');
+    expect(f.logs.at(-1)).toMatchObject({ message: 'Remote terminal login', data: { username: 'anything-at-all' } });
+  });
+
+  it('accepts the key query, rejects a bad signature, and rejects everything while disabled', () => {
+    const client = new FakeClient();
+    const d = deps().deps;
+    handleConnection(client as unknown as Connection, INFO, d);
+    const key = keyPair();
+    const query = authContext('publickey', 'x', key, false);
+    client.emit('authentication', query);
+    expect(query.accept).toHaveBeenCalled();
+
+    const forged = authContext('publickey', 'x', key);
+    forged.signature = Buffer.alloc(64, 1);
+    client.emit('authentication', forged);
+    expect(forged.reject).toHaveBeenCalledWith(['publickey']);
+
+    const disabled = deps({ authority: { ...d.authority, status: () => 'disabled' } }).deps;
+    const off = new FakeClient();
+    handleConnection(off as unknown as Connection, INFO, disabled);
+    const ctx = authContext('publickey', 'x', key);
+    off.emit('authentication', ctx);
+    expect(ctx.reject).toHaveBeenCalledWith(['publickey']);
+  });
+});
+
+describe('sessions', () => {
+  it('lands an approved key in its stream’s sandbox on a sized TTY exec, resizes, pumps bytes, and exits with it', async () => {
+    const key = keyPair();
+    const f = deps({
+      approved: [key.fingerprint],
+      streams: { 50562: { target: { account: 'alice', sandbox: 'demo' }, openedAt: 't' } },
+    });
+    const { session, client } = connect(f.deps, 'whoever', key);
+    const channel = shell(session);
+    await vi.waitFor(() => expect(f.execs).toHaveLength(1));
+    const { exec, command, options } = f.execs[0];
+    expect(command).toEqual(['tmux', 'attach', 'demo']);
+    expect(options).toEqual({ tty: true, cols: 120, rows: 40 });
+    expect(channel.out).toContain('Attaching to sandbox demo — detach with Ctrl-b then d.\r\n');
+    expect(f.live()).toBe(1);
+
+    session.emit('window-change', vi.fn(), vi.fn(), { cols: 200, rows: 50, width: 0, height: 0 });
+    await settle();
+    expect(exec.resized).toEqual([[200, 50]]);
+    channel.emit('data', Buffer.from('ls\r'));
+    await settle();
+    expect(exec.input).toBe('ls\r');
+    exec.stdout.write('hello from tmux');
+    await settle();
+    expect(channel.out).toContain('hello from tmux');
+
+    exec.exit(3);
+    await vi.waitFor(() => expect(channel.exitCode).toBe(3));
+    expect(channel.ended).toBe(true);
+    // The program's last bytes, then the terminal put back, then the word why.
+    expect(channel.out.endsWith(`hello from tmux${terminalEnded('exit code 3')}`)).toBe(true);
+    expect(f.live()).toBe(0);
+    expect(client.ended).toBe(false);
+  });
+
+  it('puts the terminal back and says the container stopped when the exec dies under the client', async () => {
+    const key = keyPair();
+    const f = deps({
+      approved: [key.fingerprint],
+      streams: { 50562: { target: { account: 'alice', sandbox: 'demo' }, openedAt: 't' } },
+      alive: async () => false,
+    });
+    const { session } = connect(f.deps, 'x', key);
+    const channel = shell(session);
+    await vi.waitFor(() => expect(f.execs).toHaveLength(1));
+    const { exec } = f.execs[0];
+    exec.stdout.write('\x1b[?1000h\x1b[?2004hlast frame');
+    await settle();
+    exec.exit(137);
+    await vi.waitFor(() => expect(channel.exitCode).toBe(137));
+    expect(channel.ended).toBe(true);
+    const reset = channel.out.indexOf(TERMINAL_RESET);
+    const why = channel.out.indexOf('[nanoclaw] session ended: container stopped');
+    expect(channel.out.indexOf('last frame')).toBeLessThan(reset);
+    expect(reset).toBeGreaterThan(-1);
+    expect(why).toBeGreaterThan(reset);
+    expect(channel.out.endsWith(terminalEnded('container stopped'))).toBe(true);
+    expect(channel.out.split(TERMINAL_RESET)).toHaveLength(2);
+  });
+
+  it('a clean detach puts the terminal back without a word, once', async () => {
+    const key = keyPair();
+    const f = deps({
+      approved: [key.fingerprint],
+      streams: { 50562: { target: { account: 'alice', sandbox: 'demo' }, openedAt: 't' } },
+      alive: async () => false,
+    });
+    const { session } = connect(f.deps, 'x', key);
+    const channel = shell(session);
+    await vi.waitFor(() => expect(f.execs).toHaveLength(1));
+    const { exec } = f.execs[0];
+    exec.stdout.write('[detached (from session agent)]\r\n');
+    await settle();
+    exec.exit(0);
+    await vi.waitFor(() => expect(channel.exitCode).toBe(0));
+    expect(channel.ended).toBe(true);
+    expect(channel.out.endsWith(`[detached (from session agent)]\r\n${TERMINAL_RESET}`)).toBe(true);
+    expect(channel.out.split(TERMINAL_RESET)).toHaveLength(2);
+    expect(channel.out).not.toContain('[nanoclaw] session ended');
+  });
+
+  it('reports the exit code when the runtime still runs or cannot say, and a broken stream as closed', async () => {
+    const key = keyPair();
+    const stream: DoorStream = { target: { account: 'alice', sandbox: 'demo' }, openedAt: 't' };
+    const running = deps({ approved: [key.fingerprint], streams: { 50562: stream }, alive: async () => true });
+    const { session } = connect(running.deps, 'x', key);
+    const channel = shell(session);
+    await vi.waitFor(() => expect(running.execs).toHaveLength(1));
+    running.execs[0].exec.exit(130);
+    await vi.waitFor(() => expect(channel.exitCode).toBe(130));
+    expect(channel.out.endsWith(terminalEnded('exit code 130'))).toBe(true);
+
+    const unsure = deps({
+      approved: [key.fingerprint],
+      streams: { 50562: stream },
+      alive: async () => {
+        throw new Error('no daemon');
+      },
+    });
+    const { session: second } = connect(unsure.deps, 'x', key);
+    const other = shell(second);
+    await vi.waitFor(() => expect(unsure.execs).toHaveLength(1));
+    unsure.execs[0].exec.exit(137);
+    await vi.waitFor(() => expect(other.exitCode).toBe(137));
+    expect(other.out.endsWith(terminalEnded('exit code 137'))).toBe(true);
+
+    const broken = deps({ approved: [key.fingerprint], streams: { 50562: stream }, alive: async () => false });
+    const { session: third } = connect(broken.deps, 'x', key);
+    const last = shell(third);
+    await vi.waitFor(() => expect(broken.execs).toHaveLength(1));
+    broken.execs[0].exec.break();
+    await vi.waitFor(() => expect(last.exitCode).toBe(1));
+    expect(last.out.endsWith(terminalEnded('stream closed'))).toBe(true);
+    expect(last.ended).toBe(true);
+  });
+
+  it('runs `ls` as an exec without a TTY and refuses other commands', async () => {
+    const key = keyPair();
+    const f = deps({
+      approved: [key.fingerprint],
+      streams: { 50562: { target: { account: 'alice' }, openedAt: 't' } },
+    });
+    const { session } = connect(f.deps, 'x', key);
+    const channel = new FakeChannel();
+    session.emit('exec', () => channel, vi.fn(), { command: 'ls' });
+    await vi.waitFor(() => expect(channel.exitCode).toBe(0));
+    expect(channel.out).toBe('SANDBOX\nalice\n');
+    expect(f.execs).toHaveLength(0);
+
+    const { session: again } = connect(f.deps, 'x', key);
+    const other = new FakeChannel();
+    again.emit('exec', () => other, vi.fn(), { command: 'bash' });
+    await vi.waitFor(() => expect(other.exitCode).toBe(2));
+    expect(other.err).toMatch(/usage/);
+  });
+
+  it('attaches without a TTY as a plain exec, keeping stderr apart and passing EOF through', async () => {
+    const key = keyPair();
+    const f = deps({
+      approved: [key.fingerprint],
+      streams: { 50562: { target: { account: 'alice' }, openedAt: 't' } },
+    });
+    const { session } = connect(f.deps, 'x', key);
+    const channel = shell(session, false);
+    await vi.waitFor(() => expect(f.execs).toHaveLength(1));
+    const { exec, options } = f.execs[0];
+    expect(options).toEqual({ tty: false });
+    expect(channel.out).toContain('Attaching to sandbox alice — detach with Ctrl-b then d.\n');
+    exec.stderr!.write('warning');
+    await settle();
+    expect(channel.err).toContain('warning');
+    const ended = new Promise<void>((resolve) => exec.stdin.on('end', () => resolve()));
+    channel.emit('eof');
+    await ended;
+    exec.exit(0);
+    await vi.waitFor(() => expect(channel.exitCode).toBe(0));
+    // No terminal, nothing to put back.
+    expect(channel.out).not.toContain(TERMINAL_RESET);
+    expect(channel.out).not.toContain('[nanoclaw] session ended');
+  });
+
+  it('holds an unknown key in the waiting room and lands it in the same session once approved', async () => {
+    const key = keyPair();
+    const f = deps({
+      streams: { 50562: { target: { account: 'alice' }, source: { ip: '203.0.113.5', port: 4242 }, openedAt: 't' } },
+    });
+    const { session } = connect(f.deps, 'x', key);
+    const channel = shell(session);
+    await vi.waitFor(() => expect(channel.out).toContain('not approved for remote access yet'));
+    expect(channel.out).toContain(`key    ${key.fingerprint}`);
+    expect(channel.out).toContain('from   203.0.113.5');
+    expect(channel.out).toContain('code   ABCD-EFGH');
+    expect(f.deps.authority.openRoom).toHaveBeenCalledWith(
+      { fingerprint: key.fingerprint, keyType: 'ssh-ed25519', publicKey: `ssh-ed25519 ${key.blob.toString('base64')}` },
+      { ip: '203.0.113.5', port: 4242 },
+    );
+    expect(f.execs).toHaveLength(0);
+
+    f.approve(key.fingerprint);
+    await vi.waitFor(() => expect(f.execs).toHaveLength(1));
+    expect(channel.out).toContain('Approved. Connecting…\r\n');
+    expect(channel.out).toContain('Attaching to sandbox alice');
+  });
+
+  it('refuses a connection the host relayed no stream for, and a runtime that cannot hand over a terminal', async () => {
+    const key = keyPair();
+    const f = deps({ approved: [key.fingerprint] });
+    const { session } = connect(f.deps, 'x', key);
+    const channel = shell(session);
+    await vi.waitFor(() => expect(channel.exitCode).toBe(1));
+    expect(channel.err).toMatch(/no target/);
+
+    const g = deps({
+      approved: [key.fingerprint],
+      noStream: true,
+      streams: { 50562: { target: { account: 'alice' }, openedAt: 't' } },
+    });
+    const { session: other } = connect(g.deps, 'x', key);
+    const plain = shell(other);
+    await vi.waitFor(() => expect(plain.exitCode).toBe(1));
+    expect(plain.err).toMatch(/cannot hand over a terminal/);
+  });
+
+  it(`caps sessions at ${MAX_SESSIONS} and ends a live session when its key is revoked`, async () => {
+    const key = keyPair();
+    const f = deps({
+      approved: [key.fingerprint],
+      streams: { 50562: { target: { account: 'alice', sandbox: 'demo' }, openedAt: 't' } },
+    });
+    const channels: FakeChannel[] = [];
+    for (let i = 0; i < MAX_SESSIONS; i++) channels.push(shell(connect(f.deps, 'x', key).session));
+    await vi.waitFor(() => expect(f.execs).toHaveLength(MAX_SESSIONS));
+    const { session, client } = connect(f.deps, 'x', key);
+    const overflow = shell(session);
+    await vi.waitFor(() => expect(overflow.exitCode).toBe(1));
+    expect(overflow.err).toMatch(/Too many terminal sessions/);
+
+    f.ends.get(key.fingerprint)!();
+    await settle();
+    const ended = channels.filter((c) => c.ended);
+    expect(ended.length).toBeGreaterThanOrEqual(1);
+    expect(ended[0].err).toMatch(/revoked/);
+    // The door hung the terminal's program up itself: the terminal is put back, once.
+    expect(ended[0].out.split(TERMINAL_RESET)).toHaveLength(2);
+    await settle();
+    expect(ended[0].out).not.toContain('[nanoclaw] session ended');
+    expect(f.execs.some((e) => e.exec.closed)).toBe(true);
+    expect(client.ended).toBe(false);
+  });
+
+  it('hangs the exec up when the channel closes, and rejects forwarding, subsystems and a second program', async () => {
+    const key = keyPair();
+    const f = deps({
+      approved: [key.fingerprint],
+      streams: { 50562: { target: { account: 'alice' }, openedAt: 't' } },
+    });
+    const { client, session } = connect(f.deps, 'x', key);
+    const reject = vi.fn();
+    client.emit('tcpip', vi.fn(), reject, {});
+    client.emit('openssh.streamlocal', vi.fn(), reject, {});
+    client.emit('request', vi.fn(), reject, 'tcpip-forward', {});
+    session.emit('sftp', vi.fn(), reject);
+    session.emit('subsystem', vi.fn(), reject, { name: 'sftp' });
+    session.emit('x11', vi.fn(), reject, {});
+    session.emit('auth-agent', vi.fn(), reject);
+    session.emit('env', vi.fn(), reject, { key: 'X', val: 'y' });
+    expect(reject).toHaveBeenCalledTimes(8);
+    const channel = shell(session);
+    session.emit('shell', vi.fn(), reject);
+    expect(reject).toHaveBeenCalledTimes(9);
+    await vi.waitFor(() => expect(f.execs).toHaveLength(1));
+    channel.emit('close');
+    await settle();
+    expect(f.execs[0].exec.closed).toBe(true);
+    // The client left first: there is nobody to put a terminal back for.
+    await settle();
+    expect(channel.out).not.toContain(TERMINAL_RESET);
+    expect(channel.out).not.toContain('[nanoclaw] session ended');
+  });
+});
+
+describe('a connection that ends while its terminal is still being set up', () => {
+  it('starts no exec when the key is revoked during a cold attach, and frees the session slot', async () => {
+    const key = keyPair();
+    let land!: (target: AttachTarget) => void;
+    const attaching = new Promise<AttachTarget>((resolve) => {
+      land = resolve;
+    });
+    const execStream = vi.fn(async (_command: string[], options: SessionExecOptions) => new FakeExec(options.tty));
+    const f = deps({
+      approved: [key.fingerprint],
+      streams: { 50562: { target: { account: 'alice', sandbox: 'cold' }, openedAt: 't' } },
+    });
+    f.deps.sandboxes = { ...f.deps.sandboxes, attach: vi.fn(() => attaching) };
+    const { session, client } = connect(f.deps, 'x', key);
+    const channel = shell(session);
+    await settle();
+    expect(f.live()).toBe(1);
+
+    f.ends.get(key.fingerprint)!();
+    await settle();
+    expect(channel.err).toMatch(/revoked/);
+    expect(client.ended).toBe(true);
+    expect(f.live()).toBe(0);
+
+    // The sandbox wakes after the revocation: nothing is started for it.
+    land({ containerName: 'ncl-cold', command: ['tmux', 'attach', 'cold'], execStream });
+    await settle();
+    await settle();
+    expect(execStream).not.toHaveBeenCalled();
+    expect(f.live()).toBe(0);
+  });
+
+  it('hangs up an exec that resolves after the client left or was revoked, on both endings', async () => {
+    for (const ending of ['close', 'revoke'] as const) {
+      const key = keyPair();
+      const started: FakeExec[] = [];
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const f = deps({
+        approved: [key.fingerprint],
+        streams: { 50562: { target: { account: 'alice', sandbox: 'slow' }, openedAt: 't' } },
+      });
+      const target: AttachTarget = {
+        containerName: 'ncl-slow',
+        command: ['tmux', 'attach', 'slow'],
+        execStream: async (_command, options) => {
+          await gate;
+          const exec = new FakeExec(options.tty);
+          started.push(exec);
+          return exec;
+        },
+      };
+      f.deps.sandboxes = { ...f.deps.sandboxes, attach: vi.fn(async () => target) };
+      const { session, client } = connect(f.deps, 'x', key);
+      const channel = shell(session);
+      await settle();
+      expect(f.live()).toBe(1);
+
+      if (ending === 'close') channel.emit('close');
+      else f.ends.get(key.fingerprint)!();
+      await settle();
+      expect(f.live()).toBe(0);
+      if (ending === 'revoke') expect(client.ended).toBe(true);
+
+      release();
+      await settle();
+      await settle();
+      expect(started).toHaveLength(1);
+      expect(started[0].closed).toBe(true);
+      expect(f.live()).toBe(0);
+    }
+  });
+});

--- a/src/modules/community-portal/door/session.ts
+++ b/src/modules/community-portal/door/session.ts
@@ -1,0 +1,343 @@
+/**
+ * One SSH connection to the door, from authentication to the terminal the
+ * session is handed.
+ *
+ * Authentication: public key only, any username (the account and the
+ * relayed stream decide where a connection lands, not the login name; the
+ * name is logged). A key the host has not approved is admitted too — into
+ * the waiting room, which becomes the landing in the same session once the
+ * key is approved. Sessions: a PTY if asked, then `shell` (land) or `exec`
+ * (`ls` lists; anything else is refused with usage). The terminal itself is
+ * the container runtime's: the attach command runs inside the session's
+ * container over the runtime's own exec stream, sized from the client's
+ * `pty-req` and every `window-change`. No forwarding of any kind, no
+ * subsystems. A revocation ends the session; so does stopping the door.
+ * A terminal whose program ended under it — the container retired, the
+ * stream torn down — is put back in order and told why before the channel
+ * closes (terminal-reset.ts).
+ */
+import type { ClientInfo, Connection, ServerChannel, Session } from 'ssh2';
+
+import type { SessionExecStream } from '../../../drivers/types.js';
+import { fingerprintOf } from './keys.js';
+import { runLanding, type AttachTarget, type LandingIo, type SandboxVerbs } from './landing.js';
+import type { PendingKeyRequest, PendingKeyResult } from './report.js';
+import type { DoorLog } from './server.js';
+import { ssh2Loaded } from './ssh2.js';
+import type { DoorSource, DoorStream } from './target-map.js';
+import { TERMINAL_RESET, terminalEnded } from './terminal-reset.js';
+import { runWaitingRoom } from './waiting-room.js';
+
+export type AuthorizeStatus = 'approved' | 'unknown' | 'disabled';
+
+export interface SessionAuthority {
+  status(fingerprint: string): AuthorizeStatus;
+  openRoom(
+    request: { fingerprint: string; keyType: string; publicKey: string },
+    source?: DoorSource,
+  ): Promise<'ok' | 'limit'>;
+  waitForApproval(fingerprint: string, waitMs: number): Promise<boolean>;
+  /** Register a way to end this session; returns the unregister. */
+  registerSession(fingerprint: string, end: () => void): () => void;
+}
+
+export interface SessionDeps {
+  authority: SessionAuthority;
+  lookupTarget(port: number): DoorStream | undefined;
+  pending(request: PendingKeyRequest): Promise<PendingKeyResult>;
+  /** The approval page, when the checkout has one. */
+  approvalUrl(): string | undefined;
+  sandboxes: SandboxVerbs;
+  /** Live sessions across the door, for the cap. */
+  sessions: { count(): number; track(): () => void };
+  maxSessions?: number;
+  /** How long a connection may take to authenticate (AUTH_DEADLINE_MS). */
+  authDeadlineMs?: number;
+  log: DoorLog;
+  now?: () => Date;
+}
+
+export const MAX_SESSIONS = 8;
+
+/** A connection that has not authenticated by then is ended: no idling on the handshake. */
+export const AUTH_DEADLINE_MS = 20_000;
+
+/** How long naming the end of a terminal may wait on the runtime's status. */
+const ALIVE_PROBE_MS = 1_000;
+
+interface Identity {
+  username: string;
+  fingerprint: string;
+  keyType: string;
+  /** `<type> <base64>` */
+  publicKey: string;
+}
+
+interface TerminalSize {
+  cols: number;
+  rows: number;
+  term: string;
+}
+
+export function handleConnection(client: Connection, info: ClientInfo, deps: SessionDeps): void {
+  // The server loaded the library before it accepted this connection.
+  const { utils } = ssh2Loaded();
+  const from = `${info.ip}:${info.port}`;
+  let identity: Identity | undefined;
+  // The pre-auth deadline: a client that never gets to `ready` is dropped.
+  const deadline = setTimeout(() => {
+    deps.log('info', 'Remote terminal connection ended: not authenticated in time', { from });
+    client.end();
+  }, deps.authDeadlineMs ?? AUTH_DEADLINE_MS);
+  client.once('close', () => clearTimeout(deadline));
+
+  client.on('authentication', (ctx) => {
+    if (ctx.method !== 'publickey') return ctx.reject(['publickey']);
+    const parsed = utils.parseKey(ctx.key.data);
+    const key = Array.isArray(parsed) ? parsed[0] : parsed;
+    if (!key || key instanceof Error) return ctx.reject(['publickey']);
+    const fingerprint = fingerprintOf(ctx.key.data);
+    if (deps.authority.status(fingerprint) === 'disabled') return ctx.reject(['publickey']);
+    // Without a signature the client is only asking whether the key would
+    // be acceptable; every key is, since the waiting room admits unknown ones.
+    if (ctx.signature) {
+      if (!ctx.blob || key.verify(ctx.blob, ctx.signature, ctx.hashAlgo) !== true) {
+        deps.log('warn', 'Remote terminal key signature rejected', { from, fingerprint });
+        return ctx.reject(['publickey']);
+      }
+    }
+    identity = {
+      username: ctx.username,
+      fingerprint,
+      keyType: ctx.key.algo,
+      publicKey: `${ctx.key.algo} ${ctx.key.data.toString('base64')}`,
+    };
+    ctx.accept();
+  });
+
+  client.on('ready', () => {
+    clearTimeout(deadline);
+    if (!identity) return;
+    deps.log('info', 'Remote terminal login', {
+      from,
+      username: identity.username,
+      fingerprint: identity.fingerprint,
+      status: deps.authority.status(identity.fingerprint),
+    });
+  });
+
+  client.on('session', (accept) => {
+    const session = accept();
+    handleSession(session);
+  });
+  client.on('tcpip', (_accept, reject) => reject());
+  client.on('openssh.streamlocal', (_accept, reject) => reject());
+  client.on('request', (_accept, reject) => reject?.());
+
+  function handleSession(session: Session): void {
+    let size: TerminalSize | undefined;
+    let exec: SessionExecStream | undefined;
+    let started = false;
+
+    session.on('pty', (accept, _reject, ptyInfo) => {
+      size = { cols: ptyInfo.cols, rows: ptyInfo.rows, term: ptyInfo.term };
+      accept?.();
+    });
+    session.on('window-change', (accept, _reject, change) => {
+      if (size) size = { ...size, cols: change.cols, rows: change.rows };
+      exec?.resize(change.cols, change.rows).catch(() => {});
+      accept?.();
+    });
+    session.on('signal', (accept, reject) => {
+      // The runtime's exec has no signal channel; a hang-up ends it (see close).
+      if (exec) accept?.();
+      else reject?.();
+    });
+    session.on('env', (_accept, reject) => reject?.());
+    session.on('x11', (_accept, reject) => reject?.());
+    session.on('auth-agent', (_accept, reject) => reject?.());
+    session.on('sftp', (_accept, reject) => reject());
+    session.on('subsystem', (_accept, reject) => reject());
+    session.on('shell', (accept, reject) => {
+      if (started) return reject();
+      started = true;
+      void run(accept(), undefined);
+    });
+    session.on('exec', (accept, reject, request) => {
+      if (started) return reject();
+      started = true;
+      void run(accept(), request.command);
+    });
+
+    async function run(channel: ServerChannel, command: string | undefined): Promise<void> {
+      // Text the door writes itself needs the carriage returns a terminal
+      // would add; the attach command's own output already has them.
+      const text = (value: string): string => (size ? value.replace(/\r?\n/g, '\r\n') : value);
+      const io: LandingIo = {
+        write: (value) => void channel.write(text(value)),
+        fail: (value) => void channel.stderr.write(text(value)),
+      };
+      let finished = false;
+      let closed = false;
+      let untrack: () => void = () => {};
+      let unregister: () => void = () => {};
+      const finish = (code: number): void => {
+        if (finished) return;
+        finished = true;
+        untrack();
+        unregister();
+        if (!closed) {
+          channel.exit(code);
+          channel.end();
+        }
+      };
+      channel.on('close', () => {
+        closed = true;
+        exec?.close();
+        finish(0);
+      });
+
+      if (!identity) return finish(1);
+      if (deps.sessions.count() >= (deps.maxSessions ?? MAX_SESSIONS)) {
+        io.fail('Too many terminal sessions on this machine; try again later.\n');
+        return finish(1);
+      }
+      untrack = deps.sessions.track();
+      const { fingerprint } = identity;
+      unregister = deps.authority.registerSession(fingerprint, () => {
+        // The door hangs the terminal's program up itself here; put the
+        // terminal back first so the message lands on a clean screen.
+        if (size && exec) channel.write(TERMINAL_RESET);
+        io.fail('\nAccess to this machine was revoked.\n');
+        exec?.close();
+        finish(1);
+        client.end();
+      });
+      const stream = deps.lookupTarget(info.port);
+
+      if (deps.authority.status(fingerprint) !== 'approved') {
+        const approvalUrl = deps.approvalUrl();
+        const approved = await runWaitingRoom({
+          fingerprint,
+          keyType: identity.keyType,
+          publicKey: identity.publicKey,
+          ...(stream?.source ? { source: stream.source } : {}),
+          ...(approvalUrl ? { approvalUrl } : {}),
+          io,
+          closed: () => closed,
+          openRoom: (request, source) => deps.authority.openRoom(request, source),
+          pending: (request) => deps.pending(request),
+          waitForApproval: (fp, ms) => deps.authority.waitForApproval(fp, ms),
+          ...(deps.now ? { now: deps.now } : {}),
+        });
+        if (!approved) return finish(1);
+      }
+
+      const code = await runLanding({
+        stream,
+        ...(command !== undefined ? { command } : {}),
+        sandboxes: deps.sandboxes,
+        io,
+        run: (target) => attach(channel, target, () => !closed && !finished),
+      });
+      finish(code);
+    }
+
+    /**
+     * Pump the channel into the attach command's stream inside the container
+     * and back. `open` says whether the client is still there to write to
+     * once the stream ends.
+     */
+    async function attach(channel: ServerChannel, target: AttachTarget, open: () => boolean): Promise<number> {
+      if (!target.execStream) {
+        channel.stderr.write(text("This session's runtime cannot hand over a terminal.\n"));
+        return 1;
+      }
+      // The landing may have waited on a cold sandbox; the client (or its
+      // key) may be gone by now. Nothing is started for a connection that
+      // already ended.
+      if (!open()) return 1;
+      let running: SessionExecStream;
+      try {
+        running = await target.execStream(
+          target.command,
+          size ? { tty: true, cols: size.cols, rows: size.rows } : { tty: false },
+        );
+      } catch (error) {
+        if (!(error instanceof Error)) throw error;
+        deps.log('error', 'Remote terminal could not start the attach command', {
+          container: target.containerName,
+          err: error,
+        });
+        channel.stderr.write(text(`The terminal could not be started: ${error.message}\n`));
+        return 1;
+      }
+      // The connection ended (close, revocation) while the exec was being
+      // started: hang the exec up instead of leaving it running untracked.
+      if (!open()) {
+        running.close();
+        return 1;
+      }
+      exec = running;
+      running.stdout.on('data', (data: Buffer) => {
+        if (!channel.write(data)) {
+          running.stdout.pause();
+          channel.once('drain', () => running.stdout.resume());
+        }
+      });
+      running.stderr?.on('data', (data: Buffer) => void channel.stderr.write(data));
+      // TODO: honour stdin's write() result and pause the channel when the
+      // runtime falls behind; today the SSH window (and the link's 64 KiB
+      // per-direction window on the relayed path) bounds what can queue here.
+      channel.on('data', (data: Buffer) => void running.stdin.write(data));
+      // Without a terminal the client's EOF is the command's EOF; a terminal
+      // ends when its program does (detach), never on a half-close.
+      if (!size) channel.on('eof', () => running.stdin.end());
+      let code: number;
+      // Why the terminal ended, when that is worth a line: a clean exit is a
+      // detach and should look like one. A non-zero end with the runtime
+      // gone is the container stopping under the client — say that, not the
+      // code of a killed tmux client.
+      let reason: string | undefined;
+      try {
+        code = await running.exited;
+        if (code !== 0) {
+          reason = target.alive && !(await stillAlive(target.alive)) ? 'container stopped' : `exit code ${code}`;
+        }
+      } catch (error) {
+        if (!(error instanceof Error)) throw error;
+        deps.log('warn', 'Remote terminal stream ended without an exit code', {
+          container: target.containerName,
+          err: error,
+        });
+        code = 1;
+        reason = 'stream closed';
+      }
+      if (exec === running) exec = undefined;
+      // A program restores its terminal on a clean exit; one ended under
+      // the client leaves mouse reporting and the rest on. Put the terminal
+      // back (and say why, when there is a why) before the channel ends —
+      // unless the client left first, in which case there is nobody to
+      // write to.
+      if (size && open()) channel.write(reason === undefined ? TERMINAL_RESET : terminalEnded(reason));
+      return code;
+
+      function text(value: string): string {
+        return size ? value.replace(/\r?\n/g, '\r\n') : value;
+      }
+    }
+  }
+}
+
+/** The runtime's word on whether it still runs; unknown (late, failed) reads as alive. */
+async function stillAlive(alive: () => Promise<boolean>): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const late = new Promise<boolean>((resolve) => {
+    timer = setTimeout(() => resolve(true), ALIVE_PROBE_MS);
+  });
+  try {
+    return await Promise.race([alive().catch(() => true), late]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/modules/community-portal/door/ssh2.ts
+++ b/src/modules/community-portal/door/ssh2.ts
@@ -1,0 +1,35 @@
+/**
+ * The SSH protocol library, loaded on first need.
+ *
+ * `ssh2` is the one dependency the door adds to the host. A host that never
+ * enables remote access never loads it: the server, the host key and the
+ * session handler ask for it here, and the door brings it in the moment it
+ * first listens or mints a host key. ssh2 is a CommonJS module, so only its
+ * default export is reachable from Node ESM.
+ */
+import type ssh2 from 'ssh2';
+
+export type Ssh2 = typeof ssh2;
+
+let loaded: Ssh2 | undefined;
+let loading: Promise<Ssh2> | undefined;
+
+/** Load (once) and return the library. */
+export function loadSsh2(): Promise<Ssh2> {
+  if (loaded) return Promise.resolve(loaded);
+  loading ??= import('ssh2').then((module) => {
+    loaded = module.default;
+    return loaded;
+  });
+  return loading;
+}
+
+/**
+ * The library, once loaded. The door's server loads it before it accepts a
+ * connection, so a session handler may call this synchronously; anything
+ * else must `await loadSsh2()` first.
+ */
+export function ssh2Loaded(): Ssh2 {
+  if (!loaded) throw new Error('the SSH library is not loaded yet; the door loads it before it listens');
+  return loaded;
+}

--- a/src/modules/community-portal/door/state.ts
+++ b/src/modules/community-portal/door/state.ts
@@ -1,0 +1,38 @@
+/**
+ * The door's state journal (`data/door/state.json`, mode 0600): what
+ * `remote enable` decided, kept across host restarts.
+ */
+import { readJson, writePrivate } from '../../../community-portal/private-file.js';
+
+export interface DoorState {
+  version: 1;
+  enabled: boolean;
+  /** The account name the service confirmed or assigned — the DNS label and the default sandbox name. */
+  name?: string;
+  /** The machine's address and host name once allocated. */
+  address?: string;
+  host?: string;
+  /** The name before a rename, so the operator learns the address changed. */
+  previousName?: string;
+  /** Loopback port the door listens on; chosen once, kept across restarts. */
+  doorPort?: number;
+  hostKey?: string;
+  hostKeyFingerprint?: string;
+  /**
+   * The page where a waiting key is approved in the browser, derived from
+   * the portal this checkout is enrolled with; absent on a checkout that is
+   * not enrolled (approval is then `ncl sandboxes remote keys approve`).
+   */
+  approvalUrl?: string;
+  enabledAt?: string;
+  updatedAt: string;
+}
+
+export async function readDoorState(file: string): Promise<DoorState | undefined> {
+  const state = await readJson<DoorState>(file);
+  return state && state.version === 1 ? state : undefined;
+}
+
+export function writeDoorState(file: string, state: DoorState): Promise<void> {
+  return writePrivate(file, state);
+}

--- a/src/modules/community-portal/door/target-map.test.ts
+++ b/src/modules/community-portal/door/target-map.test.ts
@@ -1,0 +1,48 @@
+/** Source-port → target map: register/lookup with TTL, copies out, unregister. */
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { clearTargets, DEFAULT_TARGET_TTL_MS, lookupTarget, registerTarget, unregisterTarget } from './target-map.js';
+
+beforeEach(() => clearTargets());
+
+describe('target map', () => {
+  it('registers, looks up a copy, and forgets on unregister', () => {
+    registerTarget(50001, {
+      target: { account: 'alice', sandbox: 'demo' },
+      source: { ip: '203.0.113.5', port: 40000 },
+      stream: 'abc',
+      openedAt: '2026-09-11T12:00:00.000Z',
+    });
+    const found = lookupTarget(50001);
+    expect(found).toEqual({
+      target: { account: 'alice', sandbox: 'demo' },
+      source: { ip: '203.0.113.5', port: 40000 },
+      stream: 'abc',
+      openedAt: '2026-09-11T12:00:00.000Z',
+    });
+    found!.target.sandbox = 'changed';
+    expect(lookupTarget(50001)?.target.sandbox).toBe('demo');
+    unregisterTarget(50001);
+    expect(lookupTarget(50001)).toBeUndefined();
+  });
+
+  it('stamps openedAt when the caller does not', () => {
+    registerTarget(50004, { target: { account: 'alice' } }, undefined, Date.parse('2026-09-11T12:00:00Z'));
+    expect(lookupTarget(50004, Date.parse('2026-09-11T12:00:01Z'))?.openedAt).toBe('2026-09-11T12:00:00.000Z');
+  });
+
+  it('expires entries after the TTL so a reused port cannot inherit a stale target', () => {
+    const t0 = 1_000_000;
+    registerTarget(50002, { target: { account: 'alice' } }, undefined, t0);
+    expect(lookupTarget(50002, t0 + DEFAULT_TARGET_TTL_MS - 1)?.target).toEqual({ account: 'alice' });
+    expect(lookupTarget(50002, t0 + DEFAULT_TARGET_TTL_MS)).toBeUndefined();
+    registerTarget(50003, { target: { account: 'bob' } }, 10, t0);
+    expect(lookupTarget(50003, t0 + 10)).toBeUndefined();
+  });
+
+  it('refuses nonsense registrations', () => {
+    expect(() => registerTarget(0, { target: { account: 'alice' } })).toThrow(/source port/);
+    expect(() => registerTarget(70000, { target: { account: 'alice' } })).toThrow(/source port/);
+    expect(() => registerTarget(5000, { target: { account: '' } })).toThrow(/account/);
+  });
+});

--- a/src/modules/community-portal/door/target-map.ts
+++ b/src/modules/community-portal/door/target-map.ts
@@ -1,0 +1,83 @@
+/**
+ * Source-port → target map.
+ *
+ * The host pipes each relayed terminal stream into the door from a distinct
+ * loopback source port and registers what that stream is for: an account
+ * (land in its default sandbox) or one named sandbox, plus where it came
+ * from. The forced command a connection lands in reads its client port from
+ * `SSH_CONNECTION` and asks the host over the door socket (host-socket.ts,
+ * `GET /target?port=N`) — it runs as a child of the OpenSSH server, not
+ * inside the host process. Entries expire on a TTL so a port number reused
+ * by an unrelated connection cannot inherit a stale target; the piping side
+ * unregisters when its door socket closes.
+ */
+
+export interface DoorTarget {
+  /** The account name (not an id); the default sandbox is named after it. */
+  account: string;
+  /** A specific sandbox to attach instead of the account default. */
+  sandbox?: string;
+}
+
+export interface DoorSource {
+  ip: string;
+  port: number;
+}
+
+/** What the host knows about one relayed stream, keyed by its loopback source port. */
+export interface DoorStream {
+  target: DoorTarget;
+  /** The remote client's public address as the relay saw it. */
+  source?: DoorSource;
+  /** The relay's stream id, for log correlation only. */
+  stream?: string;
+  openedAt: string;
+}
+
+export const DEFAULT_TARGET_TTL_MS = 5 * 60_000;
+
+interface Entry {
+  stream: DoorStream;
+  expiresAt: number;
+}
+
+const streams = new Map<number, Entry>();
+
+export function validPort(port: number): boolean {
+  return Number.isInteger(port) && port > 0 && port <= 65535;
+}
+
+export function registerTarget(
+  port: number,
+  entry: Omit<DoorStream, 'openedAt'> & { openedAt?: string },
+  ttlMs: number = DEFAULT_TARGET_TTL_MS,
+  now: number = Date.now(),
+): void {
+  if (!validPort(port)) throw new Error(`invalid source port ${port}`);
+  if (!entry.target?.account) throw new Error('a target needs an account');
+  const stream: DoorStream = {
+    target: { ...entry.target },
+    ...(entry.source ? { source: { ...entry.source } } : {}),
+    ...(entry.stream ? { stream: entry.stream } : {}),
+    openedAt: entry.openedAt ?? new Date(now).toISOString(),
+  };
+  streams.set(port, { stream, expiresAt: now + ttlMs });
+}
+
+export function unregisterTarget(port: number): void {
+  streams.delete(port);
+}
+
+export function lookupTarget(port: number, now: number = Date.now()): DoorStream | undefined {
+  const entry = streams.get(port);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= now) {
+    streams.delete(port);
+    return undefined;
+  }
+  return structuredClone(entry.stream);
+}
+
+export function clearTargets(): void {
+  streams.clear();
+}

--- a/src/modules/community-portal/door/terminal-reset.ts
+++ b/src/modules/community-portal/door/terminal-reset.ts
@@ -1,0 +1,33 @@
+/**
+ * What the door writes to a client's terminal when the program on it ended
+ * without getting to restore it.
+ *
+ * A tmux client that detaches cleanly turns off everything it turned on —
+ * mouse tracking, focus events, bracketed paste, the alternate screen. One
+ * killed under the operator (the container retired or stopped, the exec
+ * stream torn down) never sends those disables, and the operator's terminal
+ * is left reporting mouse movement and bracketing pastes, with no line
+ * saying what happened. The door cannot know which modes were on; the
+ * sequences here are the disables, each a no-op on a terminal that never
+ * enabled it, followed by a one-line explanation on a fresh line.
+ */
+
+/**
+ * Disable mouse tracking (X10, button, any-motion, SGR), focus events and
+ * bracketed paste; leave the alternate screen; show the cursor; reset
+ * attributes. Ordered so the explanation lands on the main screen with a
+ * visible cursor and plain attributes.
+ */
+export const TERMINAL_RESET =
+  '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l' + // mouse tracking
+  '\x1b[?1004l' + // focus events
+  '\x1b[?2004l' + // bracketed paste
+  '\x1b[?1049l' + // alternate screen
+  '\x1b[?25h' + // cursor
+  '\x1b[0m'; // attributes
+
+/** The reset, then why the session ended, on its own line — for an end that
+ * was not a clean detach; a clean one gets the bare reset and looks like one. */
+export function terminalEnded(reason: string): string {
+  return `${TERMINAL_RESET}\r\n[nanoclaw] session ended: ${reason}\r\n`;
+}

--- a/src/modules/community-portal/door/verbs.test.ts
+++ b/src/modules/community-portal/door/verbs.test.ts
@@ -1,0 +1,200 @@
+/**
+ * `ncl sandboxes remote …` through the real dispatch path with the door
+ * itself mocked: the verbs extend the trunk sandboxes resource, every verb
+ * is operator-only, the account name is validated before the door is
+ * touched, and arguments reach the door verbs intact.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./index.js', () => ({
+  enableDoor: vi.fn(),
+  disableDoor: vi.fn(),
+  doorStatus: vi.fn(),
+  listDoorKeys: vi.fn(),
+  addDoorKey: vi.fn(),
+  approveDoorKey: vi.fn(),
+  revokeDoorKey: vi.fn(),
+}));
+
+import {
+  addDoorKey,
+  approveDoorKey,
+  disableDoor,
+  doorStatus,
+  enableDoor,
+  listDoorKeys,
+  revokeDoorKey,
+} from './index.js';
+import { dispatch } from '../../../cli/dispatch.js';
+import type { CallerContext, RequestFrame, ResponseFrame } from '../../../cli/frame.js';
+import { assertSandboxVerb } from '../../../code-mode/contract.js';
+import { closeDb, initTestDb, runMigrations } from '../../../db/index.js';
+import '../../../cli/resources/sandboxes.js';
+import './verbs.js';
+
+const HOST: CallerContext = { caller: 'host' };
+const AGENT: CallerContext = { caller: 'agent', sessionId: 's1', agentGroupId: 'g-agent', messagingGroupId: 'mg1' };
+
+function call(command: string, args: Record<string, unknown> = {}, ctx: CallerContext = HOST): Promise<ResponseFrame> {
+  const req: RequestFrame = { id: `r-${Math.random().toString(36).slice(2, 8)}`, command, args };
+  return dispatch(req, ctx);
+}
+
+const human = (res: ResponseFrame): string | undefined => (res.ok ? res.human : undefined);
+
+const summary = {
+  enabled: true,
+  name: 'alice',
+  doorPort: 33022,
+  hostKeyFingerprint: 'SHA256:abc',
+  approvalUrl: 'https://portal.example.test/terminals',
+  terminal: { enabled: true, name: 'alice', hostKeyFingerprint: 'SHA256:abc', doorPort: 33022, updatedAt: 't' },
+  door: { running: true, port: 33022, connections: 1, sessions: 1 },
+  keys: { approved: 0, browser: 0, pending: 1, rooms: 1 },
+};
+
+beforeEach(async () => {
+  await runMigrations(await initTestDb());
+  vi.mocked(enableDoor).mockResolvedValue(summary);
+  vi.mocked(disableDoor).mockResolvedValue({ ...summary, enabled: false, door: { running: false } });
+  vi.mocked(doorStatus).mockResolvedValue(summary);
+  vi.mocked(listDoorKeys).mockResolvedValue({ version: 1, approved: [], pending: [] });
+  vi.mocked(addDoorKey).mockResolvedValue({ fingerprint: 'SHA256:added', publicKey: 'k', label: 'l', approvedAt: 't' });
+  vi.mocked(approveDoorKey).mockResolvedValue({
+    fingerprint: 'SHA256:ok',
+    publicKey: 'k',
+    label: 'l',
+    approvedAt: 't',
+  });
+  vi.mocked(revokeDoorKey).mockResolvedValue({ fingerprint: 'SHA256:gone' });
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await closeDb();
+});
+
+describe('sandboxes remote — operator-only surface', () => {
+  it('extends the trunk sandboxes resource with every remote verb', () => {
+    for (const verb of [
+      'remote enable',
+      'remote disable',
+      'remote status',
+      'remote keys list',
+      'remote keys add',
+      'remote keys approve',
+      'remote keys revoke',
+    ])
+      expect(() => assertSandboxVerb(verb)).not.toThrow();
+  });
+
+  it.each([
+    'sandboxes-remote-enable',
+    'sandboxes-remote-disable',
+    'sandboxes-remote-status',
+    'sandboxes-remote-keys-list',
+    'sandboxes-remote-keys-add',
+    'sandboxes-remote-keys-approve',
+    'sandboxes-remote-keys-revoke',
+  ])('%s refuses an agent caller before any handler runs', async (command) => {
+    const res = await call(command, { name: 'alice', id: 'x' }, AGENT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe('forbidden');
+    expect(enableDoor).not.toHaveBeenCalled();
+    expect(addDoorKey).not.toHaveBeenCalled();
+  });
+});
+
+describe('sandboxes remote enable', () => {
+  it('validates the account name before the door is touched', async () => {
+    for (const [args, pattern] of [
+      [{ name: 'ab' }, /3–32/],
+      [{ name: 'My-Box' }, /lowercase/],
+      [{ id: '-abc' }, /hyphen/],
+    ] as const) {
+      const res = await call('sandboxes-remote-enable', args);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error.message).toMatch(pattern);
+    }
+    expect(enableDoor).not.toHaveBeenCalled();
+  });
+
+  it('enables under the flag or positional name and renders the summary', async () => {
+    const flagged = await call('sandboxes-remote-enable', { name: 'alice' });
+    expect(flagged.ok).toBe(true);
+    expect(enableDoor).toHaveBeenLastCalledWith({ name: 'alice' });
+    expect(human(flagged)).toContain('enabled for "alice"');
+    expect(human(flagged)).toContain('127.0.0.1:33022');
+    expect(human(flagged)).toContain('SHA256:abc');
+    expect(human(flagged)).toContain('0 approved here, 0 approved in the browser, 1 pending');
+    expect(human(flagged)).toContain('approvals   https://portal.example.test/terminals');
+
+    // `ncl sandboxes remote enable bob` arrives as the trailing positional.
+    const positional = await call('sandboxes-remote-enable-bob');
+    expect(positional.ok).toBe(true);
+    expect(enableDoor).toHaveBeenLastCalledWith({ name: 'bob' });
+  });
+
+  it('enables without a name (the account assigns one) and prints the address and a rename', async () => {
+    const { approvalUrl: _unenrolled, ...standalone } = summary;
+    vi.mocked(enableDoor).mockResolvedValueOnce({
+      ...standalone,
+      name: 'alice-2',
+      host: 'alice-2.example.test',
+      previousName: 'alice',
+    });
+    const res = await call('sandboxes-remote-enable');
+    expect(res.ok).toBe(true);
+    expect(enableDoor).toHaveBeenLastCalledWith({});
+    expect(human(res)).toContain('enabled for "alice-2"');
+    expect(human(res)).toContain('ssh alice-2.example.test');
+    expect(human(res)).toContain('from "alice" — your address changed');
+    expect(human(res)).not.toContain('loopback only');
+    // No portal enrolled: approval is on the machine, and the summary says so.
+    expect(human(res)).toContain('approvals   on this machine only');
+  });
+});
+
+describe('sandboxes remote disable / status', () => {
+  it('disables and reports', async () => {
+    const off = await call('sandboxes-remote-disable');
+    expect(off.ok).toBe(true);
+    expect(disableDoor).toHaveBeenCalledTimes(1);
+    expect(human(off)).toContain('disabled');
+    const status = await call('sandboxes-remote-status');
+    expect(status.ok).toBe(true);
+    expect(doorStatus).toHaveBeenCalledTimes(1);
+    expect(human(status)).toContain('listening, 1 session');
+  });
+});
+
+describe('sandboxes remote keys', () => {
+  it('adds from a positional key or --key with an optional label', async () => {
+    const res = await call('sandboxes-remote-keys-add', { id: 'ssh-ed25519 AAAA test', label: 'laptop' });
+    expect(res.ok).toBe(true);
+    expect(addDoorKey).toHaveBeenLastCalledWith('ssh-ed25519 AAAA test', 'laptop');
+    expect(human(res)).toBe('approved SHA256:added');
+    await call('sandboxes-remote-keys-add', { key: '/home/alice/.ssh/id_ed25519.pub' });
+    expect(addDoorKey).toHaveBeenLastCalledWith('/home/alice/.ssh/id_ed25519.pub', undefined);
+    const usage = await call('sandboxes-remote-keys-add');
+    expect(usage.ok).toBe(false);
+    if (!usage.ok) expect(usage.error.message).toMatch(/usage/);
+  });
+
+  it('approves and revokes by fingerprint, keeping the fingerprint intact through the dispatch fallback', async () => {
+    const approve = await call('sandboxes-remote-keys-approve-SHA256:ab-cd');
+    expect(approve.ok).toBe(true);
+    expect(approveDoorKey).toHaveBeenLastCalledWith('SHA256:ab-cd', undefined);
+    const revoke = await call('sandboxes-remote-keys-revoke', { id: 'SHA256:gone' });
+    expect(revoke.ok).toBe(true);
+    expect(revokeDoorKey).toHaveBeenLastCalledWith('SHA256:gone');
+    expect(human(revoke)).toBe('revoked SHA256:gone');
+  });
+
+  it('lists with an empty-state hint', async () => {
+    const res = await call('sandboxes-remote-keys-list');
+    expect(res.ok).toBe(true);
+    expect(human(res)).toContain('no terminal keys');
+    expect(listDoorKeys).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/community-portal/door/verbs.ts
+++ b/src/modules/community-portal/door/verbs.ts
@@ -1,0 +1,167 @@
+/**
+ * `ncl sandboxes remote …` — the door's operator verbs, added to the
+ * sandboxes resource through code mode's resource extension. All hostOnly:
+ * enabling remote access, and deciding which terminal keys may land in a
+ * sandbox, is a host-side act.
+ */
+import { extendResource, RESOURCE_EXTENSION_SEAM, type CustomOperation } from '../../../cli/crud.js';
+import {
+  addDoorKey,
+  approveDoorKey,
+  disableDoor,
+  doorStatus,
+  enableDoor,
+  listDoorKeys,
+  revokeDoorKey,
+  type DoorSummary,
+} from './index.js';
+import type { KeyStore } from './keys.js';
+import { validateAccountName } from './name.js';
+
+function positional(args: Record<string, unknown>, flag: string): string | undefined {
+  const value = args[flag] ?? args.id;
+  return value === undefined || value === true ? undefined : String(value);
+}
+
+function renderSummary(data: unknown): string {
+  const s = data as DoorSummary;
+  const door = s.door;
+  const lines = [
+    s.enabled ? `Remote terminal access is enabled for "${s.name}".` : 'Remote terminal access is disabled.',
+  ];
+  if (s.enabled) {
+    if (s.host) lines.push(`  address     ssh ${s.host}`);
+    if (s.previousName) lines.push(`  renamed     from "${s.previousName}" — your address changed`);
+    lines.push(
+      `  door        127.0.0.1:${s.doorPort} — ${
+        door.running ? `listening, ${door.sessions} session${door.sessions === 1 ? '' : 's'}` : 'not running'
+      }`,
+      ...(s.host
+        ? []
+        : ['              loopback only; reachable over the network once the account link relays terminals']),
+      `  host key    ${s.hostKeyFingerprint} (ed25519)`,
+      `  keys        ${s.keys.approved} approved here, ${s.keys.browser} approved in the browser, ${s.keys.pending} pending` +
+        (s.keys.approved + s.keys.browser === 0
+          ? ' — add one: ncl sandboxes remote keys add ~/.ssh/id_ed25519.pub'
+          : ''),
+      s.approvalUrl
+        ? `  approvals   ${s.approvalUrl}`
+        : '  approvals   on this machine only (ncl sandboxes remote keys approve); no portal is enrolled',
+    );
+  }
+  return lines.join('\n');
+}
+
+function renderKeys(data: unknown): string {
+  const store = data as KeyStore;
+  const browser = store.mirror?.fingerprints ?? [];
+  if (store.approved.length === 0 && store.pending.length === 0 && browser.length === 0) {
+    return 'no terminal keys — add one: ncl sandboxes remote keys add ~/.ssh/id_ed25519.pub';
+  }
+  const lines: string[] = [];
+  if (store.approved.length) {
+    lines.push('APPROVED');
+    for (const k of store.approved) lines.push(`  ${k.fingerprint}  ${k.label}  since ${k.approvedAt}`);
+  }
+  if (browser.length) {
+    lines.push('APPROVED IN THE BROWSER');
+    for (const fingerprint of browser) lines.push(`  ${fingerprint}`);
+  }
+  if (store.pending.length) {
+    lines.push('PENDING (approve with: ncl sandboxes remote keys approve <fingerprint>)');
+    for (const k of store.pending)
+      lines.push(`  ${k.fingerprint}  from ${k.source ?? 'remote'}  first seen ${k.firstSeenAt}`);
+  }
+  return lines.join('\n');
+}
+
+export const remoteOperations: Record<string, CustomOperation> = {
+  'remote enable': {
+    access: 'open',
+    hostOnly: true,
+    description:
+      'Enable remote terminal access to this machine’s sandboxes (host operators only).\n' +
+      'Usage: ncl sandboxes remote enable [--name <account-name>]. The name (3–32 lowercase letters, digits ' +
+      'and single hyphens) becomes this machine’s address and names the default sandbox a remote terminal ' +
+      'lands in; when omitted, the account assigns one and the command prints the address. Generates a host ' +
+      'key once, starts a loopback SSH listener owned by the host, and keeps it running across host ' +
+      'restarts until `remote disable`.',
+    examples: ['ncl sandboxes remote enable', 'ncl sandboxes remote enable --name my-machine'],
+    handler: async (args) => {
+      const name = positional(args, 'name');
+      return enableDoor(name === undefined ? {} : { name: validateAccountName(name) });
+    },
+    formatHuman: renderSummary,
+  },
+  'remote disable': {
+    access: 'open',
+    hostOnly: true,
+    description:
+      'Disable remote terminal access: stop the loopback listener and keep it stopped across restarts ' +
+      '(host operators only). Approved keys are kept.\nUsage: ncl sandboxes remote disable',
+    handler: async () => disableDoor(),
+    formatHuman: renderSummary,
+  },
+  'remote status': {
+    access: 'open',
+    hostOnly: true,
+    description: 'Show remote terminal access state, the listener, and key counts (host operators only).',
+    handler: async () => doorStatus(),
+    formatHuman: renderSummary,
+  },
+  'remote keys list': {
+    access: 'open',
+    hostOnly: true,
+    description:
+      'List terminal keys: approved ones land in a sandbox, pending ones are waiting for approval ' +
+      '(host operators only).\nUsage: ncl sandboxes remote keys list',
+    handler: async () => listDoorKeys(),
+    formatHuman: renderKeys,
+  },
+  'remote keys add': {
+    access: 'open',
+    hostOnly: true,
+    description:
+      'Approve a terminal public key directly (host operators only).\n' +
+      'Usage: ncl sandboxes remote keys add <public-key-or-file> [--label <text>]. Accepts an OpenSSH ' +
+      'public key line or the path of a .pub file.',
+    examples: ['ncl sandboxes remote keys add ~/.ssh/id_ed25519.pub --label laptop'],
+    handler: async (args) => {
+      const key = positional(args, 'key');
+      if (!key) throw new Error('usage: ncl sandboxes remote keys add <public-key-or-file> [--label <text>]');
+      return addDoorKey(key, args.label === undefined ? undefined : String(args.label));
+    },
+    formatHuman: (data) => `approved ${(data as { fingerprint: string }).fingerprint}`,
+  },
+  'remote keys approve': {
+    access: 'open',
+    hostOnly: true,
+    description:
+      'Approve a key that is waiting after connecting once (host operators only).\n' +
+      'Usage: ncl sandboxes remote keys approve <fingerprint> [--label <text>]',
+    handler: async (args) => {
+      const fingerprint = positional(args, 'fingerprint');
+      if (!fingerprint) throw new Error('usage: ncl sandboxes remote keys approve <fingerprint>');
+      return approveDoorKey(fingerprint, args.label === undefined ? undefined : String(args.label));
+    },
+    formatHuman: (data) => `approved ${(data as { fingerprint: string }).fingerprint}`,
+  },
+  'remote keys revoke': {
+    access: 'open',
+    hostOnly: true,
+    description:
+      'Revoke a key approved on this machine and end its sessions; its next connection lands in the ' +
+      'waiting room again (host operators only). Keys approved in the browser are revoked there.\n' +
+      'Usage: ncl sandboxes remote keys revoke <fingerprint>',
+    handler: async (args) => {
+      const fingerprint = positional(args, 'fingerprint');
+      if (!fingerprint) throw new Error('usage: ncl sandboxes remote keys revoke <fingerprint>');
+      return revokeDoorKey(fingerprint);
+    },
+    formatHuman: (data) => `revoked ${(data as { fingerprint: string }).fingerprint}`,
+  },
+};
+
+// Registered on import: the sandboxes resource may register before or after
+// this module — extendResource queues until it does.
+extendResource('sandboxes', remoteOperations, { seam: RESOURCE_EXTENSION_SEAM });

--- a/src/modules/community-portal/door/waiting-room.test.ts
+++ b/src/modules/community-portal/door/waiting-room.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The waiting room: what a stranger sees, the approval hand-over, the
+ * timeout, the room cap, and a closed connection. Clock and waits are faked.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import type { LandingIo } from './landing.js';
+import { runWaitingRoom, WAITING_ROOM_TIMEOUT_MS, waitingRoomBanner, type WaitingRoomDeps } from './waiting-room.js';
+
+const FP = 'SHA256:gOakZC+YL189IEEAB60qLI8r+5H3H4lj4iMh5hlYOSo';
+const URL = 'https://example.test/terminals';
+
+/** Each wait round advances the fake clock by `roundMs`. */
+function clock(roundMs: number, start = Date.parse('2026-09-11T12:00:00Z')) {
+  let now = start;
+  return {
+    now: () => new Date(now),
+    tick: () => {
+      now += roundMs;
+    },
+  };
+}
+
+function room(overrides: Partial<WaitingRoomDeps> = {}) {
+  const out: string[] = [];
+  const err: string[] = [];
+  const io: LandingIo = { write: (t) => out.push(t), fail: (t) => err.push(t) };
+  const deps: WaitingRoomDeps = {
+    fingerprint: FP,
+    keyType: 'ssh-ed25519',
+    publicKey: 'ssh-ed25519 AAAA',
+    source: { ip: '203.0.113.5', port: 4242 },
+    approvalUrl: URL,
+    io,
+    closed: () => false,
+    openRoom: vi.fn(async () => 'ok' as const),
+    pending: vi.fn(async () => ({ code: 'ABCD-EFGH', url: `${URL}?approve=ABCD-EFGH`, expiresAt: 'x' })),
+    waitForApproval: vi.fn(async () => false),
+    pollMs: 25_000,
+    ...overrides,
+  };
+  return { deps, out, err };
+}
+
+describe('waitingRoomBanner', () => {
+  it('shows the fingerprint, the source, the time, the code, the approval page and the CLI alternative', () => {
+    const text = waitingRoomBanner(FP, '203.0.113.5', new Date('2026-09-11T12:00:00Z'), URL, 'ABCD-EFGH');
+    expect(text).toContain('not approved');
+    expect(text).toContain(`key    ${FP}`);
+    expect(text).toContain('from   203.0.113.5');
+    expect(text).toContain('at     2026-09-11T12:00:00.000Z');
+    expect(text).toContain('code   ABCD-EFGH');
+    expect(text).toContain(URL);
+    expect(text).toContain(`ncl sandboxes remote keys approve ${FP}`);
+    expect(waitingRoomBanner(FP, 'remote', new Date(), URL)).not.toContain('code   ');
+  });
+});
+
+describe('runWaitingRoom', () => {
+  it('registers the key, prints the banner with the service code, waits, and continues once approved', async () => {
+    const c = clock(25_000);
+    let rounds = 0;
+    const r = room({
+      now: c.now,
+      waitForApproval: vi.fn(async () => {
+        c.tick();
+        return ++rounds >= 3;
+      }),
+    });
+    expect(await runWaitingRoom(r.deps)).toBe(true);
+    expect(r.deps.openRoom).toHaveBeenCalledWith(
+      { fingerprint: FP, keyType: 'ssh-ed25519', publicKey: 'ssh-ed25519 AAAA' },
+      { ip: '203.0.113.5', port: 4242 },
+    );
+    expect(r.deps.pending).toHaveBeenCalledWith(
+      expect.objectContaining({ fingerprint: FP, source: { ip: '203.0.113.5', port: 4242 }, approvalUrl: URL }),
+    );
+    const text = r.out.join('');
+    expect(text).toContain('from   203.0.113.5');
+    expect(text).toContain('code   ABCD-EFGH');
+    expect(text).toContain(`${URL}?approve=ABCD-EFGH`);
+    expect(text).toContain('Approved. Connecting');
+    expect(rounds).toBe(3);
+  });
+
+  it('gives up after the timeout', async () => {
+    const c = clock(25_000);
+    let rounds = 0;
+    const r = room({
+      now: c.now,
+      waitForApproval: vi.fn(async () => {
+        c.tick();
+        rounds += 1;
+        return false;
+      }),
+    });
+    expect(await runWaitingRoom(r.deps)).toBe(false);
+    expect(rounds).toBe(WAITING_ROOM_TIMEOUT_MS / 25_000);
+    expect(r.out.join('')).toContain('Not approved within 10 minutes');
+  });
+
+  it('ends at once when the machine has no room left, and falls back to the configured page when the service fails', async () => {
+    const full = room({ openRoom: vi.fn(async () => 'limit' as const) });
+    expect(await runWaitingRoom(full.deps)).toBe(false);
+    expect(full.err.join('')).toMatch(/Too many pending approvals/);
+    expect(full.deps.pending).not.toHaveBeenCalled();
+
+    const c = clock(25_000);
+    const offline = room({
+      now: c.now,
+      pending: vi.fn(async () => Promise.reject(new Error('service down'))),
+      waitForApproval: vi.fn(async () => {
+        c.tick();
+        return true;
+      }),
+    });
+    expect(await runWaitingRoom(offline.deps)).toBe(true);
+    expect(offline.out.join('')).toContain(`Approve it in your browser: ${URL}\n`);
+    expect(offline.out.join('')).not.toContain('code   ');
+  });
+
+  it('stops waiting when the connection is gone', async () => {
+    let closed = false;
+    const r = room({
+      closed: () => closed,
+      waitForApproval: vi.fn(async () => {
+        closed = true;
+        return false;
+      }),
+    });
+    expect(await runWaitingRoom(r.deps)).toBe(false);
+    expect(r.deps.waitForApproval).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/community-portal/door/waiting-room.ts
+++ b/src/modules/community-portal/door/waiting-room.ts
@@ -1,0 +1,109 @@
+/**
+ * The waiting room — what an unknown key sees. Deliberately tiny: it is the
+ * surface strangers reach behind the SSH handshake. Registers the key as
+ * pending (rooms are capped per machine; the account link mints the
+ * approval code), prints the fingerprint, where the connection came from,
+ * the time and the approval page, then waits; approval continues into the
+ * landing in the same session, a timeout ends it.
+ */
+import type { LandingIo } from './landing.js';
+import type { PendingKeyRequest, PendingKeyResult } from './report.js';
+import type { DoorSource } from './target-map.js';
+
+export const WAITING_ROOM_TIMEOUT_MS = 10 * 60_000;
+/** One wait round; the room re-checks the connection between rounds. */
+export const WAITING_ROOM_POLL_MS = 25_000;
+
+export interface WaitingRoomDeps {
+  fingerprint: string;
+  keyType: string;
+  /** `<type> <base64>` */
+  publicKey: string;
+  source?: DoorSource;
+  /** The approval page, when the checkout has one. */
+  approvalUrl?: string;
+  io: LandingIo;
+  closed(): boolean;
+  openRoom(
+    request: { fingerprint: string; keyType: string; publicKey: string },
+    source?: DoorSource,
+  ): Promise<'ok' | 'limit'>;
+  pending(request: PendingKeyRequest): Promise<PendingKeyResult>;
+  /** Resolves true as soon as the key is approved, false after `waitMs`. */
+  waitForApproval(fingerprint: string, waitMs: number): Promise<boolean>;
+  now?: () => Date;
+  timeoutMs?: number;
+  pollMs?: number;
+}
+
+export function waitingRoomBanner(
+  fingerprint: string,
+  source: string,
+  at: Date,
+  approvalUrl?: string,
+  code?: string,
+): string {
+  return [
+    '',
+    'This terminal is not approved for remote access yet.',
+    '',
+    `  key    ${fingerprint}`,
+    `  from   ${source}`,
+    `  at     ${at.toISOString()}`,
+    ...(code ? [`  code   ${code}`] : []),
+    '',
+    ...(approvalUrl
+      ? [
+          `Approve it in your browser: ${approvalUrl}`,
+          `or on the machine:          ncl sandboxes remote keys approve ${fingerprint}`,
+        ]
+      : [`Approve it on the machine: ncl sandboxes remote keys approve ${fingerprint}`]),
+    '',
+    'Waiting for approval (up to 10 minutes)…',
+    '',
+  ].join('\n');
+}
+
+/** Resolves true once the key is approved and the session may continue. */
+export async function runWaitingRoom(deps: WaitingRoomDeps): Promise<boolean> {
+  const now = deps.now ?? (() => new Date());
+  const timeoutMs = deps.timeoutMs ?? WAITING_ROOM_TIMEOUT_MS;
+  const pollMs = deps.pollMs ?? WAITING_ROOM_POLL_MS;
+  const { fingerprint, keyType, publicKey, source, io } = deps;
+  if ((await deps.openRoom({ fingerprint, keyType, publicKey }, source)) === 'limit') {
+    io.fail('Too many pending approvals on this machine; try again in a few minutes.\n');
+    return false;
+  }
+  const started = now();
+  let result: PendingKeyResult;
+  try {
+    result = await deps.pending({
+      fingerprint,
+      keyType,
+      publicKey,
+      ...(source ? { source } : {}),
+      at: started.toISOString(),
+      ...(deps.approvalUrl ? { approvalUrl: deps.approvalUrl } : {}),
+    });
+  } catch (error) {
+    if (!(error instanceof Error)) throw error;
+    // The room still works with an approval from this machine.
+    result = {
+      ...(deps.approvalUrl ? { url: deps.approvalUrl } : {}),
+      expiresAt: new Date(started.getTime() + timeoutMs).toISOString(),
+    };
+  }
+  io.write(waitingRoomBanner(fingerprint, source?.ip ?? 'remote', started, result.url, result.code));
+  for (;;) {
+    if (deps.closed()) return false;
+    if (await deps.waitForApproval(fingerprint, pollMs)) {
+      if (deps.closed()) return false;
+      io.write('Approved. Connecting…\n');
+      return true;
+    }
+    if (now().getTime() - started.getTime() >= timeoutMs) {
+      io.write('Not approved within 10 minutes. Approve the key, then connect again.\n');
+      return false;
+    }
+  }
+}

--- a/src/modules/community-portal/index.ts
+++ b/src/modules/community-portal/index.ts
@@ -5,10 +5,18 @@
  * in at the portal (data/community-portal.json). Registers the runtime with
  * the host lifecycle so perk changes made in the browser reach the running
  * host, and the saved Slack install worker is resumed after a restart.
+ *
+ * The module also carries the remote terminal (door/): an in-process SSH
+ * server on loopback that lands an approved key in a code-mode sandbox,
+ * with its `ncl sandboxes remote …` verbs. It is off until an operator
+ * enables it, and needs no sign-in to work on loopback.
  */
 import { onHostStart, onHostShutdown } from '../../host-lifecycle.js';
 import { log } from '../../log.js';
 import { startPortalRuntime } from './runtime.js';
+// The door registers its host lifecycle; the verbs extend `ncl sandboxes`.
+import './door/index.js';
+import './door/verbs.js';
 
 let runtime: ReturnType<typeof startPortalRuntime> | undefined;
 

--- a/src/modules/community-portal/index.ts
+++ b/src/modules/community-portal/index.ts
@@ -14,9 +14,11 @@
 import { onHostStart, onHostShutdown } from '../../host-lifecycle.js';
 import { log } from '../../log.js';
 import { startPortalRuntime } from './runtime.js';
-// The door registers its host lifecycle; the verbs extend `ncl sandboxes`.
+// The door registers its host lifecycle; the verbs extend `ncl sandboxes`;
+// the address registration listens on the sandbox lifecycle.
 import './door/index.js';
 import './door/verbs.js';
+import './remote/index.js';
 
 let runtime: ReturnType<typeof startPortalRuntime> | undefined;
 

--- a/src/modules/community-portal/index.ts
+++ b/src/modules/community-portal/index.ts
@@ -19,6 +19,9 @@ import { startPortalRuntime } from './runtime.js';
 import './door/index.js';
 import './door/verbs.js';
 import './remote/index.js';
+// A chat surface for each coding session, over the service, for every
+// platform that registered its half.
+import './surface/index.js';
 
 let runtime: ReturnType<typeof startPortalRuntime> | undefined;
 

--- a/src/modules/community-portal/remote/door.test.ts
+++ b/src/modules/community-portal/remote/door.test.ts
@@ -1,0 +1,322 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import type { DoorSummary, MirrorTerminal, TerminalSeam } from '../door/index.js';
+import type { KeyStore } from '../door/keys.js';
+import {
+  DEVICE_PROOF_HEADER,
+  ensureDeviceKey,
+  verifyDeviceProof,
+  writePrivate,
+} from '../../../community-portal/index.js';
+import { MIRROR_SKEW_MS, wireDoor, type DoorModule } from './door.js';
+
+/**
+ * The seam against a stand-in for the door module and a loopback stand-in
+ * for the account service: status mapping, target pass-through, the
+ * staleness guard on snapshots, and the three seam calls with and without
+ * a checkout that is set up with the service.
+ */
+let server: Server;
+let origin: string;
+let root: string;
+let home: string;
+const seen: { method: string; route: string; authorization?: string; proofValid?: boolean; body: unknown }[] = [];
+const answers: Record<string, unknown> = {};
+
+async function serve(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  let text = '';
+  for await (const chunk of req) text += chunk;
+  const route = new URL(req.url ?? '/', origin).pathname;
+  const proof = req.headers[DEVICE_PROOF_HEADER];
+  seen.push({
+    method: req.method ?? '',
+    route,
+    authorization: req.headers.authorization,
+    ...(typeof proof === 'string'
+      ? { proofValid: verifyDeviceProof(proof, ensureDeviceKey({ homeDir: home }).publicKeyJwk).valid }
+      : {}),
+    body: text ? JSON.parse(text) : undefined,
+  });
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(answers[route] ?? { ok: true }));
+}
+
+const journalFile = (): string => path.join(root, 'data/community-portal.json');
+async function signIn(): Promise<void> {
+  await mkdir(path.join(home, '.config/nanoclaw'), { recursive: true, mode: 0o700 });
+  await writeFile(
+    path.join(home, '.config/nanoclaw/account.json'),
+    JSON.stringify({ version: 1, api: 'https://registry.example.test', account_id: 'acct-1', token: 'tok' }),
+    { mode: 0o600 },
+  );
+  await writeFile(path.join(home, '.config/nanoclaw/host-id'), 'install-1\n', { mode: 0o600 });
+}
+async function setUp(): Promise<void> {
+  await signIn();
+  ensureDeviceKey({ homeDir: home });
+  await writePrivate(journalFile(), { origin, deviceId: 'dev_1', credentials: {}, operations: {} });
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), 'nc-door-'));
+  home = await mkdtemp(path.join(os.tmpdir(), 'nc-door-home-'));
+  seen.length = 0;
+  for (const key of Object.keys(answers)) delete answers[key];
+  server = createServer((req, res) => void serve(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no port');
+  origin = `http://127.0.0.1:${address.port}`;
+});
+afterEach(async () => {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await rm(root, { recursive: true, force: true });
+  await rm(home, { recursive: true, force: true });
+});
+
+/** A stand-in for the door module: a summary and key store to answer with, and a record of every call. */
+function fakeModule(summary: Partial<DoorSummary> = {}, store: Partial<KeyStore> = {}) {
+  const calls: string[] = [];
+  const mirrors: (MirrorTerminal | undefined)[] = [];
+  let seam: Partial<TerminalSeam> = {};
+  const module: DoorModule = {
+    doorStatus: async () => ({
+      enabled: false,
+      approvalUrl: 'https://approve.example.test/terminals',
+      terminal: { enabled: false, updatedAt: 'x' },
+      door: { running: false },
+      keys: { approved: 0, browser: 0, pending: 0, rooms: 0 },
+      ...summary,
+    }),
+    listDoorKeys: async () => ({ version: 1, approved: [], pending: [], ...store }),
+    registerTarget: (port, entry) => {
+      calls.push(`register:${port}:${entry.target.account}:${entry.stream ?? '-'}`);
+    },
+    unregisterTarget: (port) => {
+      calls.push(`unregister:${port}`);
+    },
+    lookupTarget: (port) => (port === 40001 ? { target: { account: 'alice' }, openedAt: 'then' } : undefined),
+    applyTerminalMirror: async (terminal) => {
+      mirrors.push(terminal);
+      return { approved: [], revoked: [] };
+    },
+    setTerminalSeam: (partial) => {
+      seam = partial;
+    },
+  };
+  return { module, calls, mirrors, seam: () => seam as TerminalSeam };
+}
+
+it('maps the door summary and key store to the status the link needs, and passes targets through', async () => {
+  const off = fakeModule();
+  expect(await wireDoor({ root, homeDir: home, module: off.module }).status()).toEqual({
+    enabled: false,
+    authorizedFingerprints: [],
+  });
+  const on = fakeModule(
+    { enabled: true, doorPort: 33022, hostKey: 'ssh-ed25519 AAAA' },
+    {
+      approved: [{ fingerprint: 'SHA256:a', publicKey: 'k', label: 'l', approvedAt: 't' }],
+      mirror: { fingerprints: ['SHA256:a', 'SHA256:b'], updatedAt: 't' },
+    },
+  );
+  const door = wireDoor({ root, homeDir: home, module: on.module });
+  expect(await door.status()).toEqual({
+    enabled: true,
+    port: 33022,
+    hostKey: 'ssh-ed25519 AAAA',
+    authorizedFingerprints: ['SHA256:a', 'SHA256:b'],
+  });
+  const stale = fakeModule({ enabled: true, terminal: { enabled: true, updatedAt: 'x' } });
+  expect((await wireDoor({ root, homeDir: home, module: stale.module }).status()).enabled).toBe(false);
+  door.registerTarget(40001, { stream: 's', target: { account: 'alice' }, source: { ip: '::1', port: 1 } });
+  expect(door.lookupTarget(40001)).toEqual({ target: { account: 'alice' }, openedAt: 'then' });
+  expect(door.lookupTarget(40002)).toBeUndefined();
+  door.unregisterTarget(40001);
+  expect(on.calls).toEqual(['register:40001:alice:s', 'unregister:40001']);
+});
+
+it('forwards the snapshot terminal section to the door, skipping mirrors older than its own enable call', async () => {
+  await setUp();
+  answers['/api/v1/terminal/enable'] = { name: 'alice', address: '2001:db8::1', host: 'alice.example.test' };
+  const fake = fakeModule();
+  const log = vi.fn();
+  const clock = 1_000_000;
+  const door = wireDoor({ root, homeDir: home, log, module: fake.module, now: () => clock });
+  const snapshot = (updatedAt: string | undefined, extra: Record<string, unknown> = {}) => ({
+    enabled: true,
+    name: 'alice',
+    keys: [{ fingerprint: 'SHA256:a', keyType: 'ssh-ed25519' }],
+    pending: [],
+    sandboxes: [],
+    ...(updatedAt ? { updatedAt } : {}),
+    ...extra,
+  });
+  // Before any enable every snapshot is applied, as the mirror's shape.
+  await door.applyTerminalSnapshot(snapshot(undefined, { previousName: 'old' }));
+  await door.applyTerminalSnapshot(undefined);
+  expect(fake.mirrors).toEqual([
+    { enabled: true, name: 'alice', previousName: 'old', keys: [{ fingerprint: 'SHA256:a' }] },
+    undefined,
+  ]);
+  await fake.seam().enable({ name: 'alice', hostKey: 'ssh-ed25519 AAAA', hostKeyFingerprint: 'SHA256:h' });
+  const enabledAt = clock;
+  await door.applyTerminalSnapshot(snapshot(new Date(enabledAt - MIRROR_SKEW_MS - 1).toISOString()));
+  await door.applyTerminalSnapshot(snapshot(undefined));
+  await door.applyTerminalSnapshot(undefined);
+  expect(fake.mirrors).toHaveLength(2);
+  expect(log).toHaveBeenCalledTimes(3);
+  expect(log).toHaveBeenLastCalledWith({ event: 'terminal_snapshot_stale' });
+  await door.applyTerminalSnapshot(snapshot(new Date(enabledAt - MIRROR_SKEW_MS).toISOString()));
+  await door.applyTerminalSnapshot(snapshot(new Date(enabledAt + 5_000).toISOString(), { enabled: false }));
+  expect(fake.mirrors.slice(2)).toEqual([
+    { enabled: true, name: 'alice', keys: [{ fingerprint: 'SHA256:a' }] },
+    { enabled: false, name: 'alice', keys: [{ fingerprint: 'SHA256:a' }] },
+  ]);
+});
+
+it('answers the door standalone while the checkout is not set up with the account service', async () => {
+  const fake = fakeModule();
+  const onReported = vi.fn();
+  wireDoor({ root, homeDir: home, module: fake.module, onReported });
+  const seam = fake.seam();
+  await expect(seam.enable({ hostKey: 'k', hostKeyFingerprint: 'f' })).rejects.toThrow(/--name/);
+  expect(await seam.enable({ name: 'mine', hostKey: 'k', hostKeyFingerprint: 'f' })).toEqual({ name: 'mine' });
+  expect(
+    await seam.pending({
+      fingerprint: 'SHA256:p',
+      keyType: 'ssh-ed25519',
+      publicKey: 'ssh-ed25519 AAAA',
+      at: '2026-09-11T10:00:00.000Z',
+      approvalUrl: 'https://approve.example.test/terminals',
+    }),
+  ).toEqual({ url: 'https://approve.example.test/terminals', expiresAt: '2026-09-11T10:10:00.000Z' });
+  await seam.report({ enabled: true, name: 'mine', doorPort: 33022, authorizedFingerprints: [] });
+  expect(onReported).toHaveBeenCalledOnce();
+  expect(seen).toEqual([]);
+  // Signed in but without a device key: enable still needs a name, but the state and pending keys are reported.
+  await signIn();
+  await writePrivate(journalFile(), { origin, deviceId: 'dev_1', credentials: {}, operations: {} });
+  expect(await seam.enable({ name: 'mine', hostKey: 'k', hostKeyFingerprint: 'f' })).toEqual({ name: 'mine' });
+  await seam.report({ enabled: true, name: 'mine', doorPort: 33022, authorizedFingerprints: ['SHA256:a'] });
+  expect(seen.map((r) => [r.method, r.route])).toEqual([['PUT', '/api/v1/terminal/host']]);
+  expect(seen[0].body).toEqual({ enabled: true, doorPort: 33022, authorizedFingerprints: ['SHA256:a'] });
+  expect(onReported).toHaveBeenCalledTimes(2);
+});
+
+it('carries enable, report and pending keys to the account service once the checkout is set up', async () => {
+  await setUp();
+  answers['/api/v1/terminal/enable'] = {
+    name: 'alice',
+    address: '2001:db8::5:0:0:1',
+    hostKeyFingerprint: 'SHA256:h',
+  };
+  answers['/api/v1/terminal/keys/pending'] = {
+    code: 'ABCD-EFGH',
+    url: 'https://approve.example.test/?approve=ABCDEFGH',
+    expiresAt: '2026-09-11T10:10:00.000Z',
+  };
+  const fake = fakeModule();
+  const onReported = vi.fn();
+  wireDoor({ root, homeDir: home, module: fake.module, onReported, now: () => 0 });
+  const seam = fake.seam();
+  expect(await seam.enable({ hostKey: 'ssh-ed25519 AAAA', hostKeyFingerprint: 'SHA256:h' })).toEqual({
+    name: 'alice',
+    address: '2001:db8::5:0:0:1',
+  });
+  expect(seen[0]).toEqual({
+    method: 'POST',
+    route: '/api/v1/terminal/enable',
+    authorization: 'Bearer tok',
+    proofValid: true,
+    body: { hostKey: 'ssh-ed25519 AAAA' },
+  });
+  // A host name is passed on when the service composes one; a rename never comes this way.
+  answers['/api/v1/terminal/enable'] = { name: 'alice', address: '2001:db8::5:0:0:1', host: 'alice.example.test' };
+  expect(await seam.enable({ name: 'alice', hostKey: 'ssh-ed25519 AAAA', hostKeyFingerprint: 'SHA256:h' })).toEqual({
+    name: 'alice',
+    address: '2001:db8::5:0:0:1',
+    host: 'alice.example.test',
+  });
+  expect(seen[1].body).toEqual({ name: 'alice', hostKey: 'ssh-ed25519 AAAA' });
+  await seam.report({
+    enabled: true,
+    name: 'alice',
+    hostKeyFingerprint: 'SHA256:h',
+    doorPort: 33022,
+    authorizedFingerprints: ['SHA256:a'],
+  });
+  expect(seen[2]).toEqual({
+    method: 'PUT',
+    route: '/api/v1/terminal/host',
+    authorization: 'Bearer tok',
+    body: { enabled: true, doorPort: 33022, authorizedFingerprints: ['SHA256:a'] },
+  });
+  expect(onReported).toHaveBeenCalledOnce();
+  const journal = JSON.parse(await readFile(journalFile(), 'utf8')) as { terminal: unknown };
+  expect(journal.terminal).toEqual({
+    enabled: true,
+    name: 'alice',
+    hostKeyFingerprint: 'SHA256:h',
+    doorPort: 33022,
+    updatedAt: '1970-01-01T00:00:00.000Z',
+  });
+  expect(
+    await seam.pending({
+      fingerprint: 'SHA256:p',
+      keyType: 'ssh-ed25519',
+      publicKey: 'ssh-ed25519 BBBB',
+      source: { ip: '2001:db8::9', port: 4242 },
+      at: '2026-09-11T10:00:00.000Z',
+      approvalUrl: 'https://approve.example.test/terminals',
+    }),
+  ).toEqual({
+    code: 'ABCD-EFGH',
+    url: 'https://approve.example.test/?approve=ABCDEFGH',
+    expiresAt: '2026-09-11T10:10:00.000Z',
+  });
+  expect(seen[3]).toEqual({
+    method: 'POST',
+    route: '/api/v1/terminal/keys/pending',
+    authorization: 'Bearer tok',
+    body: {
+      fingerprint: 'SHA256:p',
+      keyType: 'ssh-ed25519',
+      publicKey: 'ssh-ed25519 BBBB',
+      source: { ip: '2001:db8::9', port: 4242 },
+      at: '2026-09-11T10:00:00.000Z',
+    },
+  });
+  // A service answer without a page or expiry falls back to the door's own.
+  answers['/api/v1/terminal/keys/pending'] = { code: 'ZZZZ-2222' };
+  expect(
+    await seam.pending({
+      fingerprint: 'SHA256:p',
+      keyType: 'ssh-ed25519',
+      publicKey: 'ssh-ed25519 BBBB',
+      source: { ip: '2001:db8::9', port: 4243 },
+      at: '2026-09-11T10:00:00.000Z',
+      approvalUrl: 'https://approve.example.test/terminals',
+    }),
+  ).toEqual({
+    code: 'ZZZZ-2222',
+    url: 'https://approve.example.test/terminals',
+    expiresAt: '2026-09-11T10:10:00.000Z',
+  });
+  // A key without a source (a connection the host did not relay) is not reported at all.
+  expect(seen).toHaveLength(5);
+  expect(
+    await seam.pending({
+      fingerprint: 'SHA256:p',
+      keyType: 'ssh-ed25519',
+      publicKey: 'ssh-ed25519 BBBB',
+      at: '2026-09-11T10:00:00.000Z',
+      approvalUrl: 'https://approve.example.test/terminals',
+    }),
+  ).toEqual({ url: 'https://approve.example.test/terminals', expiresAt: '2026-09-11T10:10:00.000Z' });
+  expect(seen).toHaveLength(5);
+});

--- a/src/modules/community-portal/remote/door.ts
+++ b/src/modules/community-portal/remote/door.ts
@@ -1,0 +1,172 @@
+/**
+ * The seam between the account link and the loopback door.
+ *
+ * The running host needs four things from the door: whether it is enabled
+ * and on which loopback port; a place to register what each relayed stream
+ * is for, keyed by the loopback source port the pipe connects from (the
+ * program a connection lands in reads that port from `SSH_CONNECTION` and
+ * asks the door); the reverse of that when the stream ends; and a sink for
+ * the `terminal` section of every perks snapshot, which carries the keys the
+ * account owner approved or revoked in the browser. The door needs three
+ * things from the link, which it calls through its terminal seam: the
+ * account service's answer at enable (the name it confirms or assigns and
+ * the address), the state report on every start and disable, and the
+ * approval code for a key waiting in the waiting room. `wireDoor` connects
+ * both directions. The seam's requests read the checkout's identity from
+ * disk on every call, so they work whether or not the link is up, and fall
+ * back to the door's standalone behaviour on a checkout that is not set up
+ * with the account service.
+ */
+import * as doorModule from '../door/index.js';
+import type { DoorStream } from '../door/index.js';
+import {
+  checkoutClient,
+  reportTerminalState,
+  type LinkLog,
+  type TerminalSnapshot,
+} from '../../../community-portal/index.js';
+
+export interface DoorStatus {
+  enabled: boolean;
+  /** The loopback port the door accepts on, while enabled. */
+  port?: number;
+  hostKey?: string;
+  /** The fingerprints the door currently honours. */
+  authorizedFingerprints: string[];
+}
+
+/** What the link registers per loopback source port while a stream is open. */
+export type StreamEntry = Omit<DoorStream, 'openedAt'> & { openedAt?: string };
+
+export interface Door {
+  status(): Promise<DoorStatus>;
+  registerTarget(port: number, entry: StreamEntry): void;
+  unregisterTarget(port: number): void;
+  lookupTarget(port: number): DoorStream | undefined;
+  /** The mirror's `terminal` section on every perks snapshot (undefined when the mirror carries none). */
+  applyTerminalSnapshot(terminal: TerminalSnapshot | undefined): Promise<void>;
+}
+
+/** The door module's surface the seam builds on; injectable for tests. */
+export type DoorModule = Pick<
+  typeof doorModule,
+  | 'doorStatus'
+  | 'listDoorKeys'
+  | 'registerTarget'
+  | 'unregisterTarget'
+  | 'lookupTarget'
+  | 'applyTerminalMirror'
+  | 'setTerminalSeam'
+>;
+
+export interface WireDoorOptions {
+  root?: string;
+  homeDir?: string;
+  log?: LinkLog;
+  /** Runs after every state report, so the link can re-announce its caps without waiting for a poll. */
+  onReported?: () => void;
+  module?: DoorModule;
+  now?: () => number;
+}
+
+/** A snapshot stamped this much before the host's own enable call may still be the service's answer to it. */
+export const MIRROR_SKEW_MS = 30_000;
+/** How long a waiting room may wait for an approval when the service minted no code. */
+export const PENDING_APPROVAL_TTL_MS = 10 * 60_000;
+
+/**
+ * Wire the door to the account link: install the seam and return the door
+ * as the link sees it. Nothing is written until a seam call happens.
+ */
+export function wireDoor({
+  root = process.cwd(),
+  homeDir,
+  log = () => {},
+  onReported = () => {},
+  module = doorModule,
+  now = Date.now,
+}: WireDoorOptions = {}): Door {
+  let lastEnableAt: number | undefined;
+  /** A bearer client for the checkout, or undefined while it is not set up with the account service. */
+  const client = () => checkoutClient({ root, homeDir, log });
+
+  module.setTerminalSeam({
+    async enable(request) {
+      const portal = await client();
+      if (!portal?.deviceKey) {
+        if (!request.name) {
+          throw new Error(
+            'this checkout is not set up with the account service; pass --name <account-name> to ncl sandboxes remote enable',
+          );
+        }
+        return { name: request.name };
+      }
+      lastEnableAt = now();
+      const result = await portal.terminalEnable({
+        ...(request.name ? { name: request.name } : {}),
+        hostKey: request.hostKey,
+      });
+      // A rename reaches the door through the mirror (`previousName`), not through this answer.
+      return {
+        name: result.name,
+        ...(result.address ? { address: result.address } : {}),
+        ...(result.host ? { host: result.host } : {}),
+      };
+    },
+    async report(state) {
+      await reportTerminalState(state, { root, homeDir, log, now });
+      onReported();
+    },
+    async pending(request) {
+      const fallback = {
+        url: request.approvalUrl,
+        expiresAt: new Date(Date.parse(request.at) + PENDING_APPROVAL_TTL_MS).toISOString(),
+      };
+      const portal = await client();
+      // The service records where the key came from; a connection the host did not relay has no source.
+      if (!portal || !request.source) return fallback;
+      const { fingerprint, keyType, publicKey, source, at } = request;
+      const result = await portal.terminalPending({ fingerprint, keyType, publicKey, source, at });
+      return {
+        ...(result.code ? { code: result.code } : {}),
+        url: result.url || fallback.url,
+        expiresAt: result.expiresAt || fallback.expiresAt,
+      };
+    },
+  });
+
+  return {
+    async status() {
+      const summary = await module.doorStatus();
+      const store = await module.listDoorKeys();
+      const port = summary.enabled && summary.doorPort ? summary.doorPort : undefined;
+      return {
+        enabled: port !== undefined,
+        ...(port === undefined ? {} : { port }),
+        ...(summary.hostKey ? { hostKey: summary.hostKey } : {}),
+        authorizedFingerprints: [
+          ...new Set([...store.approved.map((key) => key.fingerprint), ...(store.mirror?.fingerprints ?? [])]),
+        ],
+      };
+    },
+    registerTarget: (port, entry) => module.registerTarget(port, entry),
+    unregisterTarget: (port) => module.unregisterTarget(port),
+    lookupTarget: (port) => module.lookupTarget(port),
+    async applyTerminalSnapshot(terminal) {
+      // A mirror older than this host's own enable call would report the door disabled.
+      const stampedAt = terminal?.updatedAt ? Date.parse(terminal.updatedAt) : NaN;
+      if (lastEnableAt !== undefined && !(stampedAt >= lastEnableAt - MIRROR_SKEW_MS)) {
+        log({ event: 'terminal_snapshot_stale', ...(terminal?.updatedAt ? { updatedAt: terminal.updatedAt } : {}) });
+        return;
+      }
+      await module.applyTerminalMirror(
+        terminal && {
+          enabled: terminal.enabled,
+          ...(terminal.name ? { name: terminal.name } : {}),
+          ...(terminal.previousName ? { previousName: terminal.previousName } : {}),
+          keys: terminal.keys.map((key) => ({ fingerprint: key.fingerprint })),
+        },
+      );
+    },
+  };
+}

--- a/src/modules/community-portal/remote/index.test.ts
+++ b/src/modules/community-portal/remote/index.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The address hooks: a created sandbox is registered and a refused name is
+ * an operator-visible error (at once, or late when the account is slow); a
+ * service that does not answer is asked again every minute until it does,
+ * for a release too; neither ever fails the verb.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+vi.mock('./sandboxes.js', () => ({
+  registerSandbox: vi.fn(),
+  unregisterSandbox: vi.fn(),
+}));
+
+import { fireSandboxCreated, fireSandboxRemoved } from '../../../code-mode/hooks.js';
+import { log } from '../../../log.js';
+import { registerSandbox, unregisterSandbox } from './sandboxes.js';
+import { getHostShutdownCallbacks } from '../../../host-lifecycle.js';
+import { ADDRESS_RETRY_MS, setAddressRetryTimersForTesting, untilAnswered } from './index.js';
+
+const group = { id: 'ag-1', name: 'api', folder: 'api' };
+
+/** A fake clock for the retry loop: every sleep is recorded and released by hand. */
+function clock() {
+  const sleeps: { ms: number; release: () => void }[] = [];
+  setAddressRetryTimersForTesting({
+    sleep: (ms) => new Promise<void>((resolve) => sleeps.push({ ms, release: resolve })),
+  });
+  return { sleeps, tick: () => sleeps.shift()?.release() };
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => setAddressRetryTimersForTesting(null));
+
+describe('the created hook', () => {
+  it('registers the sandbox name and stays quiet when the account accepts or cannot be asked', async () => {
+    vi.mocked(registerSandbox).mockResolvedValueOnce({ done: true, address: '2001:db8::2' });
+    await fireSandboxCreated(group);
+    expect(registerSandbox).toHaveBeenCalledWith('api');
+    vi.mocked(registerSandbox).mockResolvedValueOnce({ done: false, code: 'not_enabled' });
+    await fireSandboxCreated(group);
+    expect(log.error).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('reports a refused name as an error, even when the answer comes late', async () => {
+    for (const code of ['invalid_name', 'name_reserved', 'name_taken']) {
+      vi.mocked(registerSandbox).mockResolvedValueOnce({ done: false, code });
+      await fireSandboxCreated(group);
+      expect(log.error).toHaveBeenLastCalledWith(
+        expect.stringContaining('refused'),
+        expect.objectContaining({ sandbox: 'api', code }),
+      );
+    }
+
+    vi.useFakeTimers();
+    let late!: (outcome: { done: boolean; code?: string }) => void;
+    vi.mocked(registerSandbox).mockReturnValueOnce(new Promise((resolve) => (late = resolve)));
+    const fired = fireSandboxCreated(group);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await fired; // the verb moved on without the answer
+    vi.mocked(log.error).mockClear();
+    late({ done: false, code: 'name_taken' });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining('refused'),
+      expect.objectContaining({ code: 'name_taken' }),
+    );
+    vi.useRealTimers();
+  });
+});
+
+describe('the retry loop', () => {
+  it('asks again every minute while the service does not answer, then stops at the first final outcome', async () => {
+    const c = clock();
+    const attempt = vi
+      .fn<() => Promise<{ done: boolean; code?: string; retryable?: boolean }>>()
+      .mockResolvedValueOnce({ done: false, code: 'ECONNREFUSED', retryable: true })
+      .mockResolvedValueOnce({ done: false, code: 'unavailable', retryable: true })
+      .mockResolvedValueOnce({ done: true, address: '2001:db8::2' } as never);
+    const outcome = untilAnswered('registration', 'api', attempt);
+    await vi.waitFor(() => expect(c.sleeps).toHaveLength(1));
+    expect(c.sleeps[0].ms).toBe(ADDRESS_RETRY_MS);
+    expect(log.warn).toHaveBeenCalledExactlyOnceWith(expect.stringContaining('retrying every minute'), {
+      sandbox: 'api',
+    });
+    c.tick();
+    await vi.waitFor(() => expect(c.sleeps).toHaveLength(1)); // the second wait
+    c.tick();
+    expect(await outcome).toEqual({ done: true, address: '2001:db8::2' });
+    expect(attempt).toHaveBeenCalledTimes(3);
+
+    // A refusal is final: no retry.
+    const refused = vi.fn(async () => ({ done: false, code: 'name_taken' }));
+    expect(await untilAnswered('registration', 'api', refused)).toEqual({ done: false, code: 'name_taken' });
+    expect(refused).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends with the host: shutdown aborts a pending retry instead of holding the process', async () => {
+    setAddressRetryTimersForTesting({
+      sleep: (_ms, signal) =>
+        new Promise<void>((_resolve, reject) => signal?.addEventListener('abort', () => reject(new Error('aborted')))),
+    });
+    const attempt = vi.fn(async () => ({ done: false, code: 'unreachable', retryable: true }));
+    const outcome = untilAnswered('registration', 'api', attempt);
+    await vi.waitFor(() => expect(attempt).toHaveBeenCalledTimes(1));
+    for (const cb of getHostShutdownCallbacks()) await cb();
+    expect(await outcome).toEqual({ done: false, code: 'unreachable', retryable: true });
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('is the created hook’s patience too, without holding the verb', async () => {
+    const c = clock();
+    vi.mocked(registerSandbox)
+      .mockResolvedValueOnce({ done: false, code: 'unreachable', retryable: true })
+      .mockResolvedValueOnce({ done: true });
+    vi.useFakeTimers();
+    const fired = fireSandboxCreated(group);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await fired;
+    vi.useRealTimers();
+    expect(registerSandbox).toHaveBeenCalledTimes(1);
+    c.tick();
+    await vi.waitFor(() => expect(registerSandbox).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe('the removed hook', () => {
+  it('frees the address without holding the verb, and keeps trying while the service does not answer', async () => {
+    const c = clock();
+    vi.mocked(unregisterSandbox)
+      .mockResolvedValueOnce({ done: false, code: 'unreachable', retryable: true })
+      .mockResolvedValueOnce({ done: true });
+    await fireSandboxRemoved(group);
+    expect(unregisterSandbox).toHaveBeenCalledWith('api');
+    await vi.waitFor(() => expect(c.sleeps).toHaveLength(1));
+    c.tick();
+    await vi.waitFor(() => expect(unregisterSandbox).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/modules/community-portal/remote/index.ts
+++ b/src/modules/community-portal/remote/index.ts
@@ -1,0 +1,120 @@
+/**
+ * Sandbox addresses follow the sandbox lifecycle.
+ *
+ * On a host with remote access enabled every named sandbox gets an address
+ * of its own from the account (`<sandbox>.<name>.<zone>`), so a terminal
+ * can land in it directly. The registration rides code mode's lifecycle
+ * hooks: `onSandboxCreated` registers the name, `onSandboxRemoved` frees
+ * it. Both are best effort by contract — a checkout that is not set up
+ * with the account or the default sandbox (which is the account's own
+ * address) leave a plain sandbox and never fail the verb. A service that
+ * does not answer is tried again every minute until it does; a refusal is
+ * final and, when it is the name (taken, reserved, invalid), loud: the
+ * operator must hear it, since the sandbox exists without an address.
+ */
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { onSandboxCreated, onSandboxRemoved, SANDBOX_HOOKS_SEAM } from '../../../code-mode/hooks.js';
+import { onHostShutdown } from '../../../host-lifecycle.js';
+import { log } from '../../../log.js';
+import { registerSandbox, unregisterSandbox, type SandboxAddressOutcome } from './sandboxes.js';
+
+export const REMOTE_ADDRESS_HOOK = 'remote-address';
+
+/**
+ * How long the created hook waits for the account's answer before the
+ * sandbox verb moves on. A refused name is worth a line at once; a slow
+ * service is not worth holding the terminal for.
+ */
+export const ADDRESS_ANSWER_WAIT_MS = 4_000;
+
+/** How long to wait before asking a service that did not answer again. */
+export const ADDRESS_RETRY_MS = 60_000;
+
+/** Names the account will not give an address: final, and the operator's to hear. */
+const NAME_REFUSALS = new Set(['invalid_name', 'name_reserved', 'name_taken']);
+
+/** Test seam: the timers the retry loop uses. */
+export interface RetryTimers {
+  sleep(ms: number, signal?: AbortSignal): Promise<void>;
+}
+let timers: RetryTimers = { sleep: (ms, signal) => sleep(ms, undefined, signal ? { signal } : undefined) };
+const inFlight = new Set<AbortController>();
+
+/** End every pending retry: a waiting registration must not hold the process past shutdown. */
+export function abortAddressRetries(): void {
+  for (const controller of inFlight) controller.abort();
+  inFlight.clear();
+}
+
+export function setAddressRetryTimersForTesting(next: RetryTimers | null): void {
+  timers = next ?? { sleep: (ms, signal) => sleep(ms, undefined, signal ? { signal } : undefined) };
+  abortAddressRetries();
+}
+
+function refusedName(sandbox: string, outcome: SandboxAddressOutcome): boolean {
+  if (!outcome.code || !NAME_REFUSALS.has(outcome.code)) return false;
+  log.error('Sandbox name refused for an address — the sandbox exists without an address of its own', {
+    sandbox,
+    code: outcome.code,
+    hint: 'pick another name (ncl sandboxes new --name <name>) to reach it by address',
+  });
+  return true;
+}
+
+/**
+ * Run `attempt` until it is done or refused; a service that did not answer
+ * is asked again every ADDRESS_RETRY_MS. Resolves with the first final
+ * outcome. The loop stops with the process (host shutdown aborts it).
+ */
+export async function untilAnswered(
+  what: string,
+  sandbox: string,
+  attempt: () => Promise<SandboxAddressOutcome>,
+): Promise<SandboxAddressOutcome> {
+  const controller = new AbortController();
+  inFlight.add(controller);
+  try {
+    for (let tries = 1; ; tries++) {
+      const outcome = await attempt();
+      if (outcome.done || !outcome.retryable) return outcome;
+      if (tries === 1)
+        log.warn(`Sandbox address ${what}: the account did not answer — retrying every minute`, { sandbox });
+      try {
+        await timers.sleep(ADDRESS_RETRY_MS, controller.signal);
+      } catch (error) {
+        if (!controller.signal.aborted) throw error;
+        return outcome; // aborted: the host is going down
+      }
+      if (controller.signal.aborted) return outcome;
+    }
+  } finally {
+    inFlight.delete(controller);
+  }
+}
+
+onSandboxCreated(
+  REMOTE_ADDRESS_HOOK,
+  async (group) => {
+    const registration = untilAnswered('registration', group.folder, () => registerSandbox(group.folder));
+    const answer = await Promise.race([registration, sleep(ADDRESS_ANSWER_WAIT_MS, null)]);
+    if (answer) {
+      refusedName(group.folder, answer);
+      return;
+    }
+    // The answer comes after the verb moved on: still loud, just late.
+    registration.then((outcome) => refusedName(group.folder, outcome)).catch(() => {});
+  },
+  { seam: SANDBOX_HOOKS_SEAM },
+);
+
+onHostShutdown(() => abortAddressRetries());
+
+onSandboxRemoved(
+  REMOTE_ADDRESS_HOOK,
+  async (group) => {
+    // The rows are gone; the address is freed in the background, with the same patience.
+    void untilAnswered('release', group.folder, () => unregisterSandbox(group.folder));
+  },
+  { seam: SANDBOX_HOOKS_SEAM },
+);

--- a/src/modules/community-portal/remote/registration.test.ts
+++ b/src/modules/community-portal/remote/registration.test.ts
@@ -1,0 +1,23 @@
+/**
+ * The module's registrations against the real composed tree: the sandbox
+ * lifecycle hooks the address registration listens on, and the remote
+ * verbs on `ncl sandboxes`.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { assertSandboxHook, assertSandboxVerb } from '../../../code-mode/contract.js';
+import '../../../cli/resources/sandboxes.js';
+import '../index.js';
+import { REMOTE_ADDRESS_HOOK } from './index.js';
+
+describe('community-portal registrations on code mode', () => {
+  it('listens on sandbox creation and removal for the address', () => {
+    expect(() => assertSandboxHook('created', REMOTE_ADDRESS_HOOK)).not.toThrow();
+    expect(() => assertSandboxHook('removed', REMOTE_ADDRESS_HOOK)).not.toThrow();
+  });
+
+  it('extends ncl sandboxes with the remote verbs', () => {
+    for (const verb of ['remote enable', 'remote disable', 'remote status', 'remote keys list'])
+      expect(() => assertSandboxVerb(verb)).not.toThrow();
+  });
+});

--- a/src/modules/community-portal/remote/sandboxes.test.ts
+++ b/src/modules/community-portal/remote/sandboxes.test.ts
@@ -1,0 +1,176 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import type { DoorSummary } from '../door/index.js';
+import { writePrivate } from '../../../community-portal/index.js';
+import { registerSandbox, sandboxTerminalAddress, unregisterSandbox } from './sandboxes.js';
+
+/**
+ * Sandbox registration against a loopback stand-in for the account service:
+ * gated on the door, never throwing, one request per verb.
+ */
+let server: Server;
+let origin: string;
+let root: string;
+let home: string;
+const seen: { method: string; route: string; body: unknown }[] = [];
+let answer: { status: number; body: unknown } = { status: 200, body: { ok: true } };
+
+async function serve(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  let text = '';
+  for await (const chunk of req) text += chunk;
+  seen.push({
+    method: req.method ?? '',
+    route: new URL(req.url ?? '/', origin).pathname,
+    body: text ? JSON.parse(text) : undefined,
+  });
+  res.setHeader('content-type', 'application/json');
+  res.writeHead(answer.status);
+  res.end(JSON.stringify(answer.body));
+}
+
+const summary =
+  (partial: Partial<DoorSummary>): (() => Promise<DoorSummary>) =>
+  async () => ({
+    enabled: false,
+    approvalUrl: 'https://approve.example.test/terminals',
+    terminal: { enabled: false, updatedAt: 'x' },
+    door: { running: false },
+    keys: { approved: 0, browser: 0, pending: 0, rooms: 0 },
+    ...partial,
+  });
+const enabled = summary({ enabled: true, name: 'alice', doorPort: 33022 });
+
+async function setUp(): Promise<void> {
+  await mkdir(path.join(home, '.config/nanoclaw'), { recursive: true, mode: 0o700 });
+  await writeFile(
+    path.join(home, '.config/nanoclaw/account.json'),
+    JSON.stringify({ version: 1, api: 'https://registry.example.test', account_id: 'acct-1', token: 'tok' }),
+    { mode: 0o600 },
+  );
+  await writeFile(path.join(home, '.config/nanoclaw/host-id'), 'install-1\n', { mode: 0o600 });
+  await writePrivate(path.join(root, 'data/community-portal.json'), {
+    origin,
+    deviceId: 'dev_1',
+    credentials: {},
+    operations: {},
+  });
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), 'nc-sandboxes-'));
+  home = await mkdtemp(path.join(os.tmpdir(), 'nc-sandboxes-home-'));
+  seen.length = 0;
+  answer = { status: 200, body: { ok: true } };
+  server = createServer((req, res) => void serve(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no port');
+  origin = `http://127.0.0.1:${address.port}`;
+});
+afterEach(async () => {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await rm(root, { recursive: true, force: true });
+  await rm(home, { recursive: true, force: true });
+});
+
+it('registers a named sandbox with the account while remote access is enabled, and never the default one', async () => {
+  const log = vi.fn();
+  answer = { status: 200, body: { name: 'api', address: '2001:db8::5:0:0:2', host: 'api.alice.example.test' } };
+  expect(await registerSandbox('api', { root, homeDir: home, log, doorStatus: summary({}) })).toEqual({
+    done: false,
+    code: 'not_enabled',
+  });
+  expect(await registerSandbox('api', { root, homeDir: home, log, doorStatus: enabled })).toEqual({
+    done: false,
+    code: 'installation_required',
+  });
+  expect(seen).toEqual([]);
+  await setUp();
+  expect(await registerSandbox('alice', { root, homeDir: home, log, doorStatus: enabled })).toEqual({
+    done: false,
+    code: 'default_sandbox',
+  });
+  expect(await registerSandbox('api', { root, homeDir: home, log, doorStatus: enabled })).toEqual({
+    done: true,
+    address: '2001:db8::5:0:0:2',
+    host: 'api.alice.example.test',
+  });
+  expect(seen).toEqual([{ method: 'POST', route: '/api/v1/terminal/sandboxes', body: { name: 'api' } }]);
+  expect(log).toHaveBeenCalledExactlyOnceWith({
+    event: 'sandbox_registered',
+    sandbox: 'api',
+    host: 'api.alice.example.test',
+  });
+});
+
+it('never throws: a refusal or an unreachable service comes back as a code and a log line', async () => {
+  const log = vi.fn();
+  await setUp();
+  answer = { status: 409, body: { error: 'name_taken' } };
+  expect(await registerSandbox('api', { root, homeDir: home, log, doorStatus: enabled })).toEqual({
+    done: false,
+    code: 'name_taken',
+    retryable: false,
+  });
+  expect(log).toHaveBeenLastCalledWith({ event: 'sandbox_register_failed', sandbox: 'api', code: 'name_taken' });
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  const outcome = await registerSandbox('api', { root, homeDir: home, log, doorStatus: enabled });
+  expect(outcome.done).toBe(false);
+  expect(outcome.code).toBeTruthy();
+  // No answer at all is worth another try; a refusal (above) is not.
+  expect(outcome.retryable).toBe(true);
+  server = createServer((req, res) => void serve(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+});
+
+it('frees the address of a deleted sandbox whenever the account ever named this machine', async () => {
+  const log = vi.fn();
+  await setUp();
+  expect(await unregisterSandbox('api', { root, homeDir: home, log, doorStatus: summary({}) })).toEqual({
+    done: false,
+    code: 'not_enabled',
+  });
+  expect(await unregisterSandbox('alice', { root, homeDir: home, log, doorStatus: enabled })).toEqual({
+    done: false,
+    code: 'default_sandbox',
+  });
+  expect(seen).toEqual([]);
+  // Disabled for now, but named: the sandbox is gone, so its address goes too.
+  const disabled = summary({ enabled: false, name: 'alice', doorPort: 33022 });
+  expect(await unregisterSandbox('api', { root, homeDir: home, log, doorStatus: disabled })).toEqual({ done: true });
+  expect(seen).toEqual([{ method: 'DELETE', route: '/api/v1/terminal/sandboxes/api', body: undefined }]);
+  expect(log).toHaveBeenCalledWith({ event: 'sandbox_unregistered', sandbox: 'api' });
+  answer = { status: 404, body: { error: 'not_found' } };
+  expect(await unregisterSandbox('gone', { root, homeDir: home, log, doorStatus: enabled })).toEqual({
+    done: false,
+    code: 'not_found',
+    retryable: false,
+  });
+});
+
+it("composes a sandbox's terminal address from the door's name and host name, and nothing without them", () => {
+  const door = { enabled: true, name: 'alice', host: 'alice.example.test' };
+  expect(sandboxTerminalAddress('api', door)).toEqual({ sandbox: 'api', address: 'api.alice.example.test' });
+  // The default sandbox is the account's own address.
+  expect(sandboxTerminalAddress('alice', door)).toEqual({ sandbox: 'alice', address: 'alice.example.test' });
+  // Lower-cased, as the address space is.
+  expect(sandboxTerminalAddress('Api', door)).toEqual({ sandbox: 'api', address: 'api.alice.example.test' });
+  // A host name recorded before a rename still yields the current name's address.
+  expect(sandboxTerminalAddress('api', { ...door, name: 'bob' })).toEqual({
+    sandbox: 'api',
+    address: 'api.bob.example.test',
+  });
+  // Not a DNS label: such a sandbox never got an address.
+  expect(sandboxTerminalAddress('my_box', door)).toBeUndefined();
+  expect(sandboxTerminalAddress('-api', door)).toBeUndefined();
+  // Off, unnamed, or no host name yet (the account has not answered): nothing to report.
+  expect(sandboxTerminalAddress('api', { ...door, enabled: false })).toBeUndefined();
+  expect(sandboxTerminalAddress('api', { enabled: true, name: 'alice' })).toBeUndefined();
+  expect(sandboxTerminalAddress('api', { enabled: true, host: 'alice.example.test' })).toBeUndefined();
+  expect(sandboxTerminalAddress('api', { enabled: true, name: 'alice', host: 'alice' })).toBeUndefined();
+});

--- a/src/modules/community-portal/remote/sandboxes.ts
+++ b/src/modules/community-portal/remote/sandboxes.ts
@@ -1,0 +1,108 @@
+/**
+ * Sandbox addresses. On a host with remote access enabled every named
+ * sandbox gets an address of its own from the account service, so a
+ * terminal can land in it directly instead of through the account's default
+ * sandbox. Registration is best effort by contract: it never fails or delays
+ * the sandbox verb; a checkout that is not set up with the service, or a
+ * service that is down, leaves a plain sandbox; and the default sandbox
+ * named after the account is never registered. Deleting a sandbox frees its
+ * address the same way.
+ */
+import * as doorModule from '../door/index.js';
+import { checkoutClient, errorCode, errorStatus, type LinkLog } from '../../../community-portal/index.js';
+import { log as hostLogger } from '../../../log.js';
+
+const hostLog: LinkLog = (event) => hostLogger.info('Remote terminal', event);
+
+export interface SandboxAddressOptions {
+  root?: string;
+  homeDir?: string;
+  log?: LinkLog;
+  /** Test seam: the door's status. */
+  doorStatus?: typeof doorModule.doorStatus;
+}
+
+export interface SandboxAddressOutcome {
+  /** The service recorded the change. */
+  done: boolean;
+  address?: string;
+  host?: string;
+  /** Why not: `not_enabled`, `default_sandbox`, `installation_required`, or the code the service or network gave. */
+  code?: string;
+  /** The service did not answer (network, timeout): worth another try later. A refusal never is. */
+  retryable?: boolean;
+}
+
+/** One DNS label: what a sandbox name must be to take part in an address. */
+const DNS_LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export interface SandboxTerminalAddress {
+  /** The sandbox's label in the address (its name, lower-cased). */
+  sandbox: string;
+  /** `<sandbox>.<account-name>.<zone>` — or the account's own address for the default sandbox. */
+  address: string;
+}
+
+/**
+ * The address a terminal connects to for a sandbox on this host, composed
+ * from what `remote enable` journaled: the account name and the machine's
+ * host name (`<account-name>.<zone>`). The zone is what follows the host
+ * name's first label, so a name renamed since the host name was recorded
+ * still yields the current address. Undefined while remote access is off,
+ * before the account has answered with a host name, or for a sandbox whose
+ * name is not a DNS label (such a sandbox never got an address).
+ */
+export function sandboxTerminalAddress(
+  name: string,
+  door: Pick<doorModule.DoorSummary, 'enabled' | 'name' | 'host'>,
+): SandboxTerminalAddress | undefined {
+  if (!door.enabled || !door.name || !door.host) return undefined;
+  const zone = door.host.split('.').slice(1).join('.');
+  if (!zone) return undefined;
+  const sandbox = name.toLowerCase();
+  if (!DNS_LABEL.test(sandbox)) return undefined;
+  const account = `${door.name}.${zone}`;
+  return { sandbox, address: sandbox === door.name ? account : `${sandbox}.${account}` };
+}
+
+/** Register a sandbox's name with the account; it gets an address of its own. */
+export async function registerSandbox(
+  name: string,
+  { root = process.cwd(), homeDir, log = hostLog, doorStatus = doorModule.doorStatus }: SandboxAddressOptions = {},
+): Promise<SandboxAddressOutcome> {
+  try {
+    const status = await doorStatus();
+    if (!status.enabled) return { done: false, code: 'not_enabled' };
+    if (status.name === name) return { done: false, code: 'default_sandbox' };
+    const client = await checkoutClient({ root, homeDir, log });
+    if (!client) return { done: false, code: 'installation_required' };
+    const result = await client.terminalSandboxAdd(name);
+    log({ event: 'sandbox_registered', sandbox: name, ...(result.host ? { host: result.host } : {}) });
+    return { done: true, address: result.address, ...(result.host ? { host: result.host } : {}) };
+  } catch (error) {
+    const code = errorCode(error);
+    log({ event: 'sandbox_register_failed', sandbox: name, code });
+    return { done: false, code, retryable: errorStatus(error) === undefined };
+  }
+}
+
+/** Free a sandbox's address once the sandbox is gone; attempted whenever the account ever named this machine. */
+export async function unregisterSandbox(
+  name: string,
+  { root = process.cwd(), homeDir, log = hostLog, doorStatus = doorModule.doorStatus }: SandboxAddressOptions = {},
+): Promise<SandboxAddressOutcome> {
+  try {
+    const status = await doorStatus();
+    if (!status.name) return { done: false, code: 'not_enabled' };
+    if (status.name === name) return { done: false, code: 'default_sandbox' };
+    const client = await checkoutClient({ root, homeDir, log });
+    if (!client) return { done: false, code: 'installation_required' };
+    await client.terminalSandboxRemove(name);
+    log({ event: 'sandbox_unregistered', sandbox: name });
+    return { done: true };
+  } catch (error) {
+    const code = errorCode(error);
+    log({ event: 'sandbox_unregister_failed', sandbox: name, code });
+    return { done: false, code, retryable: errorStatus(error) === undefined };
+  }
+}

--- a/src/modules/community-portal/remote/stream.test.ts
+++ b/src/modules/community-portal/remote/stream.test.ts
@@ -1,0 +1,393 @@
+import net from 'node:net';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SshChannel, SshOpen } from '../../../community-portal/link.js';
+import type { ChannelHandler, Frame } from '../../../community-portal/mux.js';
+import type { DoorStream } from '../door/index.js';
+import type { Door } from './door.js';
+import { CHUNK_BYTES, WINDOW_BYTES, decodeChunk, openStream } from './stream.js';
+
+/**
+ * The pipe against a loopback TCP server standing in for the door and a
+ * hand-driven channel standing in for the link. Nothing here leaves the
+ * machine; the servers listen on 127.0.0.1:0.
+ */
+type Sent = { t: string } & Record<string, unknown>;
+
+class FakeChannel implements SshChannel {
+  readonly ch = 2;
+  sent: Sent[] = [];
+  released = 0;
+  allowance = 24_000;
+  private seq = 0;
+  send(t: 'data' | 'credit' | 'end' | 'close', fields: Record<string, unknown> = {}): boolean {
+    const raw = JSON.stringify({ ...fields, v: 1, ch: this.ch, seq: ++this.seq, t });
+    if (raw.length > this.allowance) return false;
+    this.sent.push({ t, ...fields });
+    return true;
+  }
+  release(): void {
+    this.released++;
+  }
+  types(): string[] {
+    return this.sent.map((f) => f.t);
+  }
+  bytesOut(): number {
+    return this.sent
+      .filter((f) => f.t === 'data')
+      .reduce((n, f) => n + Buffer.from(f.b64 as string, 'base64').length, 0);
+  }
+  /** The door's output as sent so far, in frame order. */
+  echoed(): Buffer {
+    return Buffer.concat(this.sent.filter((f) => f.t === 'data').map((f) => Buffer.from(f.b64 as string, 'base64')));
+  }
+  /** Every data frame's offset is the running total of the frames before it. */
+  contiguous(): boolean {
+    let expected = 0;
+    for (const f of this.sent.filter((f) => f.t === 'data')) {
+      if (f.off !== expected) return false;
+      expected += Buffer.from(f.b64 as string, 'base64').length;
+    }
+    return true;
+  }
+}
+
+const OPEN: SshOpen = {
+  stream: 'q7Xk1m2n3o4p5r6s7t8u9v',
+  target: { account: 'alice' },
+  source: { ip: '2001:db8::1', port: 4242 },
+};
+const frame = (t: string, fields: Record<string, unknown> = {}): Frame => ({ v: 1, ch: 2, seq: 1, t, ...fields });
+const data = (off: number, bytes: Buffer): Frame => frame('data', { off, b64: bytes.toString('base64') });
+async function until(check: () => boolean, timeout = 5_000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (!check()) {
+    if (Date.now() > deadline) throw new Error('timed out');
+    await sleep(5);
+  }
+}
+
+const servers: net.Server[] = [];
+const sockets: net.Socket[] = [];
+const handlers: ChannelHandler[] = [];
+let door: Door;
+let registrations: string[];
+
+function listen(onConnection: (socket: net.Socket) => void): Promise<number> {
+  const server = net.createServer({ allowHalfOpen: true }, (socket) => {
+    sockets.push(socket);
+    socket.on('error', () => {});
+    onConnection(socket);
+  });
+  servers.push(server);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve(typeof address === 'object' && address ? address.port : 0);
+    });
+  });
+}
+
+function start(doorPort: number, options: Partial<Parameters<typeof openStream>[0]> = {}) {
+  const channel = new FakeChannel();
+  const log = vi.fn();
+  const handler = openStream({ open: OPEN, channel, doorPort, door, log, ...options });
+  handlers.push(handler);
+  return { channel, handler, log };
+}
+
+beforeEach(() => {
+  // A door as the link sees it, with its targets in memory and every registration recorded in order.
+  const targets = new Map<number, DoorStream>();
+  registrations = [];
+  door = {
+    status: async () => ({ enabled: true, authorizedFingerprints: [] }),
+    registerTarget: (port, entry) => {
+      registrations.push(`register:${port}`);
+      targets.set(port, { ...entry, openedAt: entry.openedAt ?? 'now' });
+    },
+    unregisterTarget: (port) => {
+      registrations.push(`unregister:${port}`);
+      targets.delete(port);
+    },
+    lookupTarget: (port) => targets.get(port),
+    applyTerminalSnapshot: async () => {},
+  };
+});
+
+afterEach(async () => {
+  for (const handler of handlers.splice(0)) handler.onTeardown();
+  for (const socket of sockets.splice(0)) socket.destroy();
+  for (const server of servers.splice(0)) await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('openStream', () => {
+  it('registers the target before the first byte reaches the door, then echoes both ways with credit', async () => {
+    let lookupAtFirstByte: DoorStream | undefined;
+    let doorSaw = Buffer.alloc(0);
+    const port = await listen((socket) => {
+      const from = socket.remotePort ?? -1;
+      socket.once('data', () => {
+        // The door's first byte goes into the same sequence log as the registrations:
+        // their order, not timing, is what the test asserts.
+        registrations.push(`first-byte:${from}`);
+        lookupAtFirstByte = door.lookupTarget(from);
+      });
+      socket.on('data', (chunk: Buffer) => {
+        doorSaw = Buffer.concat([doorSaw, chunk]);
+      });
+      socket.pipe(socket);
+    });
+    const { channel, handler, log } = start(port);
+    // Bytes that arrive before the connection is up wait for it.
+    handler.onFrame(data(0, Buffer.from('SSH-2.0-terminal\r\n')));
+    await until(() => registrations.some((entry) => entry.startsWith('first-byte:')));
+    const sourcePort = Number(registrations[0].split(':')[1]);
+    expect(registrations).toEqual([`register:${sourcePort}`, `first-byte:${sourcePort}`]);
+    const record = {
+      stream: OPEN.stream,
+      target: { account: 'alice' },
+      source: { ip: '2001:db8::1', port: 4242 },
+      openedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+    };
+    expect(lookupAtFirstByte).toEqual(record);
+    expect(door.lookupTarget(sourcePort)).toEqual(record);
+    expect(log).toHaveBeenCalledWith({ event: 'stream_open', stream: OPEN.stream, account: 'alice', sourcePort });
+    // Credit follows once the door took the bytes; the echo comes back with contiguous offsets.
+    await until(() => channel.sent.some((f) => f.t === 'credit' && f.ack === 18));
+    await until(() => channel.bytesOut() === 18);
+    expect(channel.echoed().toString()).toBe('SSH-2.0-terminal\r\n');
+    expect(channel.contiguous()).toBe(true);
+    expect(doorSaw.toString()).toBe('SSH-2.0-terminal\r\n');
+    // More bytes after the connection: contiguous offsets, credit per delivered chunk.
+    handler.onFrame(data(18, Buffer.from('more')));
+    await until(() => channel.sent.some((f) => f.t === 'credit' && f.ack === 22));
+    await until(() => channel.bytesOut() === 22);
+    expect(channel.echoed().toString()).toBe('SSH-2.0-terminal\r\nmore');
+    expect(channel.contiguous()).toBe(true);
+    handler.onFrame(frame('credit', { ack: 22 }));
+    // The far end finishes: our half-close reaches the door, whose echo ends, and close follows once acknowledged.
+    handler.onFrame(frame('end'));
+    await until(() => channel.types().includes('close'));
+    expect(channel.types().slice(-2)).toEqual(['end', 'close']);
+    expect(channel.sent.at(-1)).toEqual({ t: 'close' });
+    expect(channel.released).toBe(1);
+    expect(registrations).toEqual([`register:${sourcePort}`, `first-byte:${sourcePort}`, `unregister:${sourcePort}`]);
+    expect(door.lookupTarget(sourcePort)).toBeUndefined();
+    expect(log).toHaveBeenCalledWith({
+      event: 'stream_closed',
+      stream: OPEN.stream,
+      by: 'host',
+      bytesIn: 22,
+      bytesOut: 22,
+    });
+    expect(JSON.stringify(log.mock.calls)).not.toContain('terminal');
+  });
+
+  it('drains the final bytes: end goes out with the data, close waits for the far end and the credit', async () => {
+    const goodbye = Buffer.alloc(100, 7);
+    let doorClosed = false;
+    const port = await listen((socket) => {
+      socket.on('close', () => {
+        doorClosed = true;
+      });
+      socket.end(goodbye);
+    });
+    const { channel, handler } = start(port);
+    await until(() => channel.types().includes('end'));
+    expect(channel.types()).toEqual(['data', 'end']);
+    expect(channel.sent[0]).toMatchObject({ off: 0, b64: goodbye.toString('base64') });
+    // The door only half-closed: the stream still carries the far end's bytes to it.
+    await sleep(50);
+    expect(channel.types()).toEqual(['data', 'end']);
+    expect(doorClosed).toBe(false);
+    // The far end ends too; the socket closes, but close waits for the credit on the goodbye.
+    handler.onFrame(frame('end'));
+    await until(() => doorClosed);
+    await sleep(50);
+    expect(channel.types()).toEqual(['data', 'end']);
+    expect(channel.released).toBe(0);
+    handler.onFrame(frame('credit', { ack: 100 }));
+    await until(() => channel.types().includes('close'));
+    expect(channel.sent.at(-1)).toEqual({ t: 'close' });
+    expect(channel.released).toBe(1);
+  });
+
+  it('gives up the drain after the timeout with close timeout', async () => {
+    const port = await listen((socket) => socket.end(Buffer.alloc(10, 1)));
+    const { channel, handler } = start(port, { drainTimeoutMs: 50 });
+    await until(() => channel.types().includes('end'));
+    handler.onFrame(frame('end'));
+    await until(() => channel.types().includes('close'));
+    expect(channel.sent.at(-1)).toEqual({ t: 'close', reason: 'timeout' });
+  });
+
+  it('holds door output to 16 KiB chunks and 64 KiB in flight until credit arrives', async () => {
+    const total = 200_000;
+    const port = await listen((socket) => {
+      socket.write(Buffer.alloc(total, 3));
+    });
+    const { channel, handler } = start(port);
+    await until(() => channel.bytesOut() === WINDOW_BYTES);
+    await sleep(50);
+    expect(channel.bytesOut()).toBe(WINDOW_BYTES);
+    const sizes = () =>
+      channel.sent.filter((f) => f.t === 'data').map((f) => Buffer.from(f.b64 as string, 'base64').length);
+    // Whatever has arrived goes out at once, in chunks of at most 16 KiB, until exactly the window is in flight.
+    expect(sizes().every((size) => size >= 1 && size <= CHUNK_BYTES)).toBe(true);
+    expect(sizes().length).toBeGreaterThanOrEqual(WINDOW_BYTES / CHUNK_BYTES);
+    expect(sizes().reduce((n, s) => n + s, 0)).toBe(WINDOW_BYTES);
+    expect(channel.contiguous()).toBe(true);
+    handler.onFrame(frame('credit', { ack: CHUNK_BYTES }));
+    await until(() => channel.bytesOut() === WINDOW_BYTES + CHUNK_BYTES);
+    await sleep(20);
+    expect(channel.bytesOut()).toBe(WINDOW_BYTES + CHUNK_BYTES);
+    handler.onFrame(frame('credit', { ack: WINDOW_BYTES + CHUNK_BYTES }));
+    await until(() => channel.bytesOut() === 2 * WINDOW_BYTES + CHUNK_BYTES);
+    let acked = 2 * WINDOW_BYTES + CHUNK_BYTES;
+    while (channel.bytesOut() < total) {
+      handler.onFrame(frame('credit', { ack: acked }));
+      await until(() => channel.bytesOut() > acked || channel.bytesOut() === total);
+      acked = channel.bytesOut();
+    }
+    const offs = channel.sent.filter((f) => f.t === 'data').map((f) => f.off as number);
+    for (const [i, size] of sizes().entries()) {
+      expect(size).toBeLessThanOrEqual(CHUNK_BYTES);
+      expect(offs[i]).toBe(
+        sizes()
+          .slice(0, i)
+          .reduce((n, s) => n + s, 0),
+      );
+    }
+    expect(channel.bytesOut()).toBe(total);
+  });
+
+  it('closes with protocol on a window overrun, a wrong offset, a bad chunk, a bad credit or data after end', async () => {
+    const port = await listen((socket) => socket.pipe(socket));
+    {
+      const { channel, handler } = start(port);
+      const chunk = Buffer.alloc(CHUNK_BYTES, 1);
+      for (let i = 0; i < 4; i++) handler.onFrame(data(i * CHUNK_BYTES, chunk));
+      expect(channel.types()).toEqual([]);
+      handler.onFrame(data(4 * CHUNK_BYTES, chunk));
+      expect(channel.sent.at(-1)).toEqual({ t: 'close', reason: 'protocol' });
+      expect(channel.released).toBe(1);
+    }
+    const cases: [string, Frame][] = [
+      ['offset', data(1, Buffer.from('x'))],
+      ['not base64', frame('data', { off: 0, b64: '!!!!' })],
+      ['empty', frame('data', { off: 0, b64: '' })],
+      ['oversize', data(0, Buffer.alloc(CHUNK_BYTES + 1, 1))],
+      ['credit beyond sent', frame('credit', { ack: 1 })],
+      ['credit not an integer', frame('credit', { ack: 0.5 })],
+      ['unknown type', frame('open', { kind: 'ssh' })],
+    ];
+    for (const [, bad] of cases) {
+      const { channel, handler } = start(port);
+      await until(() => registrations.length > 0);
+      handler.onFrame(bad);
+      expect(channel.sent.at(-1)).toEqual({ t: 'close', reason: 'protocol' });
+      expect(channel.released).toBe(1);
+      registrations.length = 0;
+    }
+    {
+      const { channel, handler } = start(port);
+      await until(() => registrations.length > 0);
+      handler.onFrame(frame('end'));
+      handler.onFrame(data(0, Buffer.from('late')));
+      expect(channel.sent.at(-1)).toEqual({ t: 'close', reason: 'protocol' });
+    }
+  });
+
+  it('answers a door that does not accept with close unavailable and registers nothing', async () => {
+    const port = await listen(() => {});
+    await new Promise<void>((resolve) => servers.pop()?.close(() => resolve()));
+    const { channel, handler, log } = start(port);
+    handler.onFrame(data(0, Buffer.from('hello')));
+    await until(() => channel.types().includes('close'));
+    expect(channel.sent).toEqual([{ t: 'close', reason: 'unavailable' }]);
+    expect(channel.released).toBe(1);
+    expect(registrations).toEqual([]);
+    expect(log).toHaveBeenCalledWith({
+      event: 'stream_closed',
+      stream: OPEN.stream,
+      by: 'host',
+      reason: 'unavailable',
+      bytesIn: 5,
+      bytesOut: 0,
+    });
+  });
+
+  it('answers a door that resets an established connection with close peer', async () => {
+    // The reset follows the first byte, so it cannot race the connection itself (that would be unavailable).
+    const port = await listen((socket) => socket.once('data', () => socket.resetAndDestroy()));
+    const { channel, handler } = start(port);
+    await until(() => registrations.length === 1);
+    handler.onFrame(data(0, Buffer.from('x')));
+    await until(() => channel.types().includes('close'));
+    expect(channel.sent.at(-1)).toEqual({ t: 'close', reason: 'peer' });
+  });
+
+  it('destroys the door socket on a close from the far end and on a link teardown, sending nothing more', async () => {
+    const closed: number[] = [];
+    const port = await listen((socket) => {
+      const from = socket.remotePort ?? -1;
+      socket.on('close', () => closed.push(from));
+      socket.pipe(socket);
+    });
+    const a = start(port);
+    const b = start(port);
+    await until(() => registrations.length === 2);
+    const ports = registrations.map((r) => Number(r.split(':')[1]));
+    expect(new Set(ports).size).toBe(2);
+    a.handler.onFrame(frame('close', { reason: 'peer' }));
+    await until(() => closed.includes(ports[0]));
+    expect(a.channel.sent).toEqual([]);
+    expect(a.channel.released).toBe(1);
+    expect(door.lookupTarget(ports[0])).toBeUndefined();
+    expect(door.lookupTarget(ports[1])).toBeDefined();
+    b.handler.onTeardown();
+    await until(() => closed.includes(ports[1]));
+    expect(b.channel.sent).toEqual([]);
+    expect(b.channel.released).toBe(1);
+    expect(door.lookupTarget(ports[1])).toBeUndefined();
+    expect(b.log).toHaveBeenCalledWith({
+      event: 'stream_closed',
+      stream: OPEN.stream,
+      by: 'link',
+      bytesIn: 0,
+      bytesOut: 0,
+    });
+    // Idempotent: a late close from the socket or the link changes nothing.
+    b.handler.onTeardown();
+    b.handler.onFrame(frame('close'));
+    expect(b.channel.released).toBe(1);
+  });
+
+  it('half-closes the door on end while still relaying its output', async () => {
+    const port = await listen((socket) => {
+      socket.on('end', () => {
+        socket.write('bye');
+        socket.end();
+      });
+    });
+    const { channel, handler } = start(port);
+    await until(() => registrations.length === 1);
+    handler.onFrame(frame('end'));
+    await until(() => channel.types().includes('end'));
+    expect(channel.sent[0]).toEqual({ t: 'data', off: 0, b64: Buffer.from('bye').toString('base64') });
+    handler.onFrame(frame('credit', { ack: 3 }));
+    await until(() => channel.types().includes('close'));
+    expect(channel.sent.at(-1)).toEqual({ t: 'close' });
+  });
+
+  it('decodes only canonical base64 of 1..16 384 bytes', () => {
+    expect(decodeChunk('AAECAw==')).toEqual(Buffer.from([0, 1, 2, 3]));
+    expect(decodeChunk(Buffer.alloc(CHUNK_BYTES, 9).toString('base64'))?.length).toBe(CHUNK_BYTES);
+    expect(decodeChunk(Buffer.alloc(CHUNK_BYTES + 1, 9).toString('base64'))).toBeNull();
+    expect(decodeChunk('')).toBeNull();
+    expect(decodeChunk('AAECAw')).toBeNull();
+    expect(decodeChunk('AAEC_w==')).toBeNull();
+    expect(decodeChunk(42)).toBeNull();
+  });
+});

--- a/src/modules/community-portal/remote/stream.ts
+++ b/src/modules/community-portal/remote/stream.ts
@@ -1,0 +1,277 @@
+import net from 'node:net';
+import type { LinkLog, SshChannel, SshOpen } from '../../../community-portal/link.js';
+import type { ChannelHandler, Frame } from '../../../community-portal/mux.js';
+import type { Door } from './door.js';
+
+/**
+ * One relayed terminal stream: the pipe between an `ssh` channel on the
+ * host's link and a loopback TCP connection to the door.
+ *
+ * The host never listens on the network. A stream arrives as `open` on the
+ * outbound link; the pipe connects to the door on 127.0.0.1 from a fresh
+ * ephemeral source port, registers what that port is for before the first
+ * byte flows (the program the connection lands in looks the port up through
+ * the door), then pumps both ways. Flow control is per direction: chunks of
+ * at most 16 KiB carrying a running byte offset, a 64 KiB window of
+ * unacknowledged bytes, and a `credit` for every chunk delivered to the local
+ * socket (its write callback fired), so neither a slow terminal nor a slow
+ * door can grow an unbounded queue anywhere. `end` half-closes after the
+ * queued bytes; the last bytes of a stream (an exit status, a goodbye) are
+ * acknowledged before `close` goes out; a `close` from the far end destroys
+ * the socket. A link drop tears the channel down, which destroys the socket
+ * and forgets the registration too.
+ *
+ * Payload bytes are never logged; envelope metadata only.
+ */
+export const CHUNK_BYTES = 16_384;
+export const WINDOW_BYTES = 65_536;
+export const CONNECT_TIMEOUT_MS = 5_000;
+/** After the door socket closed, how long to wait for the far end to acknowledge the last bytes. */
+export const DRAIN_TIMEOUT_MS = 10_000;
+const BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const MAX_B64_CHARS = 4 * Math.ceil(CHUNK_BYTES / 3);
+
+export type StreamCloseReason =
+  | 'offline'
+  | 'peer'
+  | 'unavailable'
+  | 'revoked'
+  | 'unsupported'
+  | 'busy'
+  | 'timeout'
+  | 'protocol';
+
+/** Decode one `data.b64` field; null unless it is canonical base64 of 1..16 384 bytes. */
+export function decodeChunk(value: unknown): Buffer | null {
+  if (typeof value !== 'string' || value.length === 0 || value.length > MAX_B64_CHARS || !BASE64.test(value))
+    return null;
+  const bytes = Buffer.from(value, 'base64');
+  return bytes.length >= 1 && bytes.length <= CHUNK_BYTES ? bytes : null;
+}
+
+export interface StreamOptions {
+  open: SshOpen;
+  channel: SshChannel;
+  doorPort: number;
+  door: Pick<Door, 'registerTarget' | 'unregisterTarget'>;
+  log?: LinkLog;
+  /** Test seam: how the loopback connection is made. */
+  connect?: (options: net.TcpNetConnectOpts) => net.Socket;
+  connectTimeoutMs?: number;
+  drainTimeoutMs?: number;
+  now?: () => number;
+}
+
+/** Start piping one stream; the handler receives the channel's frames and its teardown. */
+export function openStream(options: StreamOptions): ChannelHandler {
+  const stream = new DoorStream(options);
+  return { onFrame: (frame) => stream.onFrame(frame), onTeardown: () => stream.teardown() };
+}
+
+class DoorStream {
+  private readonly open: SshOpen;
+  private readonly channel: SshChannel;
+  private readonly door: Pick<Door, 'registerTarget' | 'unregisterTarget'>;
+  private readonly log: LinkLog;
+  private readonly drainTimeoutMs: number;
+  private readonly now: () => number;
+  private readonly socket: net.Socket;
+  private sourcePort?: number;
+  private connected = false;
+  private finished = false;
+  /** Inbound chunks that arrived before the connection: the target is registered before the first byte. */
+  private readonly queue: { bytes: Buffer; ack: number }[] = [];
+  private queuedEnd = false;
+  // Door → link.
+  private sent = 0;
+  private acked = 0;
+  private doorEnded = false;
+  // Link → door.
+  private received = 0;
+  private delivered = 0;
+  private farEnded = false;
+  private socketClosed = false;
+  private socketError = false;
+  private drain?: NodeJS.Timeout;
+
+  constructor({
+    open,
+    channel,
+    doorPort,
+    door,
+    log = () => {},
+    connect = net.connect,
+    connectTimeoutMs = CONNECT_TIMEOUT_MS,
+    drainTimeoutMs = DRAIN_TIMEOUT_MS,
+    now = Date.now,
+  }: StreamOptions) {
+    this.open = open;
+    this.channel = channel;
+    this.door = door;
+    this.log = log;
+    this.drainTimeoutMs = drainTimeoutMs;
+    this.now = now;
+    // A fresh ephemeral source port per stream: it is what the door's program
+    // sees as the client port and looks the target up by.
+    this.socket = connect({
+      host: '127.0.0.1',
+      port: doorPort,
+      localAddress: '127.0.0.1',
+      localPort: 0,
+      allowHalfOpen: true,
+    });
+    this.socket.setNoDelay(true);
+    this.socket.setTimeout(connectTimeoutMs, () => {
+      if (!this.connected) this.socket.destroy();
+    });
+    this.socket.on('connect', () => this.onConnect());
+    this.socket.on('readable', this.pump);
+    this.socket.on('end', () => this.onDoorEnd());
+    this.socket.on('error', () => {
+      this.socketError = true;
+    });
+    this.socket.on('close', () => this.onSocketClose());
+  }
+
+  onFrame(frame: Frame): void {
+    if (this.finished) return;
+    if (frame.t === 'data') this.onData(frame);
+    else if (frame.t === 'credit') this.onCredit(frame);
+    else if (frame.t === 'end') this.onFarEnd();
+    else if (frame.t === 'close' || frame.t === 'error')
+      this.finish({ by: 'far', ...(typeof frame.reason === 'string' ? { reason: frame.reason } : {}) });
+    else this.fail('protocol');
+  }
+
+  /** The link dropped or the channel was closed under us: no frames can go out any more. */
+  teardown(): void {
+    this.finish({ by: 'link' });
+  }
+
+  private onConnect(): void {
+    if (this.finished) return;
+    this.socket.setTimeout(0);
+    const port = this.socket.localPort;
+    if (typeof port !== 'number') return this.fail('unavailable');
+    try {
+      this.door.registerTarget(port, {
+        stream: this.open.stream,
+        target: { ...this.open.target },
+        source: { ...this.open.source },
+        openedAt: new Date(this.now()).toISOString(),
+      });
+    } catch (error) {
+      this.log({ event: 'stream_refused', reason: 'unavailable', stream: this.open.stream, code: String(error) });
+      return this.fail('unavailable');
+    }
+    this.sourcePort = port;
+    this.connected = true;
+    this.log({
+      event: 'stream_open',
+      stream: this.open.stream,
+      account: this.open.target.account,
+      ...(this.open.target.sandbox ? { sandbox: this.open.target.sandbox } : {}),
+      sourcePort: port,
+      ...(this.open.ticket ? { ticket: this.open.ticket } : {}),
+    });
+    for (const { bytes, ack } of this.queue.splice(0)) this.deliver(bytes, ack);
+    if (this.queuedEnd) this.socket.end();
+    this.pump();
+  }
+
+  /** Door → link: read what the window allows, at most a chunk at a time. */
+  private readonly pump = (): void => {
+    if (this.finished || !this.connected) return;
+    while (this.socket.readableLength > 0 && this.sent - this.acked < WINDOW_BYTES) {
+      const size = Math.min(this.socket.readableLength, CHUNK_BYTES, WINDOW_BYTES - (this.sent - this.acked));
+      const bytes = this.socket.read(size) as Buffer | null;
+      if (!bytes) break;
+      if (!this.channel.send('data', { off: this.sent, b64: bytes.toString('base64') })) return this.fail('protocol');
+      this.sent += bytes.length;
+    }
+    // Reading the last buffered chunk does not itself emit 'end' in paused mode; ask for it.
+    if (this.socket.readableLength === 0) this.socket.read(0);
+  };
+
+  private onDoorEnd(): void {
+    this.doorEnded = true;
+    if (!this.finished) this.channel.send('end');
+  }
+
+  private onData(frame: Frame): void {
+    if (this.socketClosed) return;
+    if (this.farEnded) return this.fail('protocol');
+    const bytes = decodeChunk(frame.b64);
+    if (!bytes || frame.off !== this.received) return this.fail('protocol');
+    if (this.received + bytes.length - this.delivered > WINDOW_BYTES) return this.fail('protocol');
+    this.received += bytes.length;
+    const ack = this.received;
+    if (this.connected) this.deliver(bytes, ack);
+    else this.queue.push({ bytes, ack });
+  }
+
+  /** Credit is returned only once the door has taken the bytes. */
+  private deliver(bytes: Buffer, ack: number): void {
+    this.socket.write(bytes, (error) => {
+      if (error || this.finished) return;
+      this.delivered = ack;
+      this.channel.send('credit', { ack });
+    });
+  }
+
+  private onCredit(frame: Frame): void {
+    const ack = frame.ack;
+    if (typeof ack !== 'number' || !Number.isSafeInteger(ack) || ack < this.acked || ack > this.sent)
+      return this.fail('protocol');
+    this.acked = ack;
+    this.pump();
+    this.maybeClose();
+  }
+
+  private onFarEnd(): void {
+    if (this.farEnded) return;
+    this.farEnded = true;
+    if (this.connected) this.socket.end();
+    else this.queuedEnd = true;
+  }
+
+  private onSocketClose(): void {
+    this.socketClosed = true;
+    if (this.finished) return;
+    if (!this.connected) return this.fail('unavailable');
+    this.maybeClose();
+    if (!this.finished) this.drain = setTimeout(() => this.fail('timeout'), this.drainTimeoutMs);
+  }
+
+  /** The door socket is gone: `close` once the far end has acknowledged every byte sent. */
+  private maybeClose(): void {
+    if (this.finished || !this.socketClosed || this.acked < this.sent) return;
+    const reason: StreamCloseReason | undefined = this.socketError && !this.doorEnded ? 'peer' : undefined;
+    this.channel.send('close', reason ? { reason } : {});
+    this.finish({ by: 'host', ...(reason ? { reason } : {}) });
+  }
+
+  private fail(reason: StreamCloseReason): void {
+    if (this.finished) return;
+    this.channel.send('close', { reason });
+    this.finish({ by: 'host', reason });
+  }
+
+  private finish({ by, reason }: { by: 'host' | 'far' | 'link'; reason?: string }): void {
+    if (this.finished) return;
+    this.finished = true;
+    clearTimeout(this.drain);
+    this.socket.off('readable', this.pump);
+    this.socket.destroy();
+    if (this.sourcePort !== undefined) this.door.unregisterTarget(this.sourcePort);
+    this.log({
+      event: 'stream_closed',
+      stream: this.open.stream,
+      by,
+      ...(reason ? { reason } : {}),
+      bytesIn: this.received,
+      bytesOut: this.sent,
+    });
+    this.channel.release();
+  }
+}

--- a/src/modules/community-portal/runtime.test.ts
+++ b/src/modules/community-portal/runtime.test.ts
@@ -1,15 +1,22 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import type { DoorStream } from './door/index.js';
+import type { Door } from './remote/door.js';
 import {
   DEVICE_PROOF_HEADER,
   ensureDeviceKey,
+  readJson,
+  reportTerminalState,
   verifyDeviceProof,
   writePrivate,
+  type Journal,
   type LinkSocket,
+  type TerminalSnapshot,
 } from '../../community-portal/index.js';
 import { startPortalRuntime } from './runtime.js';
 
@@ -59,6 +66,7 @@ interface Seen {
   route: string;
   authorization?: string;
   proofValid?: boolean;
+  body?: unknown;
 }
 let server: Server;
 let origin: string;
@@ -70,11 +78,11 @@ const DEVICE_ID = 'dev_0123456789abcdef01234567';
 const state = { grants: [] as unknown[] };
 
 async function serve(req: IncomingMessage, res: ServerResponse): Promise<void> {
-  for await (const _chunk of req) {
-    /* drain */
-  }
+  let text = '';
+  for await (const chunk of req) text += chunk;
   const route = new URL(req.url ?? '/', origin).pathname;
   const record: Seen = { method: req.method ?? '', route, authorization: req.headers.authorization };
+  if (text) record.body = JSON.parse(text);
   const proof = req.headers[DEVICE_PROOF_HEADER];
   if (typeof proof === 'string') {
     const key = ensureDeviceKey({ homeDir: home });
@@ -98,6 +106,10 @@ async function serve(req: IncomingMessage, res: ServerResponse): Promise<void> {
   }
   if (route === '/api/v1/device/state') {
     res.end(JSON.stringify(state));
+    return;
+  }
+  if (route === '/api/v1/terminal/host') {
+    res.end(JSON.stringify({ ok: true }));
     return;
   }
   res.writeHead(404);
@@ -161,6 +173,7 @@ it('stays idle without a registered device, then dials with a proofed ticket and
     route: '/api/v1/cell-ticket',
     authorization: 'Bearer tok',
     proofValid: true,
+    body: {},
   });
   await until(() => seen.some((r) => r.route === '/api/v1/device/state'));
   expect(seen.find((r) => r.route === '/api/v1/device/state')).toEqual({
@@ -185,6 +198,125 @@ it('stays idle without a registered device, then dials with a proofed ticket and
   expect(seen.filter((r) => r.route === '/api/v1/cell-ticket')).toHaveLength(1);
   await runtime.stop();
   expect(socket.readyState).toBe(3);
+});
+
+it('announces ssh while the door is enabled, pipes streams into it, forwards the terminal snapshot and reports the door', async () => {
+  const log = vi.fn();
+  await signIn();
+  ensureDeviceKey({ homeDir: home });
+  // A loopback echo server stands in for the door.
+  const echo = net.createServer({ allowHalfOpen: true }, (socket) => socket.pipe(socket));
+  await new Promise<void>((resolve) => echo.listen(0, '127.0.0.1', resolve));
+  const doorPort = (echo.address() as net.AddressInfo).port;
+  await writePrivate(journalFile(), {
+    origin,
+    deviceId: DEVICE_ID,
+    credentials: {},
+    operations: {},
+    terminal: { enabled: true, name: 'alice', doorPort, updatedAt: 'x' },
+  });
+  // A door as the link sees it: enabled and the port from the journal, targets in memory, the last snapshot kept.
+  const applied: (TerminalSnapshot | undefined)[] = [];
+  const targets = new Map<number, DoorStream>();
+  const door: Door = {
+    status: async () => {
+      const saved = (await readJson<Partial<Journal>>(journalFile()))?.terminal;
+      const port = saved?.enabled && saved.doorPort ? saved.doorPort : undefined;
+      return {
+        enabled: port !== undefined,
+        ...(port === undefined ? {} : { port }),
+        authorizedFingerprints: applied.at(-1)?.keys.map((key) => key.fingerprint) ?? [],
+      };
+    },
+    registerTarget: (port, entry) => {
+      targets.set(port, { ...entry, openedAt: entry.openedAt ?? 'now' });
+    },
+    unregisterTarget: (port) => {
+      targets.delete(port);
+    },
+    lookupTarget: (port) => targets.get(port),
+    applyTerminalSnapshot: async (terminal) => {
+      applied.push(terminal);
+    },
+  };
+  const runtime = startPortalRuntime({
+    root,
+    homeDir: home,
+    log,
+    intervalMs: 50,
+    Socket: FakeSocket,
+    door,
+    terminalReportMs: 100,
+  });
+  await until(() => FakeSocket.instances.length === 1);
+  const socket = FakeSocket.instances[0];
+  socket.open();
+  expect(JSON.parse(socket.sent[0])).toEqual({ v: 1, ch: 0, seq: 1, t: 'hello', leg: 'host', caps: ['perks', 'ssh'] });
+  // The door's state goes to the service with the first reconcile.
+  await until(() => seen.some((r) => r.route === '/api/v1/terminal/host'));
+  expect(seen.find((r) => r.route === '/api/v1/terminal/host')).toEqual({
+    method: 'PUT',
+    route: '/api/v1/terminal/host',
+    authorization: 'Bearer tok',
+    body: { enabled: true, doorPort, authorizedFingerprints: [] },
+  });
+  // The snapshot's terminal section reaches the door, and the next report names its keys.
+  const terminal = { enabled: true, keys: [{ fingerprint: 'SHA256:a' }], pending: [], sandboxes: [] };
+  socket.frame(1, 1, 'open', { kind: 'perks' });
+  socket.frame(1, 2, 'data', { snapshot: { revision: 2, terminal }, presence: [] });
+  expect(applied).toEqual([terminal]);
+  await sleep(120);
+  socket.frame(1, 3, 'data', { snapshot: { revision: 3, terminal }, presence: [] });
+  await until(() => seen.filter((r) => r.route === '/api/v1/terminal/host').length >= 2);
+  expect(seen.filter((r) => r.route === '/api/v1/terminal/host').at(-1)?.body).toEqual({
+    enabled: true,
+    doorPort,
+    authorizedFingerprints: ['SHA256:a'],
+  });
+  // A stream the cell opens is piped into the door and echoed back, with credit for what the door took.
+  const onStream = (): Record<string, unknown>[] =>
+    socket.sent.map((raw) => JSON.parse(raw) as Record<string, unknown>).filter((f) => f.ch === 2);
+  socket.frame(2, 1, 'open', {
+    kind: 'ssh',
+    stream: 's1',
+    target: { account: 'alice' },
+    source: { ip: '::1', port: 1 },
+  });
+  socket.frame(2, 2, 'data', { off: 0, b64: Buffer.from('hi').toString('base64') });
+  await until(() => onStream().some((f) => f.t === 'credit') && onStream().some((f) => f.t === 'data'));
+  expect(onStream().find((f) => f.t === 'credit')).toMatchObject({ ack: 2 });
+  expect(onStream().find((f) => f.t === 'data')).toMatchObject({ off: 0, b64: Buffer.from('hi').toString('base64') });
+  expect(log).toHaveBeenCalledWith(
+    expect.objectContaining({ event: 'stream_open', stream: 's1', account: 'alice', deviceId: DEVICE_ID }),
+  );
+  expect([...targets.values()]).toEqual([
+    { stream: 's1', target: { account: 'alice' }, source: { ip: '::1', port: 1 }, openedAt: expect.any(String) },
+  ]);
+  // Disabling the door restarts the link without the cap; the open stream is torn down and ssh opens are refused.
+  expect(await reportTerminalState({ enabled: false, doorPort }, { root, homeDir: home })).toEqual({
+    journaled: true,
+    reported: true,
+  });
+  expect(seen.at(-1)?.body).toEqual({ enabled: false, doorPort, authorizedFingerprints: [] });
+  await until(() => FakeSocket.instances.length === 2);
+  expect(socket.readyState).toBe(3);
+  expect(log).toHaveBeenCalledWith(expect.objectContaining({ event: 'stream_closed', stream: 's1', by: 'link' }));
+  expect(targets.size).toBe(0);
+  const second = FakeSocket.instances[1];
+  second.open();
+  expect(JSON.parse(second.sent[0])).toEqual({ v: 1, ch: 0, seq: 1, t: 'hello', leg: 'host', caps: ['perks'] });
+  second.frame(2, 1, 'open', {
+    kind: 'ssh',
+    stream: 's2',
+    target: { account: 'alice' },
+    source: { ip: '::1', port: 1 },
+  });
+  expect(JSON.parse(second.sent.at(-1) ?? '{}')).toEqual({ v: 1, ch: 2, seq: 1, t: 'error', code: 'unsupported' });
+  const reports = seen.filter((r) => r.route === '/api/v1/terminal/host').length;
+  await sleep(150);
+  expect(seen.filter((r) => r.route === '/api/v1/terminal/host')).toHaveLength(reports);
+  await runtime.stop();
+  await new Promise<void>((resolve) => echo.close(() => resolve()));
 });
 
 it('reports sign_in_required and clears local credentials when the portal refuses the device', async () => {

--- a/src/modules/community-portal/runtime.ts
+++ b/src/modules/community-portal/runtime.ts
@@ -1,5 +1,7 @@
 import path from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
+import { wireDoor, type Door } from './remote/door.js';
+import { openStream } from './remote/stream.js';
 import {
   CellLink,
   DeviceClient,
@@ -13,6 +15,7 @@ import {
   readDeviceKey,
   readInstallIdentity,
   readJson,
+  terminalSnapshotOf,
 } from '../../community-portal/index.js';
 import { launchSlackJob, readSlackJob } from '../../community-portal/slack-job.js';
 
@@ -26,6 +29,14 @@ import { launchSlackJob, readSlackJob } from '../../community-portal/slack-job.j
  * bearer routes through a locked DeviceClient; the link dials with a proofed
  * ticket. Cell pushes only trigger a fresh read of locally saved, authorized
  * work: perk credentials and the saved Slack install worker.
+ *
+ * While the loopback door is enabled the link also announces the `ssh` cap
+ * and pipes every `ssh` channel the cell opens into the door from a distinct
+ * loopback source port; the door's state is part of the identity, so
+ * `remote enable|disable` restarts the link and the caps are re-announced
+ * (the door's state report wakes the runtime, and a poll catches the rest).
+ * Every perks snapshot's `terminal` section goes to the door, and the door's
+ * state is reported to the account service every fifteen minutes.
  */
 export interface PortalRuntimeOptions {
   root?: string;
@@ -35,6 +46,9 @@ export interface PortalRuntimeOptions {
   intervalMs?: number;
   /** Test seam: the WebSocket constructor the link dials with. */
   Socket?: LinkSocketConstructor;
+  /** Test seam: the door as the link sees it; the real door is wired by default. */
+  door?: Door;
+  terminalReportMs?: number;
 }
 
 interface Identity {
@@ -44,9 +58,12 @@ interface Identity {
   installId: string;
   deviceId: string;
   fingerprint: string;
+  /** The door's loopback port while it is enabled. */
+  doorPort?: number;
 }
 
 const RECONCILE_INTERVAL_MS = 60_000;
+export const TERMINAL_REPORT_INTERVAL_MS = 15 * 60_000;
 
 export function startPortalRuntime({
   root = process.cwd(),
@@ -55,9 +72,12 @@ export function startPortalRuntime({
   log = () => {},
   intervalMs = 5000,
   Socket,
+  door: providedDoor,
+  terminalReportMs = TERMINAL_REPORT_INTERVAL_MS,
 }: PortalRuntimeOptions = {}): { stop(): Promise<void> } {
   const abort = new AbortController();
   const file = path.join(root, 'data/community-portal.json');
+  const door = providedDoor ?? wireDoor({ root, homeDir, log, onReported: () => wake() });
   let link: CellLink | undefined;
   let identity: Identity | undefined;
   let rejected = false;
@@ -66,6 +86,7 @@ export function startPortalRuntime({
   let again = false;
   let dirty = true;
   let nextSync = 0;
+  let nextTerminalReport = 0;
   let stopped = false;
   let stopping: Promise<void> | undefined;
   let lastError = '';
@@ -90,6 +111,7 @@ export function startPortalRuntime({
       identity = undefined;
       throw portalError('The device key is missing. Run the portal setup step again.', 'device_key_missing');
     }
+    const doorState = await door.status();
     const current: Identity | undefined =
       local?.deviceId && local.origin && account && key
         ? {
@@ -99,6 +121,7 @@ export function startPortalRuntime({
             installId: account.installId,
             deviceId: local.deviceId,
             fingerprint: key.fingerprint,
+            ...(doorState.enabled && doorState.port !== undefined ? { doorPort: doorState.port } : {}),
           }
         : undefined;
     if (!isDeepStrictEqual(current, identity)) {
@@ -107,6 +130,7 @@ export function startPortalRuntime({
       identity = current;
       rejected = false;
       dirty = true;
+      nextTerminalReport = 0;
       if (current && key) {
         const tickets = new DeviceClient({
           origin: current.origin,
@@ -120,6 +144,8 @@ export function startPortalRuntime({
           dirty = true;
           wake();
         };
+        const linkLog = (event: LinkEvent): void => log({ ...event, deviceId: current.deviceId });
+        const doorPort = current.doorPort;
         link = new CellLink({
           origin: tickets.origin,
           getTicket: async (requestSignal) => {
@@ -130,12 +156,20 @@ export function startPortalRuntime({
               throw error;
             }
           },
-          onSnapshot: changed,
+          onSnapshot: ({ snapshot }) => {
+            door
+              .applyTerminalSnapshot(terminalSnapshotOf(snapshot))
+              .catch((error: unknown) => linkLog({ event: 'terminal_snapshot_failed', code: errorCode(error) }));
+            changed();
+          },
           onChange: changed,
           onForbidden: () => {
             if (isDeepStrictEqual(identity, current)) rejectIdentity();
           },
-          log: (event) => log({ ...event, deviceId: current.deviceId }),
+          ...(doorPort === undefined
+            ? {}
+            : { ssh: (open, channel) => openStream({ open, channel, doorPort, door, log: linkLog }) }),
+          log: linkLog,
           ...(Socket ? { Socket } : {}),
         });
         link.start();
@@ -179,6 +213,23 @@ export function startPortalRuntime({
       }
       dirty = false;
       await client.reconcile();
+      if (doorState.enabled && Date.now() >= nextTerminalReport) {
+        try {
+          await client.reportTerminal({
+            enabled: true,
+            ...(doorState.hostKey ? { hostKey: doorState.hostKey } : {}),
+            ...(doorState.port === undefined ? {} : { doorPort: doorState.port }),
+            authorizedFingerprints: doorState.authorizedFingerprints,
+          });
+          nextTerminalReport = Date.now() + terminalReportMs;
+          log({ event: 'terminal_reported', deviceId: current.deviceId });
+        } catch (error) {
+          if (denied(error)) throw error;
+          // The service may not carry the route yet; try again with the next reconcile.
+          nextTerminalReport = Date.now() + RECONCILE_INTERVAL_MS;
+          log({ event: 'terminal_report_failed', code: errorCode(error), deviceId: current.deviceId });
+        }
+      }
       nextSync = Date.now() + RECONCILE_INTERVAL_MS;
     } catch (error) {
       if (errorCode(error, '') === 'journal_busy') return;

--- a/src/modules/community-portal/surface/client.test.ts
+++ b/src/modules/community-portal/surface/client.test.ts
@@ -1,0 +1,259 @@
+/**
+ * The service client against a fake service: every route's method, path,
+ * bearer and body; the error mapping (coded 4xx → SurfaceServiceError
+ * with the code, unavailable/stopped/gone predicates); origin validation;
+ * and the long-poll's query shape.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  isChannelGone,
+  isSessionStopped,
+  isUnavailable,
+  LONG_POLL_MAX_SECONDS,
+  SurfaceServiceClient,
+  SurfaceServiceError,
+  validateServiceOrigin,
+} from './client.js';
+
+interface Call {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+type Reply = { status: number; body: unknown } | ((call: Call) => { status: number; body: unknown });
+
+/** A fake service: one reply per call, in order; records what it saw. */
+function fakeService(replies: Reply[]) {
+  const calls: Call[] = [];
+  const fetchFn = (async (input: string | URL | Request, init?: RequestInit) => {
+    const headers: Record<string, string> = {};
+    for (const [k, v] of Object.entries((init?.headers ?? {}) as Record<string, string>)) headers[k.toLowerCase()] = v;
+    const call: Call = {
+      method: init?.method ?? 'GET',
+      url: String(input),
+      headers,
+      body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+    };
+    calls.push(call);
+    const reply = replies.shift();
+    if (!reply) throw new Error(`unexpected call ${call.method} ${call.url}`);
+    const r = typeof reply === 'function' ? reply(call) : reply;
+    return new Response(r.body === undefined ? '' : JSON.stringify(r.body), {
+      status: r.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  return { calls, fetchFn };
+}
+
+const BASE = 'https://chat-service.example.test';
+
+function client(replies: Reply[]) {
+  const service = fakeService(replies);
+  return {
+    ...service,
+    client: new SurfaceServiceClient({ serviceBase: BASE, token: 'tok-1', fetch: service.fetchFn }),
+  };
+}
+
+describe('origin validation', () => {
+  it('accepts https and loopback http, refuses everything else', () => {
+    expect(validateServiceOrigin('https://chat-service.example.test/')).toBe('https://chat-service.example.test');
+    expect(validateServiceOrigin('http://localhost:3000')).toBe('http://localhost:3000');
+    expect(validateServiceOrigin('http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080');
+    for (const bad of ['http://chat.example.test', 'https://u:p@chat.example.test', 'https://x.test/?q=1', 'nope']) {
+      expect(() => validateServiceOrigin(bad)).toThrow(SurfaceServiceError);
+    }
+  });
+});
+
+describe('routes', () => {
+  it('create: POST /v1/code-channels with the bearer and the body; created flag split out', async () => {
+    const c = client([{ status: 201, body: { channelId: 'C1', sessionId: 'ag-1', status: 'active', created: true } }]);
+    const res = await c.client.create({ appId: 'A1', sessionId: 'ag-1', title: 'box' });
+    expect(res).toEqual({ channel: { channelId: 'C1', sessionId: 'ag-1', status: 'active' }, created: true });
+    expect(c.calls[0]).toMatchObject({
+      method: 'POST',
+      url: `${BASE}/v1/code-channels`,
+      body: { appId: 'A1', sessionId: 'ag-1', title: 'box' },
+    });
+    expect(c.calls[0].headers.authorization).toBe('Bearer tok-1');
+    expect(c.calls[0].headers['content-type']).toBe('application/json');
+  });
+
+  it('create on an existing session answers created:false', async () => {
+    const c = client([{ status: 200, body: { channelId: 'C1', sessionId: 'ag-1', status: 'active', created: false } }]);
+    expect((await c.client.create({ appId: 'A1', sessionId: 'ag-1', title: 'box' })).created).toBe(false);
+  });
+
+  it('create carries the member fields for the creating sandbox when given', async () => {
+    const c = client([{ status: 201, body: { channelId: 'C1', sessionId: 'ag-1', status: 'active', created: true } }]);
+    await c.client.create({
+      appId: 'A1',
+      sessionId: 'ag-1',
+      title: 'box',
+      sandboxName: 'box',
+      terminalAddress: 'box.alice.example.test',
+    });
+    expect(c.calls[0].body).toEqual({
+      appId: 'A1',
+      sessionId: 'ag-1',
+      title: 'box',
+      sandboxName: 'box',
+      terminalAddress: 'box.alice.example.test',
+    });
+  });
+
+  it('get / status / view / properties / archive / member update hit their paths with their bodies', async () => {
+    const c = client([
+      { status: 200, body: { channelId: 'C1', sessionId: 'ag-1', status: 'active' } },
+      { status: 200, body: { channelId: 'C1', sessionId: 'ag-1', status: 'processing', resumed: true } },
+      { status: 200, body: { channelId: 'C1', viewKey: 'diff', type: 'diff', views: 1 } },
+      { status: 200, body: { channelId: 'C1', contextBarItems: [] } },
+      { status: 200, body: { channelId: 'C1', sessionId: 'ag-1', status: 'closed', archived: true, archivedAt: 't' } },
+      { status: 200, body: { channelId: 'C1', member: { botUserId: 'U0BOT1', role: 'owner' } } },
+    ]);
+    await c.client.get('C1');
+    await c.client.setStatus('C1', 'processing', { resume: true });
+    await c.client.putView('C1', 'diff', { type: 'diff', content: '--- a\n+++ b\n', name: 'Changes' });
+    await c.client.putProperties('C1', { contextBarItems: [{ key: 'repo', label: 'box' }] });
+    await c.client.archive('C1', { summary: 'done' });
+    await c.client.updateMember('C1', 'U0BOT1', { terminalAddress: 'box.alice.example.test', sandboxName: 'box' });
+    expect(c.calls.map((x) => [x.method, x.url.slice(BASE.length), x.body])).toEqual([
+      ['GET', '/v1/code-channels/C1', undefined],
+      ['POST', '/v1/code-channels/C1/status', { status: 'processing', resume: true }],
+      ['PUT', '/v1/code-channels/C1/views/diff', { type: 'diff', content: '--- a\n+++ b\n', name: 'Changes' }],
+      ['PUT', '/v1/code-channels/C1/properties', { contextBarItems: [{ key: 'repo', label: 'box' }] }],
+      ['POST', '/v1/code-channels/C1/archive', { summary: 'done' }],
+      ['PUT', '/v1/code-channels/C1/members/U0BOT1', { terminalAddress: 'box.alice.example.test', sandboxName: 'box' }],
+    ]);
+  });
+
+  it('members / add / remove / commands hit their paths', async () => {
+    const c = client([
+      {
+        status: 200,
+        body: { channelId: 'C1', sessionId: 'ag-1', status: 'active', members: [{ botUserId: 'U0A', role: 'owner' }] },
+      },
+      { status: 200, body: { channelId: 'C1', member: { botUserId: 'U0B', role: 'member' } } },
+      { status: 200, body: { channelId: 'C1', removed: true } },
+      { status: 200, body: { channelId: 'C1', commands: 2 } },
+    ]);
+    expect(await c.client.members('C1')).toEqual([{ botUserId: 'U0A', role: 'owner' }]);
+    await c.client.addMember('C1', { botUserId: 'U0B', sandboxName: 'web' });
+    await c.client.removeMember('C1', 'U0B');
+    await c.client.setCommands('C1', [
+      { name: 'terminal', description: 'the address' },
+      { name: 'board', description: 'the board' },
+    ]);
+    expect(c.calls.map((x) => [x.method, x.url.slice(BASE.length), x.body])).toEqual([
+      ['GET', '/v1/code-channels/C1', undefined],
+      ['POST', '/v1/code-channels/C1/members', { botUserId: 'U0B', sandboxName: 'web' }],
+      ['DELETE', '/v1/code-channels/C1/members/U0B', undefined],
+      [
+        'PUT',
+        '/v1/code-channels/C1/commands',
+        {
+          commands: [
+            { name: 'terminal', description: 'the address' },
+            { name: 'board', description: 'the board' },
+          ],
+        },
+      ],
+    ]);
+  });
+
+  it('status without resume sends no resume key; archive without summary sends an empty body', async () => {
+    const c = client([
+      { status: 200, body: { channelId: 'C1', sessionId: 'ag-1', status: 'active' } },
+      { status: 200, body: { channelId: 'C1', sessionId: 'ag-1', status: 'closed', archived: true, archivedAt: 't' } },
+    ]);
+    await c.client.setStatus('C1', 'active');
+    await c.client.archive('C1');
+    expect(c.calls[0].body).toEqual({ status: 'active' });
+    expect(c.calls[1].body).toEqual({});
+  });
+
+  it('events: long-poll query carries since and a wait capped at the service ceiling', async () => {
+    const c = client([
+      { status: 200, body: { channelId: 'C1', sessionId: 'ag-1', status: 'active', events: [], cursor: null } },
+      {
+        status: 200,
+        body: {
+          channelId: 'C1',
+          sessionId: 'ag-1',
+          status: 'stopped',
+          events: [{ cursor: 'EVT#2', type: 'code_channel.stopped', channelId: 'C1', sessionId: 'ag-1', ts: 't' }],
+          cursor: 'EVT#2',
+        },
+      },
+    ]);
+    await c.client.events('C1');
+    const page = await c.client.events('C1', { since: 'EVT#1', wait: 999 });
+    expect(new URL(c.calls[0].url).searchParams.get('wait')).toBe(String(LONG_POLL_MAX_SECONDS));
+    expect(new URL(c.calls[0].url).searchParams.has('since')).toBe(false);
+    expect(new URL(c.calls[1].url).searchParams.get('since')).toBe('EVT#1');
+    expect(new URL(c.calls[1].url).searchParams.get('wait')).toBe(String(LONG_POLL_MAX_SECONDS));
+    expect(page.events[0].type).toBe('code_channel.stopped');
+    expect(page.cursor).toBe('EVT#2');
+  });
+});
+
+describe('errors', () => {
+  it('a coded failure becomes a SurfaceServiceError with the code and status', async () => {
+    const c = client([{ status: 409, body: { error: 'session_stopped', message: 'The user stopped this session.' } }]);
+    const err = await c.client.setStatus('C1', 'active').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(SurfaceServiceError);
+    expect((err as SurfaceServiceError).code).toBe('session_stopped');
+    expect((err as SurfaceServiceError).status).toBe(409);
+    expect((err as SurfaceServiceError).message).toBe('The user stopped this session.');
+    expect(isSessionStopped(err)).toBe(true);
+    expect(isUnavailable(err)).toBe(false);
+    expect(isChannelGone(err)).toBe(false);
+  });
+
+  it('409 code_channels_unavailable and 404 code_channels_disabled are "unavailable" — degrade, never retry', async () => {
+    for (const [status, code] of [
+      [409, 'code_channels_unavailable'],
+      [404, 'code_channels_disabled'],
+      [409, 'manager_missing_scope'],
+      [409, 'app_not_installed'],
+    ] as const) {
+      const c = client([{ status, body: { error: code, message: 'no' } }]);
+      const err = await c.client.create({ appId: 'A1', sessionId: 'ag-1', title: 'box' }).catch((e: unknown) => e);
+      expect(isUnavailable(err)).toBe(true);
+    }
+  });
+
+  it('404 not_found and 409 already_archived mean the channel is gone', async () => {
+    const gone = client([{ status: 404, body: { error: 'not_found', message: 'No such channel for this account.' } }]);
+    expect(isChannelGone(await gone.client.get('C9').catch((e: unknown) => e))).toBe(true);
+    const archived = client([{ status: 409, body: { error: 'already_archived', message: 'archived' } }]);
+    expect(isChannelGone(await archived.client.setStatus('C1', 'active').catch((e: unknown) => e))).toBe(true);
+  });
+
+  it('a body without a code still yields a coded error; an unreachable service is "unreachable"', async () => {
+    const c = client([{ status: 502, body: undefined }]);
+    const err = (await c.client.get('C1').catch((e: unknown) => e)) as SurfaceServiceError;
+    expect(err.code).toBe('http_502');
+    const down = new SurfaceServiceClient({
+      serviceBase: BASE,
+      token: 't',
+      fetch: (async () => {
+        throw new TypeError('fetch failed');
+      }) as typeof fetch,
+    });
+    const offline = (await down.get('C1').catch((e: unknown) => e)) as SurfaceServiceError;
+    expect(offline.code).toBe('unreachable');
+    expect(offline.status).toBe(0);
+  });
+
+  it('a 2xx without JSON is refused rather than returned as garbage', async () => {
+    const c = client([{ status: 200, body: undefined }]);
+    const err = (await c.client.get('C1').catch((e: unknown) => e)) as SurfaceServiceError;
+    expect(err.code).toBe('bad_response');
+  });
+});

--- a/src/modules/community-portal/surface/client.ts
+++ b/src/modules/community-portal/surface/client.ts
@@ -1,0 +1,402 @@
+/**
+ * Client for the service routes that manage a coding session's chat surface.
+ *
+ * The service is the one that provisioned the host's managed chat app; the
+ * bearer is the registry install token; the origin is the one the saved
+ * install names (install.ts). Every route is under `/v1/code-channels`.
+ * Responses are JSON; failures are `{ error, message }` with a meaningful
+ * status, surfaced here as SurfaceServiceError so callers branch on a code
+ * rather than parse prose.
+ *
+ * Three answers matter to callers (provider.ts maps them onto the
+ * session-surface contract's failure kinds):
+ *   - "unavailable" (isUnavailable): the workspace or the deployment cannot
+ *     do this at all (feature off, the managing app lacking the scopes, a
+ *     service flag off). A sandbox degrades silently — it works without a
+ *     surface.
+ *   - session_stopped (isSessionStopped): the user pressed Stop; the service
+ *     refuses status/views until the host declares the next human turn with
+ *     `resume: true`.
+ *   - gone (isChannelGone): archived or unknown — stop mirroring it.
+ *
+ * Nothing here retries: the mirror runs on a tick and the long-poll loop
+ * has its own backoff (code-mode/surface/runtime.ts).
+ */
+
+export type SessionStatus = 'active' | 'processing' | 'suspended' | 'closed';
+
+export type ViewType = 'diff' | 'html' | 'block_kit' | 'canvas';
+
+/** The service's one code tab lives at this view key. */
+export const DIFF_VIEW_KEY = 'diff';
+
+/** The service caps a long-poll at this many seconds (API gateway ceiling). */
+export const LONG_POLL_MAX_SECONDS = 25;
+
+/** Notification type the service relays when the user stops the session from the channel. */
+export const STOPPED_EVENT = 'code_channel.stopped';
+
+/**
+ * Notification type the service relays for a slash command typed in the
+ * channel (`command` is the slash word, `text` what followed it). The service
+ * answers the ones it can itself; the host is told so it may react.
+ */
+export const COMMAND_EVENT = 'code_channel.command';
+
+/** The one command the service answers on its own, from the members' terminal addresses. */
+export const TERMINAL_COMMAND = '/terminal';
+
+/** A sandbox on the channel: the creating one (`owner`) and any that joined. */
+export interface ChannelMember {
+  botUserId: string;
+  appId?: string;
+  accountId?: string;
+  role: 'owner' | 'member' | string;
+  sessionId?: string | null;
+  sandboxName?: string | null;
+  /** The address a terminal connects to for this member's sandbox, when its host reported one. */
+  terminalAddress?: string | null;
+  joinedAt?: string;
+  updatedAt?: string;
+}
+
+export interface ChannelRecord {
+  channelId: string;
+  sessionId: string;
+  teamId?: string;
+  appId?: string;
+  /** The owner's bot user — the member id this host updates through updateMember. */
+  botUserId?: string | null;
+  title?: string;
+  /** The service's own view: active | processing | suspended | closed | stopped. */
+  status: string;
+  sandboxName?: string | null;
+  terminalAddress?: string | null;
+  /** Present on a GET, owner first. */
+  members?: ChannelMember[];
+  createdAt?: string;
+  updatedAt?: string;
+  stoppedAt?: string | null;
+  archivedAt?: string | null;
+  views?: Array<{ viewKey: string; type: string; name?: string | null; updatedAt?: string }>;
+  contextBarItems?: Array<{ key: string; label: string; icon?: string; url?: string }>;
+}
+
+export interface ChannelEvent {
+  cursor: string;
+  type: string;
+  channelId: string;
+  sessionId: string;
+  ts: string;
+  threadTs?: string;
+  user?: string;
+  /** COMMAND_EVENT only: the slash word and the text after it. */
+  command?: string;
+  text?: string;
+}
+
+/** What a host reports about its own sandbox on a channel: fields the service keeps on the member row. */
+export interface MemberFields {
+  /** A DNS name a terminal connects to; the service lower-cases and validates it. */
+  terminalAddress?: string;
+  /** One DNS label — the sandbox as the channel names it. */
+  sandboxName?: string;
+}
+
+export interface EventsPage {
+  channelId: string;
+  sessionId: string;
+  status: string;
+  events: ChannelEvent[];
+  cursor: string | null;
+}
+
+export interface ViewBody {
+  type: ViewType;
+  name?: string;
+  content?: string;
+  blocks?: unknown[];
+  baseBranch?: string;
+  headBranch?: string;
+  accessLevel?: 'comment' | 'read' | 'edit';
+}
+
+export interface ContextBarItem {
+  key: string;
+  label: string;
+  icon?: string;
+  url?: string;
+  itemType?: 'info' | 'action';
+}
+
+export class SurfaceServiceError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly path: string;
+
+  constructor(status: number, code: string, message: string, path: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'SurfaceServiceError';
+    this.status = status;
+    this.code = code;
+    this.path = path;
+  }
+}
+
+/** The service cannot give this host a channel at all — degrade, do not retry. */
+const UNAVAILABLE_CODES = new Set([
+  'code_channels_unavailable',
+  'code_channels_disabled',
+  'manager_missing_scope',
+  'manager_bot_token_missing',
+  'workspace_disconnected',
+  'app_not_installed',
+  'no_origin',
+]);
+
+export function isUnavailable(error: unknown): boolean {
+  return error instanceof SurfaceServiceError && UNAVAILABLE_CODES.has(error.code);
+}
+
+export function isSessionStopped(error: unknown): boolean {
+  return error instanceof SurfaceServiceError && error.code === 'session_stopped';
+}
+
+export function isNotFound(error: unknown): boolean {
+  return error instanceof SurfaceServiceError && error.status === 404;
+}
+
+/** The channel is gone for good (archived or unknown) — stop mirroring it. */
+export function isChannelGone(error: unknown): boolean {
+  return (
+    error instanceof SurfaceServiceError &&
+    (error.status === 404 || error.code === 'already_archived' || error.code === 'is_archived')
+  );
+}
+
+/**
+ * The origin rule the install worker applies before it sends the bearer
+ * anywhere: https, or plain http to loopback for a local service; never
+ * credentials, query or fragment in the configured origin.
+ */
+export function validateServiceOrigin(serviceBase: string): string {
+  let base: URL;
+  try {
+    base = new URL(serviceBase);
+  } catch (error) {
+    throw new SurfaceServiceError(0, 'invalid_service', 'Invalid service origin.', serviceBase, {
+      cause: error,
+    });
+  }
+  if (
+    base.username ||
+    base.password ||
+    base.search ||
+    base.hash ||
+    (base.protocol !== 'https:' &&
+      !(base.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]'].includes(base.hostname)))
+  ) {
+    throw new SurfaceServiceError(0, 'invalid_service', 'Invalid service origin.', serviceBase);
+  }
+  return base.origin;
+}
+
+export interface SurfaceServiceClientOptions {
+  serviceBase: string;
+  token: string;
+  /** Test seam. */
+  fetch?: typeof fetch;
+  /** Per-request ceiling for ordinary calls (the long-poll adds its wait). */
+  timeoutMs?: number;
+}
+
+export class SurfaceServiceClient {
+  private readonly origin: string;
+  private readonly token: string;
+  private readonly fetchFn: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(options: SurfaceServiceClientOptions) {
+    this.origin = validateServiceOrigin(options.serviceBase);
+    this.token = options.token;
+    this.fetchFn = options.fetch ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? 30_000;
+  }
+
+  /**
+   * Create the channel for a session, or return the existing one (idempotent
+   * on sessionId). The member fields describe the creating sandbox — the
+   * channel's first member — and are optional.
+   */
+  async create(
+    input: {
+      appId: string;
+      sessionId: string;
+      title: string;
+      teamId?: string;
+      botUserId?: string;
+      origin?: { channel: string; ts: string };
+    } & MemberFields,
+  ): Promise<{ channel: ChannelRecord; created: boolean }> {
+    const body = await this.request<ChannelRecord & { created?: boolean }>('POST', '/v1/code-channels', input);
+    const { created, ...channel } = body;
+    return { channel, created: created === true };
+  }
+
+  get(channelId: string): Promise<ChannelRecord> {
+    return this.request<ChannelRecord>('GET', `/v1/code-channels/${encodeURIComponent(channelId)}`);
+  }
+
+  /**
+   * Fill in or change this host's member fields on a channel that already
+   * exists — a terminal address learned after the channel was opened. The
+   * member is keyed by its bot user; at least one field must be sent.
+   */
+  updateMember(
+    channelId: string,
+    botUserId: string,
+    fields: MemberFields,
+  ): Promise<{ channelId: string; member: ChannelMember }> {
+    return this.request(
+      'PUT',
+      `/v1/code-channels/${encodeURIComponent(channelId)}/members/${encodeURIComponent(botUserId)}`,
+      fields,
+    );
+  }
+
+  /** The members of a channel (owner first), from its record. */
+  async members(channelId: string): Promise<ChannelMember[]> {
+    return (await this.get(channelId)).members ?? [];
+  }
+
+  /** Add a sandbox (by its bot user) to a channel that exists. */
+  addMember(
+    channelId: string,
+    member: { botUserId: string } & MemberFields & { sessionId?: string; appId?: string },
+  ): Promise<{ channelId: string; member: ChannelMember }> {
+    return this.request('POST', `/v1/code-channels/${encodeURIComponent(channelId)}/members`, member);
+  }
+
+  removeMember(channelId: string, botUserId: string): Promise<{ channelId: string; removed: boolean }> {
+    return this.request(
+      'DELETE',
+      `/v1/code-channels/${encodeURIComponent(channelId)}/members/${encodeURIComponent(botUserId)}`,
+    );
+  }
+
+  /** The commands the channel offers its members. */
+  setCommands(
+    channelId: string,
+    commands: Array<{ name: string; description: string }>,
+  ): Promise<{ channelId: string; commands: number }> {
+    return this.request('PUT', `/v1/code-channels/${encodeURIComponent(channelId)}/commands`, { commands });
+  }
+
+  setStatus(
+    channelId: string,
+    status: SessionStatus,
+    options: { resume?: boolean } = {},
+  ): Promise<{ channelId: string; sessionId: string; status: SessionStatus; resumed?: boolean }> {
+    return this.request('POST', `/v1/code-channels/${encodeURIComponent(channelId)}/status`, {
+      status,
+      ...(options.resume ? { resume: true } : {}),
+    });
+  }
+
+  putView(
+    channelId: string,
+    viewKey: string,
+    view: ViewBody,
+  ): Promise<{ channelId: string; viewKey: string; type: string; views: number }> {
+    return this.request(
+      'PUT',
+      `/v1/code-channels/${encodeURIComponent(channelId)}/views/${encodeURIComponent(viewKey)}`,
+      view,
+    );
+  }
+
+  putProperties(
+    channelId: string,
+    properties: { contextBarItems?: ContextBarItem[]; summaryMessage?: { messageTs: string; threadTs?: string } },
+  ): Promise<{ channelId: string; contextBarItems: ContextBarItem[] }> {
+    return this.request('PUT', `/v1/code-channels/${encodeURIComponent(channelId)}/properties`, properties);
+  }
+
+  archive(
+    channelId: string,
+    options: { summary?: string } = {},
+  ): Promise<{ channelId: string; sessionId: string; status: string; archived: boolean; archivedAt: string }> {
+    return this.request('POST', `/v1/code-channels/${encodeURIComponent(channelId)}/archive`, {
+      ...(options.summary ? { summary: options.summary } : {}),
+    });
+  }
+
+  /** Long-poll for host-bound notifications; returns as soon as one is queued or `wait` seconds pass. */
+  events(
+    channelId: string,
+    options: { since?: string | null; wait?: number; signal?: AbortSignal } = {},
+  ): Promise<EventsPage> {
+    const wait = Math.max(0, Math.min(options.wait ?? LONG_POLL_MAX_SECONDS, LONG_POLL_MAX_SECONDS));
+    const query = new URLSearchParams({ wait: String(wait) });
+    if (options.since) query.set('since', options.since);
+    return this.request<EventsPage>(
+      'GET',
+      `/v1/code-channels/${encodeURIComponent(channelId)}/events?${query.toString()}`,
+      undefined,
+      { timeoutMs: this.timeoutMs + wait * 1000, signal: options.signal },
+    );
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    options: { timeoutMs?: number; signal?: AbortSignal } = {},
+  ): Promise<T> {
+    const timeout = AbortSignal.timeout(options.timeoutMs ?? this.timeoutMs);
+    const signal = options.signal ? AbortSignal.any([options.signal, timeout]) : timeout;
+    let response: Response;
+    try {
+      response = await this.fetchFn(`${this.origin}${path}`, {
+        method,
+        headers: {
+          authorization: `Bearer ${this.token}`,
+          accept: 'application/json',
+          ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+        },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+        signal,
+        redirect: 'error',
+      });
+    } catch (error) {
+      if (options.signal?.aborted) throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SurfaceServiceError(0, 'unreachable', `Service did not answer ${method} ${path}: ${message}`, path, {
+        cause: error,
+      });
+    }
+    const text = await response.text();
+    let parsed: unknown = null;
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch (error) {
+        if (!(error instanceof SyntaxError)) throw error;
+        parsed = null;
+      }
+    }
+    if (!response.ok) {
+      const failure = (parsed ?? {}) as { error?: unknown; message?: unknown };
+      const code = typeof failure.error === 'string' && failure.error ? failure.error : `http_${response.status}`;
+      const message =
+        typeof failure.message === 'string' && failure.message
+          ? failure.message
+          : `${method} ${path} failed with HTTP ${response.status}.`;
+      throw new SurfaceServiceError(response.status, code, message, path);
+    }
+    if (parsed === null || typeof parsed !== 'object') {
+      throw new SurfaceServiceError(response.status, 'bad_response', `${method} ${path} returned no JSON.`, path);
+    }
+    return parsed as T;
+  }
+}

--- a/src/modules/community-portal/surface/index.ts
+++ b/src/modules/community-portal/surface/index.ts
@@ -1,0 +1,268 @@
+/**
+ * A chat surface for each coding session, over the service — module wiring.
+ *
+ * For every chat platform that registered its half (platforms.ts) and for
+ * which this host holds a managed install and a sign-in (install.ts), the
+ * module registers a SessionSurfaceProvider (provider.ts) with code mode's
+ * session-surface registry under the platform's channel type. From there
+ * core does the rest: `sandboxes new` opens a surface through the provider,
+ * binds the sandbox to it, mirrors status and the diff view, honours a
+ * Stop. Activation is the service's answer: a host whose service says
+ * "unavailable" (or has no channel to give) keeps a plain sandbox — no
+ * flag, no setting.
+ *
+ * Two things ride the door here: a sandbox's terminal address is announced
+ * on its surface when the surface is bound and again for every open
+ * surface when remote access is enabled or renamed (terminal-address.ts),
+ * so a `/terminal` on the surface answers with the address without a host
+ * round trip. `ncl sandboxes surface status | archive | enable | disable`
+ * are the operator verbs (verbs.ts); enable/disable is the host's one
+ * setting, whether a new sandbox gets a surface opened at all (setting.ts).
+ */
+import { readInstallIdentity } from '../../../community-portal/install-identity.js';
+import { getAgentGroup } from '../../../db/agent-groups.js';
+import {
+  onRemoteAccessChanged,
+  onSandboxBound,
+  SANDBOX_HOOKS_SEAM,
+  type BoundSurface,
+  type SandboxGroup,
+} from '../../../code-mode/hooks.js';
+import { listOpenSessionSurfaces, type SessionSurfaceRow } from '../../../code-mode/surface/db.js';
+import { registerSessionSurface, SESSION_SURFACE_SEAM } from '../../../code-mode/surface/registry.js';
+import type { SessionSurfaceProvider } from '../../../code-mode/surface/types.js';
+import { onHostShutdown, onHostStart } from '../../../host-lifecycle.js';
+import { log } from '../../../log.js';
+import { doorStatus, type DoorSummary } from '../door/index.js';
+import { sandboxTerminalAddress } from '../remote/sandboxes.js';
+import { SurfaceServiceClient } from './client.js';
+import { managedInstallCredentials, type ManagedInstallCredentials, type ManagedInstallOptions } from './install.js';
+import {
+  listSurfacePlatforms,
+  onSurfacePlatformRegistered,
+  type BotIdentity,
+  type SurfacePlatform,
+} from './platforms.js';
+import { createServiceSurfaceProvider } from './provider.js';
+import { surfaceAutoOpen } from './setting.js';
+import {
+  announceTerminalAddress,
+  announceTerminalAddresses,
+  type AnnounceSweepOutcome,
+  type TerminalAddressFields,
+} from './terminal-address.js';
+
+export { registerSurfacePlatform, type BotIdentity, type SurfacePlatform } from './platforms.js';
+export { managedInstall, type ManagedInstall } from './install.js';
+export { readSurfaceSetting, setSurfaceAutoOpen, surfaceAutoOpen, type SurfaceSetting } from './setting.js';
+
+/** The hook names this module registers, for contract tests. */
+export const SURFACE_ADDRESS_HOOK = 'surface-address';
+
+/** What the address helper needs to know about the door. */
+export type DoorAddressState = Pick<DoorSummary, 'enabled' | 'name' | 'host'>;
+
+interface Active {
+  kind: string;
+  channelType: string;
+  platform: SurfacePlatform;
+  provider: SessionSurfaceProvider;
+  unregister: () => void;
+}
+
+/** Seams the module goes through; tests swap them. */
+export interface SurfaceModuleDeps extends ManagedInstallOptions {
+  credentials(kind: string, platform: SurfacePlatform): Promise<ManagedInstallCredentials | null>;
+  doorState(): Promise<DoorAddressState>;
+}
+
+const defaultDeps: SurfaceModuleDeps = {
+  async credentials(kind, platform) {
+    const where = { ...(deps.root ? { root: deps.root } : {}), ...(deps.homeDir ? { homeDir: deps.homeDir } : {}) };
+    if (!platform.install) return managedInstallCredentials(kind, where);
+    // The platform keeps its own install record; the bearer is still the sign-in's.
+    const install = await platform.install();
+    if (!install) return null;
+    const identity = await readInstallIdentity(where.homeDir ? { homeDir: where.homeDir } : {});
+    return identity ? { ...install, token: identity.token } : null;
+  },
+  doorState: () => doorStatus(),
+};
+
+let deps: SurfaceModuleDeps = defaultDeps;
+const active = new Map<string, Active>();
+const clients = new Map<string, SurfaceServiceClient>();
+let started = false;
+let unsubscribe: (() => void) | undefined;
+
+export function setSurfaceModuleDeps(overrides: Partial<SurfaceModuleDeps> | null): void {
+  deps = overrides ? { ...defaultDeps, ...overrides } : defaultDeps;
+}
+
+/** One bearer client per service origin. */
+function clientFor(credentials: ManagedInstallCredentials): SurfaceServiceClient {
+  let client = clients.get(credentials.serviceBase);
+  if (!client) {
+    client = new SurfaceServiceClient({ serviceBase: credentials.serviceBase, token: credentials.token });
+    clients.set(credentials.serviceBase, client);
+  }
+  return client;
+}
+
+/** The member fields for a sandbox on this host, or undefined when it has no address. */
+function terminalAddressFields(sandbox: string, door: DoorAddressState): TerminalAddressFields | undefined {
+  const found = sandboxTerminalAddress(sandbox, door);
+  return found ? { sandboxName: found.sandbox, terminalAddress: found.address } : undefined;
+}
+
+/**
+ * Offer a session surface for `kind` when this host can: a managed install
+ * and a sign-in. Registered once; a platform without an install stays out
+ * and its sandboxes are plain.
+ */
+export async function activateSurface(kind: string, platform: SurfacePlatform): Promise<boolean> {
+  if (active.has(kind)) return true;
+  const channelType = platform.channelType ?? kind;
+  let credentials: ManagedInstallCredentials | null;
+  try {
+    credentials = await deps.credentials(kind, platform);
+  } catch (err) {
+    log.warn('Session surface: managed install unreadable — no surface for this platform', { kind, err });
+    return false;
+  }
+  if (!credentials) {
+    log.info('Session surface: no managed install or sign-in for this platform — sandboxes stay plain', { kind });
+    return false;
+  }
+  const provider = createServiceSurfaceProvider({
+    kind,
+    platform,
+    credentials: () => deps.credentials(kind, platform),
+    clientFor,
+    terminalAddress: async (sandbox) => terminalAddressFields(sandbox, await deps.doorState()),
+    autoOpen: surfaceAutoOpen,
+  });
+  const unregister = registerSessionSurface(channelType, provider, { seam: SESSION_SURFACE_SEAM });
+  active.set(kind, { kind, channelType, platform, provider, unregister });
+  return true;
+}
+
+/** Activate every registered platform, and any registered from now on. */
+export async function activateSurfaces(): Promise<string[]> {
+  started = true;
+  unsubscribe ??= onSurfacePlatformRegistered((kind, platform) => {
+    if (started) void activateSurface(kind, platform);
+  });
+  const activated: string[] = [];
+  for (const { kind, platform } of listSurfacePlatforms()) {
+    if (await activateSurface(kind, platform)) activated.push(kind);
+  }
+  return activated;
+}
+
+export function deactivateSurfaces(): void {
+  started = false;
+  unsubscribe?.();
+  unsubscribe = undefined;
+  for (const entry of active.values()) entry.unregister();
+  active.clear();
+  clients.clear();
+}
+
+/** The platforms this module serves a surface for right now. */
+export function activeSurfacePlatforms(): string[] {
+  return [...active.keys()];
+}
+
+function activeFor(row: Pick<SessionSurfaceRow, 'provider'>): Active | undefined {
+  for (const entry of active.values()) if (entry.channelType === row.provider) return entry;
+  return undefined;
+}
+
+/** A client for a row's platform, when this module serves it and the host holds a bearer. */
+export async function clientForRow(
+  row: Pick<SessionSurfaceRow, 'provider'>,
+): Promise<{ client: SurfaceServiceClient; entry: Active; credentials: ManagedInstallCredentials } | null> {
+  const entry = activeFor(row);
+  if (!entry) return null;
+  const credentials = await deps.credentials(entry.kind, entry.platform).catch(() => null);
+  return credentials ? { client: clientFor(credentials), entry, credentials } : null;
+}
+
+async function botUserIdFor(entry: Active, credentials: ManagedInstallCredentials): Promise<string | undefined> {
+  if (!entry.platform.botIdentity) return undefined;
+  const identity: BotIdentity | null = await entry.platform.botIdentity(credentials).catch(() => null);
+  return identity?.botUserId;
+}
+
+/**
+ * Every open binding this module serves reports its sandbox's terminal
+ * address — run after `remote enable`, so surfaces opened before remote
+ * access was on learn where a terminal reaches them. Best effort
+ * throughout; never throws.
+ */
+export async function announceAddresses(): Promise<AnnounceSweepOutcome> {
+  const none: AnnounceSweepOutcome = { announced: 0, skipped: 0, failed: 0 };
+  try {
+    const door = await deps.doorState();
+    if (!door.enabled || !door.host) return none;
+    const resolved = new Map<string, Awaited<ReturnType<typeof clientForRow>>>();
+    const lookup = async (row: SessionSurfaceRow) => {
+      if (!resolved.has(row.provider)) resolved.set(row.provider, await clientForRow(row));
+      return resolved.get(row.provider) ?? null;
+    };
+    const rows = await listOpenSessionSurfaces();
+    for (const row of rows) await lookup(row);
+    const outcome = await announceTerminalAddresses({
+      listBindings: async () => rows,
+      sandboxNameOf: async (agentGroupId) => (await getAgentGroup(agentGroupId))?.folder,
+      fieldsOf: (sandbox) => terminalAddressFields(sandbox, door),
+      clientFor: (row) => resolved.get(row.provider)?.client ?? null,
+      botUserIdFor: async (row) => {
+        const found = resolved.get(row.provider);
+        return found ? botUserIdFor(found.entry, found.credentials) : undefined;
+      },
+    });
+    if (outcome.announced || outcome.failed) log.info('Session surfaces told their terminal addresses', { ...outcome });
+    return outcome;
+  } catch (err) {
+    log.warn('Session surfaces: terminal addresses not announced', { err });
+    return none;
+  }
+}
+
+/** A freshly bound surface learns its sandbox's address, when the host has one. */
+async function announceOnBound(group: SandboxGroup, surface: BoundSurface): Promise<void> {
+  const found = await clientForRow({ provider: surface.channelType });
+  if (!found) return;
+  const fields = terminalAddressFields(group.folder, await deps.doorState());
+  if (!fields) return;
+  await announceTerminalAddress({
+    client: found.client,
+    row: { agent_group_id: group.id, surface_id: surface.surfaceId },
+    fields,
+    botUserId: await botUserIdFor(found.entry, found.credentials),
+  });
+}
+
+onSandboxBound(SURFACE_ADDRESS_HOOK, announceOnBound, { seam: SANDBOX_HOOKS_SEAM });
+
+// The sweep runs in the background: `remote enable` must not wait on it.
+onRemoteAccessChanged(
+  SURFACE_ADDRESS_HOOK,
+  async (state) => {
+    if (state.enabled && state.host) void announceAddresses();
+  },
+  { seam: SANDBOX_HOOKS_SEAM },
+);
+
+onHostStart(async () => {
+  await activateSurfaces();
+});
+
+onHostShutdown(() => {
+  deactivateSurfaces();
+});
+
+// The operator verbs extend `ncl sandboxes`.
+import './verbs.js';

--- a/src/modules/community-portal/surface/install.ts
+++ b/src/modules/community-portal/surface/install.ts
@@ -1,0 +1,101 @@
+/**
+ * Does this host have a managed chat app on `platform`, and how does it
+ * talk to the service that minted it?
+ *
+ * The portal manages the install of a chat app for the host and keeps the
+ * record on this machine: the saved installation job and the setup
+ * journal (`data/community-portal.json`). The bearer for the service is
+ * the registry install token (`~/.config/nanoclaw/account.json`), the same
+ * credential the host presented when it asked the service for the app.
+ *
+ * Today the portal manages one kind of install, the Slack app
+ * (community-portal/slack-job.ts); its record is read under the platform
+ * key `slack`. Another platform whose install the portal manages gets a
+ * reader here. An app supplied by hand (a token pasted into .env with no
+ * managed install) is not a managed install: the service knows nothing
+ * about it, so there is nothing to bind. Absence is the ordinary answer,
+ * not an error — a sandbox works the same without a chat surface.
+ */
+import path from 'node:path';
+
+import type { Journal } from '../../../community-portal/device-client.js';
+import { readInstallIdentity } from '../../../community-portal/install-identity.js';
+import { readJson } from '../../../community-portal/private-file.js';
+import { DEFAULT_SLACK_SERVICE, readSlackJob } from '../../../community-portal/slack-job.js';
+
+export interface ManagedInstall {
+  /** The platform the app lives on (the key it was read under). */
+  platform: string;
+  /** Origin of the service that manages this host's app. */
+  serviceBase: string;
+  /** The managed app the service provisioned for this host. */
+  appId: string;
+  /**
+   * The app's bot token, when the install delivered one. A platform half
+   * may use it for one identity lookup; it is never logged and never sent
+   * anywhere but the platform itself.
+   */
+  botToken?: string;
+}
+
+export interface ManagedInstallCredentials extends ManagedInstall {
+  /** Registry install token — the bearer for every service call. */
+  token: string;
+}
+
+export interface ManagedInstallOptions {
+  root?: string;
+  homeDir?: string;
+}
+
+type Reader = (root: string) => Promise<Omit<ManagedInstall, 'platform'> | null>;
+
+async function readSlackManagedInstall(root: string): Promise<Omit<ManagedInstall, 'platform'> | null> {
+  const job = await readSlackJob(root);
+  // A job that never reached the workspace (failed/expired) leaves no app
+  // the service would let into a channel; one still installing does — the
+  // create route answers with its own 409 until the install lands.
+  if (job && job.app?.appId && !['failed', 'expired'].includes(job.status)) {
+    return {
+      serviceBase: job.serviceBase || DEFAULT_SLACK_SERVICE,
+      appId: job.app.appId,
+      ...(job.app.botToken ? { botToken: job.app.botToken } : {}),
+    };
+  }
+  const journal = await readJson<Journal>(path.join(root, 'data/community-portal.json'));
+  const saved = journal?.slackSetup;
+  if (saved?.app?.appId) {
+    return {
+      serviceBase: saved.serviceBase || DEFAULT_SLACK_SERVICE,
+      appId: saved.app.appId,
+      ...(saved.app.botToken ? { botToken: saved.app.botToken } : {}),
+    };
+  }
+  return null;
+}
+
+/** The portal's managed-install records, by platform. */
+const readers: Record<string, Reader> = { slack: readSlackManagedInstall };
+
+/** The managed app this checkout installed on `platform`, or null when there is none. */
+export async function managedInstall(
+  platform: string,
+  { root = process.cwd() }: ManagedInstallOptions = {},
+): Promise<ManagedInstall | null> {
+  const read = readers[platform];
+  if (!read) return null;
+  const install = await read(root);
+  return install ? { platform, ...install } : null;
+}
+
+/** Install + bearer, or null when either half is missing. */
+export async function managedInstallCredentials(
+  platform: string,
+  { root = process.cwd(), homeDir }: ManagedInstallOptions = {},
+): Promise<ManagedInstallCredentials | null> {
+  const install = await managedInstall(platform, { root });
+  if (!install) return null;
+  const identity = await readInstallIdentity(homeDir ? { homeDir } : {});
+  if (!identity) return null;
+  return { ...install, token: identity.token };
+}

--- a/src/modules/community-portal/surface/module.test.ts
+++ b/src/modules/community-portal/surface/module.test.ts
@@ -1,0 +1,358 @@
+/**
+ * The module against the real composed tree with a placeholder platform:
+ * a platform that registered its half and has a managed install gets a
+ * session surface registered under its channel type; `sandboxes new` then
+ * opens a surface at the (fake) service with the sandbox's terminal address,
+ * a freshly bound surface and `remote enable` announce the address on the
+ * member row, `sandboxes surface status | archive` reach the service, and a
+ * platform without an install — or a service that says unavailable — leaves
+ * the sandbox plain. Nothing platform-specific is in play.
+ */
+import fs from 'node:fs';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ROOT = vi.hoisted(() => `/tmp/nanoclaw-test-surface-module-${process.pid}`);
+
+vi.mock('../../../container-runner.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../../container-runner.js')>();
+  return { ...orig, wakeContainer: vi.fn(async (): Promise<boolean> => false) };
+});
+vi.mock('../../../drivers/index.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../../drivers/index.js')>();
+  return { ...orig, getSessionDriver: vi.fn() };
+});
+vi.mock('../../../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../config.js')>();
+  return { ...actual, DATA_DIR: `${ROOT}/data`, GROUPS_DIR: `${ROOT}/groups` };
+});
+
+import { dispatch } from '../../../cli/dispatch.js';
+import type { CallerContext, RequestFrame, ResponseFrame } from '../../../cli/frame.js';
+import { fireRemoteAccessChanged } from '../../../code-mode/hooks.js';
+import { assertSandboxHook, assertSandboxVerb, assertSurfaceRegistered } from '../../../code-mode/surface/contract.js';
+import { insertSessionSurface } from '../../../code-mode/surface/db.js';
+import {
+  createSessionSurfaceRuntime,
+  getSessionSurfaceByGroup,
+  setSessionSurfaceRuntime,
+} from '../../../code-mode/surface/index.js';
+import { resetSessionSurfacesForTesting } from '../../../code-mode/surface/registry.js';
+import { closeDb, initTestDb, runMigrations } from '../../../db/index.js';
+import { getMessagingGroupByPlatform } from '../../../db/messaging-groups.js';
+import { getSessionDriver } from '../../../drivers/index.js';
+import type { SessionEventsDriver } from '../../../drivers/session-events.js';
+import '../../../cli/resources/sandboxes.js';
+import '../../../code-mode/index.js';
+import '../index.js';
+import {
+  activateSurfaces,
+  activeSurfacePlatforms,
+  deactivateSurfaces,
+  registerSurfacePlatform,
+  setSurfaceModuleDeps,
+  SURFACE_ADDRESS_HOOK,
+} from './index.js';
+import { resetSurfacePlatformsForTesting } from './platforms.js';
+
+const HOST: CallerContext = { caller: 'host' };
+interface Seen {
+  method: string;
+  route: string;
+  authorization?: string;
+  body: unknown;
+}
+let server: Server;
+let origin: string;
+let home: string;
+const seen: Seen[] = [];
+const answers: Record<string, { status: number; body: unknown }> = {};
+
+async function serve(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  let text = '';
+  for await (const chunk of req) text += chunk;
+  const route = new URL(req.url ?? '/', origin).pathname;
+  seen.push({
+    method: req.method ?? '',
+    route,
+    authorization: req.headers.authorization,
+    body: text ? JSON.parse(text) : undefined,
+  });
+  const answer = answers[`${req.method} ${route}`] ?? answers[route] ?? { status: 200, body: { ok: true } };
+  res.setHeader('content-type', 'application/json');
+  res.writeHead(answer.status);
+  res.end(JSON.stringify(answer.body));
+}
+
+function call(command: string, args: Record<string, unknown> = {}): Promise<ResponseFrame> {
+  const req: RequestFrame = { id: `r-${Math.random().toString(36).slice(2, 8)}`, command, args };
+  return dispatch(req, HOST);
+}
+function dataOf<T>(res: ResponseFrame): T {
+  if (!res.ok) throw new Error(`expected ok, got: ${res.error.message}`);
+  return res.data as T;
+}
+
+/** A placeholder platform: spells `chat:<id>`, knows its bot, keeps its own install record. */
+function chatPlatform(install: { serviceBase: string; appId: string } | null) {
+  return {
+    spell: (id: string) => ({ platformId: `chat:${id}`, instance: 'chat' }),
+    botIdentity: async () => ({ botUserId: 'U0BOT' }),
+    install: async () => (install ? { platform: 'chat', ...install } : null),
+  };
+}
+
+const door = { enabled: true, name: 'alice', host: 'alice.example.test' };
+
+beforeEach(async () => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+  fs.mkdirSync(path.join(ROOT, 'groups'), { recursive: true });
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'nc-surface-home-'));
+  fs.mkdirSync(path.join(home, '.config/nanoclaw'), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(
+    path.join(home, '.config/nanoclaw/account.json'),
+    JSON.stringify({ version: 1, api: 'https://registry.example.test', account_id: 'acct-1', token: 'tok' }),
+    { mode: 0o600 },
+  );
+  fs.writeFileSync(path.join(home, '.config/nanoclaw/host-id'), 'install-1\n', { mode: 0o600 });
+  seen.length = 0;
+  for (const key of Object.keys(answers)) delete answers[key];
+  server = createServer((req, res) => void serve(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no port');
+  origin = `http://127.0.0.1:${address.port}`;
+  await runMigrations(await initTestDb());
+  vi.mocked(getSessionDriver).mockReturnValue({
+    kind: 'fake-container',
+    listSessions: vi.fn(async () => []),
+    watchSessions: () => ({ stop: () => {} }),
+  } as unknown as SessionEventsDriver);
+  resetSessionSurfacesForTesting();
+  resetSurfacePlatformsForTesting();
+  setSurfaceModuleDeps({ homeDir: home, doorState: async () => door });
+});
+
+afterEach(async () => {
+  setSessionSurfaceRuntime(null);
+  deactivateSurfaces();
+  resetSessionSurfacesForTesting();
+  resetSurfacePlatformsForTesting();
+  setSurfaceModuleDeps(null);
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await closeDb();
+  fs.rmSync(ROOT, { recursive: true, force: true });
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe('registrations', () => {
+  it('registers the address hooks and the surface verbs on the real tree', () => {
+    expect(() => assertSandboxHook('bound', SURFACE_ADDRESS_HOOK)).not.toThrow();
+    expect(() => assertSandboxHook('remote-access-changed', SURFACE_ADDRESS_HOOK)).not.toThrow();
+    expect(() => assertSandboxVerb('surface status')).not.toThrow();
+    expect(() => assertSandboxVerb('surface archive')).not.toThrow();
+    expect(() => assertSandboxVerb('surface enable')).not.toThrow();
+    expect(() => assertSandboxVerb('surface disable')).not.toThrow();
+  });
+
+  it('offers a surface only for a platform with a managed install, and hears of a platform registered later', async () => {
+    registerSurfacePlatform('chat', chatPlatform({ serviceBase: origin, appId: 'A1' }));
+    registerSurfacePlatform('other', chatPlatform(null));
+    expect(await activateSurfaces()).toEqual(['chat']);
+    expect(() => assertSurfaceRegistered('chat')).not.toThrow();
+    expect(() => assertSurfaceRegistered('other')).toThrow(/no session surface/);
+    registerSurfacePlatform('late', {
+      ...chatPlatform({ serviceBase: origin, appId: 'A2' }),
+      channelType: 'late-chat',
+    });
+    await vi.waitFor(() => expect(activeSurfacePlatforms()).toEqual(['chat', 'late']));
+    expect(() => assertSurfaceRegistered('late-chat')).not.toThrow();
+  });
+});
+
+describe('a sandbox on a host that serves a surface', () => {
+  it('opens the surface at the service with its address, wires it, announces on bind and after remote enable, and archives', async () => {
+    registerSurfacePlatform('chat', chatPlatform({ serviceBase: origin, appId: 'A1' }));
+    await activateSurfaces();
+    answers['POST /v1/code-channels'] = {
+      status: 201,
+      body: { channelId: 'C1', sessionId: 'x', status: 'active', created: true },
+    };
+
+    const { id } = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't1', 'no-attach': true }));
+    const create = seen.find((r) => r.route === '/v1/code-channels');
+    expect(create).toEqual({
+      method: 'POST',
+      route: '/v1/code-channels',
+      authorization: 'Bearer tok',
+      body: {
+        appId: 'A1',
+        title: 't1',
+        botUserId: 'U0BOT',
+        sandboxName: 't1',
+        terminalAddress: 't1.alice.example.test',
+        sessionId: id,
+      },
+    });
+    const row = (await getSessionSurfaceByGroup(id))!;
+    expect(row).toMatchObject({ provider: 'chat', surface_id: 'C1', title: 't1' });
+    expect(await getMessagingGroupByPlatform('chat', 'chat:C1', 'chat')).toBeTruthy();
+    // The bound hook told the surface the address on the member row.
+    await vi.waitFor(() =>
+      expect(seen.find((r) => r.route === '/v1/code-channels/C1/members/U0BOT')).toMatchObject({
+        method: 'PUT',
+        body: { sandboxName: 't1', terminalAddress: 't1.alice.example.test' },
+      }),
+    );
+
+    // `remote enable` (or a rename) sweeps every open surface.
+    const before = seen.filter((r) => r.route === '/v1/code-channels/C1/members/U0BOT').length;
+    await fireRemoteAccessChanged({ enabled: true, name: 'alice', host: 'alice.example.test' });
+    await vi.waitFor(() =>
+      expect(seen.filter((r) => r.route === '/v1/code-channels/C1/members/U0BOT').length).toBe(before + 1),
+    );
+
+    answers['GET /v1/code-channels/C1'] = {
+      status: 200,
+      body: {
+        channelId: 'C1',
+        sessionId: id,
+        status: 'processing',
+        members: [{ botUserId: 'U0BOT', role: 'owner', sandboxName: 't1', terminalAddress: 't1.alice.example.test' }],
+        views: [{ viewKey: 'diff', type: 'diff' }],
+      },
+    };
+    const status = await call('sandboxes-surface-status', { id: 't1' });
+    expect(dataOf<{ status: string; members: unknown[] }>(status)).toMatchObject({
+      provider: 'chat',
+      surfaceId: 'C1',
+      status: 'processing',
+      members: [{ id: 'U0BOT', role: 'owner', sandbox: 't1', terminalAddress: 't1.alice.example.test' }],
+    });
+    expect(status.ok && status.human).toContain('ssh t1.alice.example.test');
+
+    answers['POST /v1/code-channels/C1/archive'] = {
+      status: 200,
+      body: { channelId: 'C1', sessionId: id, status: 'closed', archived: true, archivedAt: 't' },
+    };
+    const archived = await call('sandboxes-surface-archive', { id: 't1', summary: 'done' });
+    expect(dataOf<{ archived: true }>(archived).archived).toBe(true);
+    expect(seen.at(-1)).toMatchObject({ route: '/v1/code-channels/C1/archive', body: { summary: 'done' } });
+    expect((await getSessionSurfaceByGroup(id))!.archived_at).toBeTruthy();
+  });
+
+  it('leaves the sandbox plain when the service says unavailable, and when no platform has an install', async () => {
+    registerSurfacePlatform('chat', chatPlatform({ serviceBase: origin, appId: 'A1' }));
+    await activateSurfaces();
+    answers['POST /v1/code-channels'] = { status: 409, body: { error: 'code_channels_unavailable', message: 'no' } };
+    const { id } = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't2', 'no-attach': true }));
+    expect(await getSessionSurfaceByGroup(id)).toBeUndefined();
+    expect(dataOf<{ surface: null }>(await call('sandboxes-surface-status', { id: 't2' })).surface).toBeNull();
+
+    deactivateSurfaces();
+    resetSessionSurfacesForTesting();
+    resetSurfacePlatformsForTesting();
+    registerSurfacePlatform('chat', chatPlatform(null));
+    expect(await activateSurfaces()).toEqual([]);
+    const plain = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't3', 'no-attach': true }));
+    expect(await getSessionSurfaceByGroup(plain.id)).toBeUndefined();
+    expect(seen.filter((r) => r.route === '/v1/code-channels')).toHaveLength(1);
+  });
+});
+
+describe('a binding restored before this module activates', () => {
+  it('waits without a tick or a write, then flows status to the service once the platform registers', async () => {
+    // No platform yet: the sandbox is created plain, and the row below is what
+    // a previous host process wrote for it.
+    const { id } = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't5', 'no-attach': true }));
+    await insertSessionSurface({
+      agent_group_id: id,
+      provider: 'chat',
+      surface_id: 'C9',
+      session_id: id,
+      messaging_group_id: null,
+      title: 't5',
+      last_status: null,
+      last_status_at: null,
+      stopped_at: null,
+      last_turn_seq: 0,
+      events_cursor: null,
+      archived_at: null,
+    });
+    const runtime = createSessionSurfaceRuntime({ watchEvents: false });
+    setSessionSurfaceRuntime(runtime);
+    await runtime.start();
+    expect(runtime.isWaiting(id)).toBe(true);
+    await runtime.tick();
+    expect(seen.filter((r) => r.route.startsWith('/v1/code-channels'))).toHaveLength(0);
+    expect((await getSessionSurfaceByGroup(id))!.last_status).toBeNull();
+
+    // The platform's module comes up after the host restored its bindings.
+    registerSurfacePlatform('chat', chatPlatform({ serviceBase: origin, appId: 'A1' }));
+    expect(await activateSurfaces()).toEqual(['chat']);
+    await vi.waitFor(() => expect(runtime.has(id)).toBe(true));
+    expect(runtime.isWaiting(id)).toBe(false);
+    await runtime.tick();
+    const statuses = () => seen.filter((r) => r.route === '/v1/code-channels/C9/status');
+    expect(statuses()).toEqual([
+      {
+        method: 'POST',
+        route: '/v1/code-channels/C9/status',
+        authorization: 'Bearer tok',
+        body: { status: 'suspended' },
+      },
+    ]);
+    expect((await getSessionSurfaceByGroup(id))!.last_status).toBe('suspended');
+    // The next tick is coalesced: the same status is not sent twice.
+    await runtime.tick();
+    expect(statuses()).toHaveLength(1);
+    await runtime.stop();
+  });
+});
+
+describe('sandboxes surface enable | disable', () => {
+  it('disable keeps new sandboxes plain and open surfaces mirrored, persists across activation, enable turns it back on', async () => {
+    registerSurfacePlatform('chat', chatPlatform({ serviceBase: origin, appId: 'A1' }));
+    await activateSurfaces();
+    answers['POST /v1/code-channels'] = {
+      status: 201,
+      body: { channelId: 'C1', sessionId: 'x', status: 'active', created: true },
+    };
+    const first = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't6', 'no-attach': true }));
+    expect((await getSessionSurfaceByGroup(first.id))!.surface_id).toBe('C1');
+
+    const disabled = await call('sandboxes-surface-disable');
+    expect(dataOf<{ autoOpen: boolean }>(disabled).autoOpen).toBe(false);
+    expect(disabled.ok && disabled.human).toMatch(/no chat surface on this host/);
+    expect(JSON.parse(fs.readFileSync(path.join(ROOT, 'data/session-surface.json'), 'utf8'))).toMatchObject({
+      version: 1,
+      autoOpen: false,
+    });
+    const creates = () => seen.filter((r) => r.route === '/v1/code-channels').length;
+    const before = creates();
+    const plain = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't7', 'no-attach': true }));
+    expect(await getSessionSurfaceByGroup(plain.id)).toBeUndefined();
+    expect(creates()).toBe(before);
+    // The surface opened before stays bound; the setting archives nothing.
+    expect((await getSessionSurfaceByGroup(first.id))!.archived_at).toBeNull();
+
+    // A fresh activation (a host restart) reads the same setting.
+    deactivateSurfaces();
+    resetSessionSurfacesForTesting();
+    expect(await activateSurfaces()).toEqual(['chat']);
+    const still = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't8', 'no-attach': true }));
+    expect(await getSessionSurfaceByGroup(still.id)).toBeUndefined();
+
+    const enabled = await call('sandboxes-surface-enable');
+    expect(dataOf<{ autoOpen: boolean }>(enabled).autoOpen).toBe(true);
+    answers['POST /v1/code-channels'] = {
+      status: 201,
+      body: { channelId: 'C2', sessionId: 'y', status: 'active', created: true },
+    };
+    const again = dataOf<{ id: string }>(await call('sandboxes-new', { name: 't9', 'no-attach': true }));
+    expect((await getSessionSurfaceByGroup(again.id))!.surface_id).toBe('C2');
+  });
+});

--- a/src/modules/community-portal/surface/platforms.ts
+++ b/src/modules/community-portal/surface/platforms.ts
@@ -1,0 +1,79 @@
+/**
+ * The platform registry — the one thing a chat platform tells this module.
+ *
+ * The provider here talks to the service; it knows no platform API. What
+ * it cannot know on its own is how the platform's adapter spells a
+ * conversation as a messaging_groups row (so the binding writes the row
+ * the adapter's inbound path resolves) and, optionally, which bot user
+ * this host is on the platform (so a member update names the right
+ * member). A platform's module registers that half with
+ * `registerSurfacePlatform(kind, half)`; the module then offers a session
+ * surface for that platform on every host with a managed install for it.
+ */
+import { log } from '../../../log.js';
+import type { SurfaceSpelling } from '../../../code-mode/surface/types.js';
+import type { ManagedInstall } from './install.js';
+
+export interface BotIdentity {
+  botUserId: string;
+  teamId?: string;
+}
+
+export interface SurfacePlatform {
+  /** The adapter's channel type; defaults to the platform kind. */
+  channelType?: string;
+  /** The adapter instance the surface rows belong to; defaults to the channel type. */
+  instance?: string;
+  /** How the adapter spells a conversation id as a messaging_groups platform id. */
+  spell(conversationId: string): SurfaceSpelling;
+  /**
+   * Where the managed install for this platform is recorded, when it is
+   * not one the portal keeps (install.ts `managedInstall(kind)` is the
+   * default). Null: no managed app, so no surface.
+   */
+  install?(): Promise<ManagedInstall | null>;
+  /**
+   * This host's own bot on the platform, when the platform half can name
+   * it; null (or absent) lets the service name it from its own record.
+   * Consulted at open and at a member update, never a gate.
+   */
+  botIdentity?(install: ManagedInstall): Promise<BotIdentity | null>;
+}
+
+const platforms = new Map<string, SurfacePlatform>();
+const listeners = new Set<(kind: string, platform: SurfacePlatform) => void>();
+
+/** Undo the registration. */
+export type Unregister = () => void;
+
+export function registerSurfacePlatform(kind: string, platform: SurfacePlatform): Unregister {
+  if (platforms.has(kind)) {
+    log.error('Surface platform refused: already registered', { platform: kind });
+    return () => {};
+  }
+  platforms.set(kind, platform);
+  for (const listener of [...listeners]) listener(kind, platform);
+  return () => {
+    if (platforms.get(kind) === platform) platforms.delete(kind);
+  };
+}
+
+export function getSurfacePlatform(kind: string): SurfacePlatform | undefined {
+  return platforms.get(kind);
+}
+
+export function listSurfacePlatforms(): Array<{ kind: string; platform: SurfacePlatform }> {
+  return [...platforms.entries()].map(([kind, platform]) => ({ kind, platform }));
+}
+
+/** Hear of platforms registered after this module started. */
+export function onSurfacePlatformRegistered(listener: (kind: string, platform: SurfacePlatform) => void): Unregister {
+  listeners.add(listener);
+  return () => void listeners.delete(listener);
+}
+
+/** Test seam. */
+export function resetSurfacePlatformsForTesting(): void {
+  platforms.clear();
+  listeners.clear();
+}

--- a/src/modules/community-portal/surface/provider.test.ts
+++ b/src/modules/community-portal/surface/provider.test.ts
@@ -1,0 +1,280 @@
+/**
+ * The provider against a fake service: what each contract method sends,
+ * how the service's answers become the contract's failure kinds, the
+ * archived-surface rebind, the events mapping, and a host with no install
+ * or a service that says "unavailable" answering null at open.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { SurfaceError, surfaceErrorKind } from '../../../code-mode/surface/types.js';
+import { SurfaceServiceClient } from './client.js';
+import type { ManagedInstallCredentials } from './install.js';
+import type { SurfacePlatform } from './platforms.js';
+import { createServiceSurfaceProvider, mapEvent } from './provider.js';
+
+interface Call {
+  method: string;
+  path: string;
+  body: unknown;
+}
+type Reply = { status: number; body: unknown };
+
+const BASE = 'https://chat-service.example.test';
+const CREDENTIALS: ManagedInstallCredentials = {
+  platform: 'chat',
+  serviceBase: BASE,
+  appId: 'A1',
+  token: 'tok-1',
+};
+const SANDBOX = { id: 'ag-1', name: 'box', folder: 'box' };
+const HANDLE = { surfaceId: 'C1', sessionId: 'ag-1' };
+
+function service(replies: Reply[]) {
+  const calls: Call[] = [];
+  const fetchFn = (async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push({
+      method: init?.method ?? 'GET',
+      path: String(input).slice(BASE.length),
+      body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+    });
+    const reply = replies.shift();
+    if (!reply) throw new Error(`unexpected call ${calls.at(-1)?.method} ${calls.at(-1)?.path}`);
+    return new Response(reply.body === undefined ? '' : JSON.stringify(reply.body), {
+      status: reply.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  return { calls, fetchFn };
+}
+
+function provider(
+  replies: Reply[],
+  over: {
+    credentials?: ManagedInstallCredentials | null;
+    platform?: Partial<SurfacePlatform>;
+    address?: { sandboxName: string; terminalAddress: string };
+  } = {},
+) {
+  const fake = service(replies);
+  const platform: SurfacePlatform = {
+    spell: (id) => ({ platformId: `chat:${id}`, instance: 'chat' }),
+    ...over.platform,
+  };
+  const p = createServiceSurfaceProvider({
+    kind: 'chat',
+    platform,
+    credentials: async () => (over.credentials === undefined ? CREDENTIALS : over.credentials),
+    clientFor: (c) => new SurfaceServiceClient({ serviceBase: c.serviceBase, token: c.token, fetch: fake.fetchFn }),
+    terminalAddress: async () => over.address,
+  });
+  return { provider: p, calls: fake.calls };
+}
+
+const channel = (extra: Record<string, unknown> = {}) => ({
+  status: 200,
+  body: { channelId: 'C1', sessionId: 'ag-1', status: 'active', ...extra },
+});
+
+describe('open', () => {
+  it('creates the surface for the sandbox with the bot identity and the terminal address, and spells it for the adapter', async () => {
+    const { provider: p, calls } = provider([channel({ created: true })], {
+      platform: { botIdentity: async () => ({ botUserId: 'U0BOT', teamId: 'T1' }) },
+      address: { sandboxName: 'box', terminalAddress: 'box.alice.example.test' },
+    });
+    expect(await p.open(SANDBOX, { title: 'box' })).toEqual({ surfaceId: 'C1', sessionId: 'ag-1' });
+    expect(calls[0]).toEqual({
+      method: 'POST',
+      path: '/v1/code-channels',
+      body: {
+        appId: 'A1',
+        title: 'box',
+        botUserId: 'U0BOT',
+        teamId: 'T1',
+        sandboxName: 'box',
+        terminalAddress: 'box.alice.example.test',
+        sessionId: 'ag-1',
+      },
+    });
+    expect(await p.spell('C1')).toEqual({ platformId: 'chat:C1', instance: 'chat' });
+  });
+
+  it('answers null without an install, and when the service says unavailable or has no channel to give', async () => {
+    const none = provider([], { credentials: null });
+    expect(await none.provider.open(SANDBOX, {})).toBeNull();
+    expect(none.calls).toHaveLength(0);
+    const off = provider([{ status: 409, body: { error: 'code_channels_unavailable', message: 'no' } }]);
+    expect(await off.provider.open(SANDBOX, {})).toBeNull();
+    const missing = provider([{ status: 404, body: { error: 'not_found', message: 'no route' } }]);
+    expect(await missing.provider.open(SANDBOX, {})).toBeNull();
+    // Anything else is the caller's to log; it is thrown.
+    const down = provider([{ status: 502, body: undefined }]);
+    await expect(down.provider.open(SANDBOX, {})).rejects.toThrow(/HTTP 502/);
+  });
+
+  it('binds an archived surface again under a suffixed session id', async () => {
+    const archivedAt = '2026-09-11T10:00:00.000Z';
+    const { provider: p, calls } = provider([
+      channel({ status: 'closed', archivedAt }),
+      {
+        status: 201,
+        body: { channelId: 'C2', sessionId: `ag-1.${Date.parse(archivedAt).toString(36)}`, status: 'active' },
+      },
+    ]);
+    expect(await p.open(SANDBOX, {})).toEqual({
+      surfaceId: 'C2',
+      sessionId: `ag-1.${Date.parse(archivedAt).toString(36)}`,
+    });
+    expect(calls.map((c) => (c.body as { sessionId: string }).sessionId)).toEqual([
+      'ag-1',
+      `ag-1.${Date.parse(archivedAt).toString(36)}`,
+    ]);
+  });
+
+  it('uses the address core hands it when the host cannot compose one', async () => {
+    const { provider: p, calls } = provider([channel()]);
+    await p.open({ ...SANDBOX, folder: 'Box' }, { terminalAddress: 'box.alice.example.test' });
+    expect(calls[0].body).toMatchObject({ sandboxName: 'box', terminalAddress: 'box.alice.example.test' });
+  });
+});
+
+describe('status, views, bar, commands, members', () => {
+  it('sends each to its route in the service’s vocabulary', async () => {
+    const { provider: p, calls } = provider([
+      channel({ status: 'processing', resumed: true }),
+      { status: 200, body: { channelId: 'C1', viewKey: 'diff', type: 'diff', views: 1 } },
+      { status: 200, body: { channelId: 'C1', viewKey: 'plan', type: 'block_kit', views: 2 } },
+      { status: 200, body: { channelId: 'C1', contextBarItems: [] } },
+      { status: 200, body: { channelId: 'C1', commands: 1 } },
+      channel({
+        members: [
+          { botUserId: 'U0A', role: 'owner', sandboxName: 'box' },
+          { botUserId: 'U0B', role: 'member' },
+        ],
+      }),
+      { status: 200, body: { channelId: 'C1', member: { botUserId: 'U0C', role: 'member' } } },
+      { status: 200, body: { channelId: 'C1', removed: true } },
+    ]);
+    await p.status(HANDLE, 'processing', { resume: true });
+    await p.view(HANDLE, { key: 'diff', type: 'diff', name: 'Changes', content: '--- a\n+++ b\n', headBranch: 'main' });
+    await p.view(HANDLE, { key: 'plan', type: 'blocks', content: '[]' });
+    await p.bar!(HANDLE, [{ key: 'terminal', label: 'ssh box.alice.example.test' }]);
+    await p.commands!(HANDLE, [{ name: 'terminal', description: 'the address' }]);
+    expect(await p.members!(HANDLE)).toEqual([
+      { id: 'U0A', name: 'box', role: 'owner' },
+      { id: 'U0B', role: 'member' },
+    ]);
+    await p.join!(HANDLE, { id: 'U0C', name: 'web' });
+    await p.leave!(HANDLE, { id: 'U0C' });
+    expect(calls.map((c) => [c.method, c.path, c.body])).toEqual([
+      ['POST', '/v1/code-channels/C1/status', { status: 'processing', resume: true }],
+      [
+        'PUT',
+        '/v1/code-channels/C1/views/diff',
+        { type: 'diff', name: 'Changes', content: '--- a\n+++ b\n', headBranch: 'main' },
+      ],
+      ['PUT', '/v1/code-channels/C1/views/plan', { type: 'block_kit', content: '[]' }],
+      [
+        'PUT',
+        '/v1/code-channels/C1/properties',
+        { contextBarItems: [{ key: 'terminal', label: 'ssh box.alice.example.test' }] },
+      ],
+      ['PUT', '/v1/code-channels/C1/commands', { commands: [{ name: 'terminal', description: 'the address' }] }],
+      ['GET', '/v1/code-channels/C1', undefined],
+      ['POST', '/v1/code-channels/C1/members', { botUserId: 'U0C', sandboxName: 'web' }],
+      ['DELETE', '/v1/code-channels/C1/members/U0C', undefined],
+    ]);
+  });
+
+  it('maps the service’s refusals onto the contract: stopped, gone, unavailable; the rest stays transient', async () => {
+    const kinds: Array<[number, string, string | undefined]> = [
+      [409, 'session_stopped', 'stopped'],
+      [404, 'not_found', 'gone'],
+      [409, 'already_archived', 'gone'],
+      [409, 'code_channels_disabled', 'unavailable'],
+      [503, 'busy', undefined],
+    ];
+    for (const [status, code, kind] of kinds) {
+      const { provider: p } = provider([{ status, body: { error: code, message: code } }]);
+      const err = await p.status(HANDLE, 'active').catch((e: unknown) => e);
+      expect(surfaceErrorKind(err)).toBe(kind);
+      if (kind) expect(err).toBeInstanceOf(SurfaceError);
+    }
+    // No install any more: every send is "unavailable" and core drops the binding from this process.
+    const none = provider([], { credentials: null });
+    expect(
+      surfaceErrorKind(
+        await none.provider.view(HANDLE, { key: 'diff', type: 'diff', content: 'x' }).catch((e: unknown) => e),
+      ),
+    ).toBe('unavailable');
+  });
+});
+
+describe('events and close', () => {
+  it('long-polls with the cursor and wait, and maps stop, command and member events', async () => {
+    const { provider: p, calls } = provider([
+      {
+        status: 200,
+        body: {
+          channelId: 'C1',
+          sessionId: 'ag-1',
+          status: 'stopped',
+          events: [
+            { cursor: 'E1', type: 'code_channel.stopped', channelId: 'C1', sessionId: 'ag-1', ts: 't1', user: 'U1' },
+            {
+              cursor: 'E2',
+              type: 'code_channel.stopped',
+              channelId: 'C1',
+              sessionId: 'ag-1',
+              ts: 't2',
+              threadTs: 'th',
+            },
+            {
+              cursor: 'E3',
+              type: 'code_channel.command',
+              channelId: 'C1',
+              sessionId: 'ag-1',
+              ts: 't3',
+              command: '/terminal',
+              text: '',
+              user: 'U1',
+            },
+            {
+              cursor: 'E4',
+              type: 'code_channel.member_joined',
+              channelId: 'C1',
+              sessionId: 'ag-1',
+              ts: 't4',
+              user: 'U0B',
+            },
+            { cursor: 'E5', type: 'code_channel.something_new', channelId: 'C1', sessionId: 'ag-1', ts: 't5' },
+          ],
+          cursor: 'E5',
+        },
+      },
+    ]);
+    const page = await p.events(HANDLE, 'E0', 10);
+    expect(calls[0].path).toBe('/v1/code-channels/C1/events?wait=10&since=E0');
+    expect(page).toEqual({
+      events: [
+        { type: 'stop', ts: 't1', user: 'U1' },
+        { type: 'stop', ts: 't2', threadId: 'th' },
+        { type: 'command', command: '/terminal', text: '', user: 'U1', ts: 't3' },
+        { type: 'member_joined', member: { id: 'U0B' } },
+      ],
+      cursor: 'E5',
+    });
+    expect(mapEvent({ cursor: 'x', type: 'unknown', channelId: 'C1', sessionId: 'ag-1', ts: 't' })).toBeUndefined();
+  });
+
+  it('archives with the summary, and treats an already archived or unknown surface as closed', async () => {
+    const { provider: p, calls } = provider([
+      { status: 200, body: { channelId: 'C1', sessionId: 'ag-1', status: 'closed', archived: true, archivedAt: 't' } },
+      { status: 409, body: { error: 'already_archived', message: 'archived' } },
+      { status: 409, body: { error: 'session_stopped', message: 'stopped' } },
+    ]);
+    await p.close(HANDLE, { summary: 'done' });
+    expect(calls[0]).toEqual({ method: 'POST', path: '/v1/code-channels/C1/archive', body: { summary: 'done' } });
+    await expect(p.close(HANDLE)).resolves.toBeUndefined();
+    expect(surfaceErrorKind(await p.close(HANDLE).catch((e: unknown) => e))).toBe('stopped');
+  });
+});

--- a/src/modules/community-portal/surface/provider.ts
+++ b/src/modules/community-portal/surface/provider.ts
@@ -1,0 +1,300 @@
+/**
+ * A SessionSurfaceProvider over the service: the platform-agnostic half of
+ * "a chat surface for a coding session" as a remote implementation.
+ *
+ * Core (code-mode/surface) decides WHEN — open at sandbox creation, status
+ * on every mapper tick, the diff view after a turn, the long-poll, the
+ * interrupt on a Stop, the archive — and hands this provider its own ids.
+ * The provider turns each call into one service route (client.ts) and
+ * maps the service's answers onto the contract's failure vocabulary:
+ * "unavailable" (no surface for this host: `open` answers null, anything
+ * else throws SurfaceError 'unavailable'), "gone" (archived or unknown) and
+ * "stopped" (the user pressed Stop). Everything platform-shaped — how a
+ * conversation id is spelled for the adapter, which bot this host is — is
+ * the registered platform half's (platforms.ts).
+ */
+import type { SandboxGroup } from '../../../code-mode/hooks.js';
+import {
+  SurfaceError,
+  type BoardState,
+  type SessionSurfaceProvider,
+  type SurfaceBarItem,
+  type SurfaceBoardOp,
+  type SurfaceCommandSpec,
+  type SurfaceEvent,
+  type SurfaceEventsPage,
+  type SurfaceHandle,
+  type SurfaceMember,
+  type SurfaceSpelling,
+  type SurfaceStatus,
+  type SurfaceView,
+} from '../../../code-mode/surface/types.js';
+import { log } from '../../../log.js';
+import {
+  COMMAND_EVENT,
+  isChannelGone,
+  isNotFound,
+  isSessionStopped,
+  isUnavailable,
+  STOPPED_EVENT,
+  SurfaceServiceError,
+  type ChannelEvent,
+  type ChannelRecord,
+  type SurfaceServiceClient,
+  type ViewType,
+} from './client.js';
+import type { ManagedInstallCredentials } from './install.js';
+import type { BotIdentity, SurfacePlatform } from './platforms.js';
+import type { TerminalAddressFields } from './terminal-address.js';
+
+/** Member events the service relays, mapped onto the contract's. */
+export const MEMBER_JOINED_EVENT = 'code_channel.member_joined';
+export const MEMBER_LEFT_EVENT = 'code_channel.member_left';
+
+export interface ServiceSurfaceProviderDeps {
+  /** The platform kind the provider serves (the registry key). */
+  kind: string;
+  platform: SurfacePlatform;
+  /** The install and bearer, read on every open (an install may land later); null = no surface. */
+  credentials(): Promise<ManagedInstallCredentials | null>;
+  /** A client for the credentials' service (cached by the caller). */
+  clientFor(credentials: ManagedInstallCredentials): SurfaceServiceClient;
+  /** The address a terminal reaches a sandbox at on this host, when it has one. */
+  terminalAddress(sandbox: string): Promise<TerminalAddressFields | undefined>;
+  /** The host's setting: open a surface for a new sandbox at all (setting.ts). Absent = yes. */
+  autoOpen?(): Promise<boolean>;
+}
+
+/** The contract's failure kinds for the service's answers; anything else is transient and rethrown as is. */
+export function mapServiceError(error: unknown): unknown {
+  if (isSessionStopped(error)) return new SurfaceError('stopped', (error as Error).message, { cause: error });
+  if (isChannelGone(error)) return new SurfaceError('gone', (error as Error).message, { cause: error });
+  if (isUnavailable(error)) return new SurfaceError('unavailable', (error as Error).message, { cause: error });
+  return error;
+}
+
+const VIEW_TYPES: Record<SurfaceView['type'], ViewType> = {
+  diff: 'diff',
+  html: 'html',
+  blocks: 'block_kit',
+  canvas: 'canvas',
+};
+
+/** One service event as the contract names it; undefined for a type this host does not know. */
+export function mapEvent(event: ChannelEvent): SurfaceEvent | undefined {
+  switch (event.type) {
+    case STOPPED_EVENT:
+      return {
+        type: 'stop',
+        ...(event.ts ? { ts: event.ts } : {}),
+        ...(event.user ? { user: event.user } : {}),
+        ...(event.threadTs ? { threadId: event.threadTs } : {}),
+      };
+    case COMMAND_EVENT:
+      return {
+        type: 'command',
+        command: event.command ?? '',
+        ...(event.text !== undefined ? { text: event.text } : {}),
+        ...(event.user ? { user: event.user } : {}),
+        ...(event.ts ? { ts: event.ts } : {}),
+      };
+    case MEMBER_JOINED_EVENT:
+      return { type: 'member_joined', member: { id: event.user ?? '' } };
+    case MEMBER_LEFT_EVENT:
+      return { type: 'member_left', member: { id: event.user ?? '' } };
+    default:
+      return undefined;
+  }
+}
+
+function memberOf(member: NonNullable<ChannelRecord['members']>[number]): SurfaceMember {
+  return {
+    id: member.botUserId,
+    ...(member.sandboxName ? { name: member.sandboxName } : {}),
+    ...(member.role ? { role: member.role } : {}),
+  };
+}
+
+export function createServiceSurfaceProvider(deps: ServiceSurfaceProviderDeps): SessionSurfaceProvider {
+  const { kind, platform } = deps;
+
+  async function client(): Promise<SurfaceServiceClient> {
+    const credentials = await deps.credentials();
+    if (!credentials) {
+      throw new SurfaceError('unavailable', `no managed install for ${kind} on this host`);
+    }
+    return deps.clientFor(credentials);
+  }
+
+  async function identity(credentials: ManagedInstallCredentials): Promise<BotIdentity | null> {
+    if (!platform.botIdentity) return null;
+    try {
+      return await platform.botIdentity(credentials);
+    } catch (err) {
+      log.warn('Session surface: bot identity lookup failed — the service names the bot instead', { kind, err });
+      return null;
+    }
+  }
+
+  async function address(sandbox: SandboxGroup, given?: string): Promise<TerminalAddressFields | undefined> {
+    try {
+      const found = await deps.terminalAddress(sandbox.folder);
+      if (found) return found;
+    } catch (err) {
+      log.warn('Session surface: terminal address lookup failed — opening without it', { kind, err });
+    }
+    return given ? { terminalAddress: given, sandboxName: sandbox.folder.toLowerCase() } : undefined;
+  }
+
+  /** The service keys idempotency on the session id and refuses a new channel for an archived one. */
+  function isArchived(record: ChannelRecord): boolean {
+    return Boolean(record.archivedAt) || record.status === 'closed';
+  }
+
+  const provider: SessionSurfaceProvider = {
+    async spell(surfaceId): Promise<SurfaceSpelling> {
+      return platform.spell(surfaceId);
+    },
+
+    async open(sandbox, options): Promise<SurfaceHandle | null> {
+      if (deps.autoOpen && !(await deps.autoOpen())) {
+        log.info('Session surface: opening surfaces is disabled on this host — sandbox continues without one', {
+          kind,
+          sandbox: sandbox.folder,
+        });
+        return null;
+      }
+      const credentials = await deps.credentials();
+      if (!credentials) {
+        log.info('Session surface: no managed install on this host — sandbox continues without one', { kind });
+        return null;
+      }
+      const service = deps.clientFor(credentials);
+      const who = await identity(credentials);
+      const fields = await address(sandbox, options.terminalAddress);
+      const body = {
+        appId: credentials.appId,
+        title: options.title ?? sandbox.folder,
+        ...(who ? { botUserId: who.botUserId, ...(who.teamId ? { teamId: who.teamId } : {}) } : {}),
+        ...(fields ?? {}),
+      };
+      try {
+        let { channel } = await service.create({ ...body, sessionId: sandbox.id });
+        if (isArchived(channel)) {
+          // A sandbox whose surface was archived binds again under a suffixed
+          // session id; a retry after a crash converges on the same one.
+          const suffix = Date.parse(channel.archivedAt ?? '') || Date.now();
+          ({ channel } = await service.create({ ...body, sessionId: `${sandbox.id}.${suffix.toString(36)}` }));
+        }
+        return { surfaceId: channel.channelId, sessionId: channel.sessionId };
+      } catch (error) {
+        if (isUnavailable(error) || isNotFound(error)) {
+          log.info('Session surface not available from the service — sandbox continues without one', {
+            kind,
+            reason: error instanceof SurfaceServiceError ? error.code : String(error),
+          });
+          return null;
+        }
+        throw error;
+      }
+    },
+
+    async status(handle, status: SurfaceStatus, options = {}): Promise<void> {
+      try {
+        await (await client()).setStatus(handle.surfaceId, status, options);
+      } catch (error) {
+        throw mapServiceError(error);
+      }
+    },
+
+    async view(handle, view: SurfaceView): Promise<void> {
+      try {
+        await (
+          await client()
+        ).putView(handle.surfaceId, view.key, {
+          type: VIEW_TYPES[view.type],
+          ...(view.name ? { name: view.name } : {}),
+          content: view.content,
+          ...(view.headBranch ? { headBranch: view.headBranch } : {}),
+        });
+      } catch (error) {
+        throw mapServiceError(error);
+      }
+    },
+
+    async bar(handle, items: SurfaceBarItem[]): Promise<void> {
+      try {
+        await (await client()).putProperties(handle.surfaceId, { contextBarItems: items });
+      } catch (error) {
+        throw mapServiceError(error);
+      }
+    },
+
+    async commands(handle, specs: SurfaceCommandSpec[]): Promise<void> {
+      try {
+        await (await client()).setCommands(handle.surfaceId, specs);
+      } catch (error) {
+        throw mapServiceError(error);
+      }
+    },
+
+    async members(handle): Promise<SurfaceMember[]> {
+      try {
+        return (await (await client()).members(handle.surfaceId)).map(memberOf);
+      } catch (error) {
+        throw mapServiceError(error);
+      }
+    },
+
+    async join(handle, member: SurfaceMember): Promise<void> {
+      try {
+        await (
+          await client()
+        ).addMember(handle.surfaceId, {
+          botUserId: member.id,
+          ...(member.name ? { sandboxName: member.name } : {}),
+        });
+      } catch (error) {
+        throw mapServiceError(error);
+      }
+    },
+
+    async leave(handle, member: SurfaceMember): Promise<void> {
+      try {
+        await (await client()).removeMember(handle.surfaceId, member.id);
+      } catch (error) {
+        throw mapServiceError(error);
+      }
+    },
+
+    async events(handle, cursor, waitSec, signal): Promise<SurfaceEventsPage> {
+      let page;
+      try {
+        page = await (await client()).events(handle.surfaceId, { since: cursor, wait: waitSec, signal });
+      } catch (error) {
+        throw mapServiceError(error);
+      }
+      const events: SurfaceEvent[] = [];
+      for (const event of page.events) {
+        const mapped = mapEvent(event);
+        if (mapped) events.push(mapped);
+        else log.debug('Session surface: service event not known to this host', { kind, type: event.type });
+      }
+      return { events, cursor: page.cursor };
+    },
+
+    async close(handle, options = {}): Promise<void> {
+      try {
+        await (await client()).archive(handle.surfaceId, options);
+      } catch (error) {
+        // Already archived or unknown: the wrap-up is done either way.
+        if (isChannelGone(error)) return;
+        throw mapServiceError(error);
+      }
+    },
+  };
+  return provider;
+}
+
+/** The board is not carried by the service yet; the contract leaves it optional and core never calls an absent method. */
+export type { BoardState, SurfaceBoardOp };

--- a/src/modules/community-portal/surface/setting.ts
+++ b/src/modules/community-portal/surface/setting.ts
@@ -1,0 +1,39 @@
+/**
+ * The host's one setting for session surfaces: whether a new sandbox gets
+ * a chat surface opened for it automatically. On by default; `ncl sandboxes
+ * surface disable` turns it off for this host and keeps it off across
+ * restarts, `surface enable` turns it back on. Existing surfaces are not
+ * touched either way — the setting only decides what `sandboxes new` does.
+ * Journaled at `data/session-surface.json` (mode 0600); a missing file is
+ * the default.
+ */
+import path from 'node:path';
+
+import { readJson, writePrivate } from '../../../community-portal/private-file.js';
+import { DATA_DIR } from '../../../config.js';
+
+export interface SurfaceSetting {
+  version: 1;
+  /** Open a surface for every new sandbox the service offers one for. */
+  autoOpen: boolean;
+  updatedAt: string;
+}
+
+export const SURFACE_SETTING_FILE = path.join(DATA_DIR, 'session-surface.json');
+
+export async function readSurfaceSetting(file = SURFACE_SETTING_FILE): Promise<SurfaceSetting> {
+  const saved = await readJson<SurfaceSetting>(file);
+  if (saved && saved.version === 1 && typeof saved.autoOpen === 'boolean') return saved;
+  return { version: 1, autoOpen: true, updatedAt: '' };
+}
+
+/** Whether `sandboxes new` opens a surface on this host. */
+export async function surfaceAutoOpen(file = SURFACE_SETTING_FILE): Promise<boolean> {
+  return (await readSurfaceSetting(file)).autoOpen;
+}
+
+export async function setSurfaceAutoOpen(autoOpen: boolean, file = SURFACE_SETTING_FILE): Promise<SurfaceSetting> {
+  const setting: SurfaceSetting = { version: 1, autoOpen, updatedAt: new Date().toISOString() };
+  await writePrivate(file, setting);
+  return setting;
+}

--- a/src/modules/community-portal/surface/terminal-address.test.ts
+++ b/src/modules/community-portal/surface/terminal-address.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Telling a surface where a terminal reaches its sandbox: the member update
+ * keyed by the identity or, failing that, by the bot the channel record
+ * names; a refusal is false, never a throw; and the sweep over every open
+ * binding counts what it announced, skipped and failed.
+ */
+import { describe, expect, it, vi, type Mock } from 'vitest';
+
+import type { SessionSurfaceRow } from '../../../code-mode/surface/db.js';
+import type { ChannelRecord, SurfaceServiceClient } from './client.js';
+import { announceTerminalAddress, announceTerminalAddresses, ownerBotUserId } from './terminal-address.js';
+
+const FIELDS = { sandboxName: 'api', terminalAddress: 'api.alice.example.test' };
+
+type Client = Pick<SurfaceServiceClient, 'get' | 'updateMember'>;
+
+function row(over: Partial<SessionSurfaceRow> = {}): SessionSurfaceRow {
+  return {
+    agent_group_id: 'ag-1',
+    provider: 'chat',
+    surface_id: 'C1',
+    session_id: 'ag-1',
+    messaging_group_id: 'mg-1',
+    title: 'api',
+    last_status: null,
+    last_status_at: null,
+    stopped_at: null,
+    last_turn_seq: 0,
+    events_cursor: null,
+    archived_at: null,
+    created_at: '2026-09-11T10:00:00.000Z',
+    updated_at: '2026-09-11T10:00:00.000Z',
+    ...over,
+  };
+}
+
+function fakeClient(record: Partial<ChannelRecord> = {}): {
+  get: Mock<Client['get']>;
+  updateMember: Mock<Client['updateMember']>;
+} {
+  const get: Mock<Client['get']> = vi.fn(async (channelId) => ({
+    channelId,
+    sessionId: 'ag-1',
+    status: 'active',
+    ...record,
+  }));
+  const updateMember: Mock<Client['updateMember']> = vi.fn(async (channelId, botUserId, fields) => ({
+    channelId,
+    member: { botUserId, role: 'owner', ...fields },
+  }));
+  return { get, updateMember };
+}
+
+describe('ownerBotUserId', () => {
+  it('prefers the record’s own field, else the owner member, else nothing', () => {
+    expect(ownerBotUserId({ botUserId: 'U0A' })).toBe('U0A');
+    expect(
+      ownerBotUserId({
+        members: [
+          { botUserId: 'U0B', role: 'member' },
+          { botUserId: 'U0C', role: 'owner' },
+        ],
+      }),
+    ).toBe('U0C');
+    expect(ownerBotUserId({ botUserId: null, members: [{ botUserId: 'U0B', role: 'member' }] })).toBeUndefined();
+    expect(ownerBotUserId({})).toBeUndefined();
+  });
+});
+
+describe('announceTerminalAddress', () => {
+  it('updates the member keyed by the identity without asking the service who the bot is', async () => {
+    const client = fakeClient();
+    expect(await announceTerminalAddress({ client, row: row(), fields: FIELDS, botUserId: 'U0BOT1' })).toBe(true);
+    expect(client.get).not.toHaveBeenCalled();
+    expect(client.updateMember).toHaveBeenCalledExactlyOnceWith('C1', 'U0BOT1', FIELDS);
+  });
+
+  it('without an identity the channel record names the bot', async () => {
+    const client = fakeClient({ botUserId: 'U0OWNER' });
+    expect(await announceTerminalAddress({ client, row: row(), fields: FIELDS })).toBe(true);
+    expect(client.get).toHaveBeenCalledExactlyOnceWith('C1');
+    expect(client.updateMember).toHaveBeenCalledExactlyOnceWith('C1', 'U0OWNER', FIELDS);
+  });
+
+  it('a record that names no bot, a refused update, or an unreachable service is false — never a throw', async () => {
+    const nameless = fakeClient({ botUserId: null });
+    expect(await announceTerminalAddress({ client: nameless, row: row(), fields: FIELDS })).toBe(false);
+    expect(nameless.updateMember).not.toHaveBeenCalled();
+
+    const refusing = fakeClient();
+    refusing.updateMember.mockRejectedValueOnce(new Error('404 no such member'));
+    expect(await announceTerminalAddress({ client: refusing, row: row(), fields: FIELDS, botUserId: 'U0BOT1' })).toBe(
+      false,
+    );
+
+    const down = fakeClient();
+    down.get.mockRejectedValueOnce(new Error('unreachable'));
+    expect(await announceTerminalAddress({ client: down, row: row(), fields: FIELDS })).toBe(false);
+  });
+});
+
+describe('announceTerminalAddresses (the sweep after remote enable)', () => {
+  it('announces every binding with an address, skips the rest, counts refusals', async () => {
+    const client = fakeClient();
+    client.updateMember.mockImplementation(async (channelId, botUserId, fields) => {
+      if (channelId === 'C3') throw new Error('refused');
+      return { channelId, member: { botUserId, role: 'owner', ...fields } };
+    });
+    const rows = [
+      row(),
+      row({ agent_group_id: 'ag-2', surface_id: 'C2' }), // a name that takes no address
+      row({ agent_group_id: 'ag-3', surface_id: 'C3' }), // the service refuses
+      row({ agent_group_id: 'ag-4', surface_id: 'C4' }), // group gone
+      row({ agent_group_id: 'ag-5', surface_id: 'C5', provider: 'other' }), // a platform this module does not serve
+    ];
+    const names: Record<string, string | undefined> = { 'ag-1': 'api', 'ag-2': 'my_box', 'ag-3': 'web', 'ag-5': 'db' };
+    const outcome = await announceTerminalAddresses({
+      listBindings: async () => rows,
+      sandboxNameOf: async (id) => names[id],
+      fieldsOf: (sandbox) =>
+        /^[a-z0-9-]+$/.test(sandbox)
+          ? { sandboxName: sandbox, terminalAddress: `${sandbox}.alice.example.test` }
+          : undefined,
+      clientFor: (r) => (r.provider === 'chat' ? client : null),
+      botUserIdFor: async () => 'U0BOT1',
+    });
+    expect(outcome).toEqual({ announced: 1, skipped: 3, failed: 1 });
+    expect(client.updateMember.mock.calls.map((c) => [c[0], c[2]])).toEqual([
+      ['C1', { sandboxName: 'api', terminalAddress: 'api.alice.example.test' }],
+      ['C3', { sandboxName: 'web', terminalAddress: 'web.alice.example.test' }],
+    ]);
+  });
+
+  it('no bindings is a quiet zero', async () => {
+    expect(
+      await announceTerminalAddresses({
+        listBindings: async () => [],
+        sandboxNameOf: async () => undefined,
+        fieldsOf: () => undefined,
+        clientFor: () => null,
+      }),
+    ).toEqual({ announced: 0, skipped: 0, failed: 0 });
+  });
+});

--- a/src/modules/community-portal/surface/terminal-address.ts
+++ b/src/modules/community-portal/surface/terminal-address.ts
@@ -1,0 +1,104 @@
+/**
+ * A session tells its chat surface where a terminal reaches it.
+ *
+ * On a host with remote access enabled every sandbox has an address of its
+ * own (../remote/sandboxes.ts), and the service keeps that address on the
+ * surface's member row so a `/terminal` typed on the surface is answered
+ * from it without a host round trip. The address rides the create when the
+ * surface is opened (provider.ts); a surface that already existed when
+ * `remote enable` ran, or a re-bind, learns it through the member update
+ * route. Everything here is best effort: the address is a convenience for
+ * the surface, never a condition of the binding, so nothing throws and a
+ * service that refuses is a log line.
+ */
+import type { SessionSurfaceRow } from '../../../code-mode/surface/db.js';
+import { log } from '../../../log.js';
+import type { ChannelRecord, MemberFields, SurfaceServiceClient } from './client.js';
+
+/** Both member fields, as the address helper yields them together. */
+export type TerminalAddressFields = Required<MemberFields>;
+
+/** The owner's bot user on a channel record: the top-level field, else the owner member. */
+export function ownerBotUserId(record: Pick<ChannelRecord, 'botUserId' | 'members'>): string | undefined {
+  if (record.botUserId) return record.botUserId;
+  return record.members?.find((member) => member.role === 'owner')?.botUserId ?? undefined;
+}
+
+export interface AnnounceTerminalAddressInput {
+  client: Pick<SurfaceServiceClient, 'updateMember' | 'get'>;
+  row: Pick<SessionSurfaceRow, 'agent_group_id' | 'surface_id'>;
+  fields: TerminalAddressFields;
+  /** This host's bot user id when known (the platform half); otherwise the channel record names it. */
+  botUserId?: string | null;
+}
+
+/**
+ * Report the sandbox's address on its existing surface. Resolves true when
+ * the service recorded it; false — with a log line — when the member could
+ * not be named or the service refused. Never throws.
+ */
+export async function announceTerminalAddress(input: AnnounceTerminalAddressInput): Promise<boolean> {
+  const { client, row, fields } = input;
+  const context = {
+    agentGroupId: row.agent_group_id,
+    surfaceId: row.surface_id,
+    terminalAddress: fields.terminalAddress,
+  };
+  try {
+    const botUserId = input.botUserId || ownerBotUserId(await client.get(row.surface_id));
+    if (!botUserId) {
+      log.warn('Session surface: terminal address not announced — the surface names no bot for this host', context);
+      return false;
+    }
+    await client.updateMember(row.surface_id, botUserId, fields);
+    log.info('Session surface learned its terminal address', context);
+    return true;
+  } catch (err) {
+    log.warn('Session surface: terminal address not announced', { ...context, err });
+    return false;
+  }
+}
+
+export interface AnnounceSweepDeps {
+  listBindings(): Promise<SessionSurfaceRow[]>;
+  /** The sandbox's name (its group folder), or undefined when the group is gone. */
+  sandboxNameOf(agentGroupId: string): Promise<string | undefined>;
+  /** The address for a sandbox on this host, or undefined when it has none. */
+  fieldsOf(sandbox: string): TerminalAddressFields | undefined;
+  /** A client for the row's platform, or null when this module serves no surface for it. */
+  clientFor(row: SessionSurfaceRow): Pick<SurfaceServiceClient, 'updateMember' | 'get'> | null;
+  /** This host's bot user on the row's platform, when known. */
+  botUserIdFor?(row: SessionSurfaceRow): Promise<string | undefined>;
+}
+
+export interface AnnounceSweepOutcome {
+  /** Surfaces that now carry an address. */
+  announced: number;
+  /** Bindings without an address to report (no sandbox, no client, or a name that takes no address). */
+  skipped: number;
+  /** Announcements the service or the network refused. */
+  failed: number;
+}
+
+/**
+ * Every open binding on this host reports its sandbox's address — what
+ * `remote enable` runs once the door is up, so surfaces opened before it
+ * catch up. Sequential: one host, a handful of surfaces, no hurry.
+ */
+export async function announceTerminalAddresses(deps: AnnounceSweepDeps): Promise<AnnounceSweepOutcome> {
+  const outcome: AnnounceSweepOutcome = { announced: 0, skipped: 0, failed: 0 };
+  for (const row of await deps.listBindings()) {
+    const client = deps.clientFor(row);
+    const sandbox = await deps.sandboxNameOf(row.agent_group_id);
+    const fields = client && sandbox ? deps.fieldsOf(sandbox) : undefined;
+    if (!client || !fields) {
+      outcome.skipped += 1;
+      continue;
+    }
+    const botUserId = deps.botUserIdFor ? await deps.botUserIdFor(row) : undefined;
+    const done = await announceTerminalAddress({ client, row, fields, botUserId });
+    if (done) outcome.announced += 1;
+    else outcome.failed += 1;
+  }
+  return outcome;
+}

--- a/src/modules/community-portal/surface/verbs.ts
+++ b/src/modules/community-portal/surface/verbs.ts
@@ -1,0 +1,170 @@
+/**
+ * `ncl sandboxes surface status | archive | enable | disable` — the
+ * operator's view of the chat surface bound to a coding session, and the
+ * host's setting for opening one, added to the sandboxes resource through
+ * code mode's resource extension. Host-only, like every sandbox verb: the
+ * ncl socket is the auth boundary.
+ */
+import { extendResource, RESOURCE_EXTENSION_SEAM, type CustomOperation } from '../../../cli/crud.js';
+import { sandboxVerbs } from '../../../code-mode/sandboxes.js';
+import { archiveSandboxSurface, getSessionSurfaceByGroup } from '../../../code-mode/surface/index.js';
+import type { AgentGroup } from '../../../types.js';
+import type { ChannelRecord } from './client.js';
+import { clientForRow } from './index.js';
+import { setSurfaceAutoOpen, type SurfaceSetting } from './setting.js';
+
+/** id-first, then folder — the sandbox API's own resolution; the not-found text names the verb. */
+async function resolveSandboxGroup(raw: unknown, verb: string): Promise<AgentGroup> {
+  const id = raw === undefined || raw === null ? '' : String(raw);
+  if (!id) throw new Error(`usage: ncl sandboxes ${verb} <name-or-id>`);
+  const group = await sandboxVerbs().find(id);
+  if (!group) throw new Error(`no sandbox '${id}' — create it: ncl sandboxes new --name ${id}`);
+  return group;
+}
+
+export interface SurfaceStatusView {
+  sandbox: string;
+  provider: string;
+  surfaceId: string;
+  sessionId: string;
+  title: string;
+  /** The service's view when reachable, else the last status this host sent. */
+  status: string | null;
+  lastStatusSent: string | null;
+  lastStatusAt: string | null;
+  stoppedAt: string | null;
+  archivedAt: string | null;
+  members: Array<{ id: string; role?: string; sandbox?: string | null; terminalAddress?: string | null }>;
+  views: Array<{ viewKey: string; type: string; updatedAt?: string }>;
+  createdAt: string;
+  serviceError?: string;
+}
+
+async function surfaceStatus(
+  args: Record<string, unknown>,
+): Promise<SurfaceStatusView | { sandbox: string; surface: null }> {
+  const group = await resolveSandboxGroup(args.id, 'surface status');
+  const row = await getSessionSurfaceByGroup(group.id);
+  if (!row) return { sandbox: group.folder, surface: null };
+  let live: ChannelRecord | undefined;
+  let serviceError: string | undefined;
+  if (!row.archived_at) {
+    const found = await clientForRow(row);
+    if (found) {
+      try {
+        live = await found.client.get(row.surface_id);
+      } catch (err) {
+        serviceError = err instanceof Error ? err.message : String(err);
+      }
+    } else {
+      serviceError = 'this host serves no surface for the platform (no managed install or sign-in)';
+    }
+  }
+  return {
+    sandbox: group.folder,
+    provider: row.provider,
+    surfaceId: row.surface_id,
+    sessionId: row.session_id,
+    title: row.title,
+    status: live?.status ?? (row.archived_at ? 'closed' : row.last_status),
+    lastStatusSent: row.last_status,
+    lastStatusAt: row.last_status_at,
+    stoppedAt: live?.stoppedAt ?? row.stopped_at,
+    archivedAt: live?.archivedAt ?? row.archived_at,
+    members: (live?.members ?? []).map((m) => ({
+      id: m.botUserId,
+      ...(m.role ? { role: m.role } : {}),
+      ...(m.sandboxName !== undefined ? { sandbox: m.sandboxName } : {}),
+      ...(m.terminalAddress !== undefined ? { terminalAddress: m.terminalAddress } : {}),
+    })),
+    views: (live?.views ?? []).map((v) => ({
+      viewKey: v.viewKey,
+      type: v.type,
+      ...(v.updatedAt ? { updatedAt: v.updatedAt } : {}),
+    })),
+    createdAt: row.created_at,
+    ...(serviceError ? { serviceError } : {}),
+  };
+}
+
+function renderSetting(data: unknown): string {
+  const s = data as SurfaceSetting;
+  return s.autoOpen
+    ? 'New sandboxes get a chat surface when the service offers one.'
+    : 'New sandboxes get no chat surface on this host (ncl sandboxes surface enable turns it back on).';
+}
+
+export const surfaceOperations: Record<string, CustomOperation> = {
+  'surface enable': {
+    access: 'open',
+    hostOnly: true,
+    description:
+      'Open a chat surface for every new sandbox the service offers one for — the default (host operators only).\n' +
+      'Usage: ncl sandboxes surface enable. Kept across host restarts. Sandboxes created while it was disabled ' +
+      'stay plain.',
+    handler: async () => setSurfaceAutoOpen(true),
+    formatHuman: renderSetting,
+  },
+  'surface disable': {
+    access: 'open',
+    hostOnly: true,
+    description:
+      'Stop opening a chat surface for new sandboxes on this host (host operators only).\n' +
+      'Usage: ncl sandboxes surface disable. Kept across host restarts. Surfaces already open are untouched: ' +
+      'they keep mirroring their sessions until archived.',
+    handler: async () => setSurfaceAutoOpen(false),
+    formatHuman: renderSetting,
+  },
+  'surface status': {
+    access: 'open',
+    hostOnly: true,
+    description:
+      "Show the chat surface bound to a sandbox's coding session, as the service sees it (host operators only).\n" +
+      'Usage: ncl sandboxes surface status <name-or-id>. Reports the surface id, the status the service holds, ' +
+      'the last status this host sent, the members with their terminal addresses, and the views it carries. ' +
+      'A sandbox on a host without a managed chat app has none.',
+    handler: surfaceStatus,
+    formatHuman: (data) => {
+      const d = data as Partial<SurfaceStatusView> & { sandbox: string; surface?: null };
+      if (!d.surfaceId) return `${d.sandbox}: no chat surface`;
+      const lines = [
+        `${d.sandbox}: ${d.provider} ${d.surfaceId} (${d.title ?? ''})`,
+        `  status:     ${d.status ?? '-'}${d.archivedAt ? ' (archived)' : ''}${d.stoppedAt && !d.archivedAt ? ' (stopped by the user)' : ''}`,
+        `  last sent:  ${d.lastStatusSent ?? '-'}${d.lastStatusAt ? ` at ${d.lastStatusAt}` : ''}`,
+        `  members:    ${
+          d.members && d.members.length > 0
+            ? d.members
+                .map(
+                  (m) =>
+                    `${m.id}${m.role ? ` (${m.role})` : ''}${m.terminalAddress ? ` ssh ${m.terminalAddress}` : ''}`,
+                )
+                .join(', ')
+            : '-'
+        }`,
+        `  views:      ${d.views && d.views.length > 0 ? d.views.map((v) => `${v.viewKey} (${v.type})`).join(', ') : '-'}`,
+      ];
+      if (d.serviceError) lines.push(`  service:    ${d.serviceError}`);
+      return lines.join('\n');
+    },
+  },
+  'surface archive': {
+    access: 'open',
+    hostOnly: true,
+    description:
+      "Archive the chat surface bound to a sandbox's coding session (host operators only).\n" +
+      'Usage: ncl sandboxes surface archive <name-or-id> [--summary <text>]. The explicit wrap-up: the surface ' +
+      'closes at the service (with the summary posted first, when given) and this host stops mirroring it. ' +
+      'Nothing else archives a surface — not a Stop, not deleting the sandbox. The sandbox itself is untouched.',
+    handler: async (args) => {
+      const group = await resolveSandboxGroup(args.id, 'surface archive');
+      const summary = args.summary === undefined ? undefined : String(args.summary);
+      return archiveSandboxSurface(group, summary ? { summary } : {});
+    },
+    formatHuman: (data) => {
+      const d = data as { sandbox: string; surfaceId: string; archivedAt: string };
+      return `${d.sandbox}: surface ${d.surfaceId} archived at ${d.archivedAt}`;
+    },
+  },
+};
+
+extendResource('sandboxes', surfaceOperations, { seam: RESOURCE_EXTENSION_SEAM });


### PR DESCRIPTION
<!-- nanoclaw-pr-template:v2 -->

## Summary

Extends the community-portal module with the two things a signed-in host can add to code mode: a remote terminal (an in-process SSH server on loopback whose streams the account link relays, so an approved key lands in a sandbox from another machine) and a chat surface for each coding session, implemented over the service that manages the host's chat app. Both attach to code mode through the seams PR A landed and nothing else; a host that never enables remote access or never installed a managed chat app is unchanged.

- **Problem**: a sandbox can only be reached from the Host's own terminal, and a coding session has no chat surface unless a platform provides one in-process.
- **Fix**: `ncl sandboxes remote enable | disable | status | keys …` run a loopback SSH door inside the Host (public keys only, a waiting room for unknown keys, no shell/forwarding/subsystems); the account link gains the `ssh` channel kind and pipes each relayed stream into the door with per-direction flow control; every named sandbox gets an address of its own; and a platform-agnostic `SessionSurfaceProvider` over `/v1/code-channels` gives sessions a surface on any platform whose module registers its half with `registerSurfacePlatform`. `ncl sandboxes surface enable | disable` is the host's persisted opt-out of opening a surface for new sandboxes (default on; existing surfaces untouched).
- **Seams consumed**: `extendResource('sandboxes')` (remote and surface verbs), `sandboxVerbs()` + `AttachTarget` (the door lands terminals), `onSandboxCreated / onSandboxRemoved` (address registration), `onSandboxBound / onRemoteAccessChanged` (address announce), `registerSessionSurface` (the provider). The door fires `onRemoteAccessChanged`.
- **Out of scope**: any concrete chat platform (the platform id form, adapter-group adoption, bot user lookup, notice filter, agent-to-agent admission move to the channels branch), a task board (no service route yet), a `surface join` verb.

<details>
<summary>Commits, in order</summary>

1. `feat(community-portal): opt-in remote terminal — an in-process SSH door and its verbs`
2. `feat(community-portal): the link relays terminal streams into the door; sandboxes get addresses`
3. `feat(community-portal): a chat surface for each coding session, over the service`
4. `docs(code-mode): remote terminal access and the chat surface over the account service`

</details>

## Related work

Stacks on PR A (`code-mode/core` 61a0e6f2). Safe to review directly: every behaviour is off until an operator runs `remote enable` or a chat platform registers its surface half on a host with a managed install.

## Change kind

- [ ] `kind/bug`
- [x] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- At tip 877a2150 (after the rebase onto 61a0e6f2 and the external-review fixes): `pnpm exec tsc --noEmit` -> clean, and clean at each of the 4 commits; `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` -> clean; `pnpm build` -> clean; `pnpm run format:check` -> clean; `pnpm lint` -> 0 errors, 219 warnings (all `no-catch-all`, trunk-wide; the ones in files this PR adds are deliberate best-effort boundaries — a report, a lookup, an announce, a status read — that log and degrade rather than fail the sandbox or the link).
- Module suites at the tip (`src/modules/community-portal`, `src/community-portal`, `src/code-mode`, `src/cli/resources/sandboxes*.test.ts`, `src/cli/crud-extend.test.ts`): 46 files / 367 tests, all green.
- `pnpm exec vitest run` at the tip: 252 files: 251 passed, 1 skipped; 2849 tests: 2848 passed, 1 skipped, 0 failed (19.5 s).
- `bun test` in `container/agent-runner` was last run before the rebase (660 pass, 3 skip, 0 fail); this PR touches nothing under `container/`, and the container tsc is clean at the tip.
- Hygiene grep over the diff (internal names, hosted-URL literals) -> clean; one `TODO` remains, on purpose: stdin backpressure in `door/session.ts` (bounded today by the SSH window and the link's 64 KiB per-direction window).
- New or changed behaviour is covered by: `src/modules/community-portal/door/{authority,keys,host-key,paths,target-map,waiting-room,landing,session,verbs,approval-url}.test.ts` and `door/door.e2e.test.ts` (a real OpenSSH client against the door: waiting room, approval, landing through the real `sandboxes new`, `ls`, plain attach, password refused, the `onRemoteAccessChanged` hook); `src/community-portal/{link,mux,terminal,terminal-routes}.test.ts` (ssh kind, credit/renew, frame allowances and vectors, the terminal routes and the state report); `src/modules/community-portal/remote/{door,stream,sandboxes,index,registration}.test.ts` and `runtime.test.ts` (the seam, the stream pipe, address registration, the hooks, the link announcing `ssh`); `src/modules/community-portal/surface/{client,provider,terminal-address,module}.test.ts` (every route, the failure-kind mapping, event mapping, the archived rebind; the module through the real dispatch path with a placeholder platform: activation, open with the address, announce on bind and after remote enable, `surface status | archive`, unavailable → plain).
- Review fixes folded in (pr-b-review): pending address retries are aborted on host shutdown (test); a 20 s pre-auth deadline on every door connection; the key store's mutations serialized (two unknown keys admitted at once both land); the door inert until enabled (no `data/door/` files on an enrolled host that never opted in; no key-store write for an account with nothing approved); the journal says `enabled` only once the door listens; the journaled port is reused only while free; a rename from the account recomposes the host name for the status line and the `onRemoteAccessChanged` payload; address registration and release retry every 60 s while the service does not answer (contract §3.5), a name refusal (`invalid_name`, `name_reserved`, `name_taken`) is final and logged as an error; the approval page falls back to the bare portal origin. Covered by `door/{lifecycle,session,authority}.test.ts` and `remote/{index,sandboxes}.test.ts` (fake clock for the retry loop).
- Review fixes folded in (external review of #3784, findings 4 and 7, plus the P1 shared with PR A) are covered by `door/lifecycle.test.ts` (repeated enable keeps the live port: summary, `door.port`, journal and seam report agree), `door/session.test.ts` (revocation during a cold attach starts no exec and frees the slot; an exec resolving after close or revocation is hung up, live count 0), and `surface/module.test.ts` (a row restored before the module activates waits with no service call and no write, then flows one `suspended` status to the service once the platform registers and the module activates, coalesced on the next tick; `surface enable | disable` verbs: new sandboxes plain, the open surface not archived, the setting read again after a fresh activation, enable restores opening).
- Manual path CI cannot cover: `remote enable --name x`, `ssh -p <door> localhost` on loopback with a registered target (the e2e does this with a ProxyCommand), and the relayed path through a published cell.
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change

```release-note
Code mode: `ncl sandboxes remote enable` runs an SSH server inside the Host so an approved key can land in a sandbox from another machine over the account link (public keys only, a waiting room for unknown keys, addresses per sandbox); it is off until enabled. A signed-in host with a managed chat app gives each new coding session a chat surface — status, the diff after each turn, messages both ways, Stop — for any platform whose module registers its half; `ncl sandboxes surface disable` turns that off for new sandboxes on the host. See docs/code-mode.md.
```

## Security and trust boundaries

- The door listens on 127.0.0.1 only and is off until `remote enable`; every network stream reaching it was relayed by the Host's own outbound link, and a connection the Host did not register a target for is refused after authentication.
- Public keys only, signatures verified; no password, no shell, no forwarding (tcpip, streamlocal, X11, agent), no subsystems, no env. An unknown key reaches only the waiting room: at most four rooms per machine, at most ten pending keys per ten minutes, ten-minute timeout. A revocation ends live sessions; browser approvals arrive as fingerprints only.
- The host key and key store live under `data/door/` at mode 0600/0700; the journal never carries public keys. Payload bytes are never logged on the stream path.
- The link's stream pipe enforces 16 KiB chunks and a 64 KiB window per direction, at most eight streams, and the mux refuses oversize frames both ways.
- The surface provider sends the registry install token only to the service origin the saved install names, validated as https (or loopback http); nothing is sent to a chat platform from this module.
- `ssh2` is a new pinned runtime dependency (1.17.0), loaded on first use; a host that never enables remote access never loads it.

## Skill delivery

- [x] Not a skill

## AI assistance

- [x] AI tools or agents helped produce this change
- [ ] A human has reviewed this PR and stands behind every change

## Review fixes folded in (external review of #3783/#3784, all findings accepted; the UX ruling)

Base moved from 7d34ef31 to 61a0e6f2 (PR A's third pass). The rebase conflicted only in `docs/code-mode.md` (A's waiting-binding paragraph next to B's new sections; both kept).

- **(2) P1 restored bindings stuck on the no-op provider** — core's fix (rebind on `registerSessionSurface`, the runtime's `waiting` map) is in PR A. PR B's provider needed no code change to ride it: it registers through `registerSessionSurface` at activation, which now notifies the runtime. What PR B adds is the end-to-end proof in `surface/module.test.ts`: a saved row, runtime started, the platform registers and the module activates later → exactly one status POST reaches the fake service, `last_status` is written only then, the next tick sends nothing new. Provider commit.
- **(4) P2 repeated `remote enable` advertised a port the door was not on** — `doorPortFor` in `door/index.ts` returns the live server's port while the door runs; the free-port probe (which saw our own listener as taken) is consulted only when it is down. Journal, seam report, `onRemoteAccessChanged` payload and the summary agree. Door commit. The review's `enable.test.ts` scenario is the new assertion block in `door/lifecycle.test.ts`.
- **(7) P2 disconnect or revocation during a pending attach left an untracked exec** — `door/session.ts` `attach()` checks the connection is still open before starting the exec (the landing may have waited on a cold sandbox) and hangs up an exec that resolves after a close or a revocation; counters (`sessions.track`) and `registerSession` were already released at `finish`, so they now match reality. Door commit. The review's `revoke-real.ts` against this tree prints `execStartedAfterRevocation: 0` (was 1); both pending paths are in `door/session.test.ts`.
- **UX ruling: an explicit opt-out for the automatic surface** — `ncl sandboxes surface enable | disable` (`surface/setting.ts`, `data/session-surface.json` at 0600, default on). The provider's `open` answers null while disabled, so core leaves the sandbox plain through the contract's own "not available" path; nothing is archived. Provider commit; the docs commit states in one paragraph that a surface opens automatically when the service offers one while remote terminal access needs `remote enable`.

