### PR TITLE
typing: follow the runner's turn state, show its status text, and clear when the turn ends

### DIFF
--- a/container/agent-runner/src/db/container-state.ts
+++ b/container/agent-runner/src/db/container-state.ts
@@ -8,6 +8,10 @@ export function clearContainerToolInFlight(): void {
   getAgentMailbox().operations.clearContainerToolInFlight();
 }
 
+export function markContainerTurn(turn: 'working' | 'idle'): void {
+  getAgentMailbox().operations.markContainerTurn(turn);
+}
+
 export function clearStaleProcessingAcks(): void {
   getAgentMailbox().operations.clearStaleProcessingAcks();
 }

--- a/container/agent-runner/src/mailbox/model.generated.ts
+++ b/container/agent-runner/src/mailbox/model.generated.ts
@@ -27,6 +27,16 @@ const INBOUND_KINDS = ['chat', 'chat-sdk', 'task', 'webhook', 'system'] as const
 
 export type InboundKind = (typeof INBOUND_KINDS)[number];
 
+const TURN_STATES = ['working', 'idle'] as const;
+
+/**
+ * The runner's own report of whether it is inside a turn. `working` is
+ * re-marked periodically while a turn runs; `idle` is written when the turn
+ * ends. Runners that predate the field never write it, so a record without
+ * one carries `null` — "not reported", not "idle".
+ */
+export type TurnState = (typeof TURN_STATES)[number];
+
 export interface InboundWrite {
   id: string;
   kind: InboundKind;
@@ -154,6 +164,7 @@ export interface ContainerRecord {
   currentTool: string | null;
   toolDeclaredTimeoutMs: number | null;
   toolStartedAt: IsoTimestamp | null;
+  turn: TurnState | null;
   updatedAt: IsoTimestamp;
 }
 
@@ -282,6 +293,16 @@ function oneOf<const T extends readonly string[]>(record: UnknownRecord, key: st
   if (typeof value !== 'string' || !values.includes(value))
     throw new Error(`invalid mailbox field ${key}: unexpected value`);
   return value as T[number];
+}
+
+/** A field added after records were first persisted: absent or null both read as null. */
+function optionalNullableOneOf<const T extends readonly string[]>(
+  record: UnknownRecord,
+  key: string,
+  values: T,
+): T[number] | null {
+  if (!(key in record) || record[key] === undefined || record[key] === null) return null;
+  return oneOf(record, key, values);
 }
 
 export function parseInboundWrite(value: unknown): InboundWrite {
@@ -515,12 +536,15 @@ export function parseContainerRecord(value: unknown): ContainerRecord {
     'currentTool',
     'toolDeclaredTimeoutMs',
     'toolStartedAt',
+    'turn',
     'updatedAt',
   ]);
   return {
     currentTool: nullableText(record, 'currentTool'),
     toolDeclaredTimeoutMs: nullableNonNegativeInteger(record, 'toolDeclaredTimeoutMs'),
     toolStartedAt: nullableTimestamp(record, 'toolStartedAt'),
+    // Older runners never wrote `turn`; their persisted records still parse.
+    turn: optionalNullableOneOf(record, 'turn', TURN_STATES),
     updatedAt: timestamp(record, 'updatedAt'),
   };
 }

--- a/container/agent-runner/src/mailbox/sqlite/connection.ts
+++ b/container/agent-runner/src/mailbox/sqlite/connection.ts
@@ -102,16 +102,26 @@ export function getOutboundDb(): Database {
     _outbound.exec(`UPDATE session_state SET updated_at = '1970-01-01T00:00:00.000Z' WHERE updated_at = ''`);
     // container_state: tracks the current tool in flight (if any) so the host
     // sweep can widen its stuck tolerance when Bash is running with a user-
-    // declared long timeout. Forward-compat for older outbound.db files.
+    // declared long timeout, and the runner's turn report (working/idle) that
+    // the host's typing indicator follows. Forward-compat for older
+    // outbound.db files: create the table, then add `turn` where an earlier
+    // revision of the table exists without it.
     _outbound.exec(`
       CREATE TABLE IF NOT EXISTS container_state (
         id                       INTEGER PRIMARY KEY CHECK (id = 1),
         current_tool             TEXT,
         tool_declared_timeout_ms INTEGER,
         tool_started_at          TEXT,
+        turn                     TEXT,
         updated_at               TEXT NOT NULL
       );
     `);
+    const containerCols = new Set(
+      (_outbound.prepare("PRAGMA table_info('container_state')").all() as Array<{ name: string }>).map((c) => c.name),
+    );
+    if (!containerCols.has('turn')) {
+      _outbound.exec('ALTER TABLE container_state ADD COLUMN turn TEXT');
+    }
   }
   return _outbound;
 }
@@ -134,6 +144,24 @@ export function sqliteSetContainerToolInFlight(tool: string, declaredTimeoutMs: 
          updated_at = excluded.updated_at`,
     )
     .run(tool, declaredTimeoutMs, now, now);
+}
+
+/**
+ * Record the runner's turn state. Only `turn` and `updated_at` move: the
+ * tool-in-flight fields belong to the PreToolUse/PostToolUse hooks and must
+ * survive a turn re-mark that lands while a tool is running.
+ */
+export function sqliteMarkContainerTurn(turn: 'working' | 'idle'): void {
+  const now = new Date().toISOString();
+  getOutboundDb()
+    .prepare(
+      `INSERT INTO container_state (id, current_tool, tool_declared_timeout_ms, tool_started_at, turn, updated_at)
+       VALUES (1, NULL, NULL, NULL, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         turn = excluded.turn,
+         updated_at = excluded.updated_at`,
+    )
+    .run(turn, now);
 }
 
 /** Clear the in-flight tool — called on PostToolUse / PostToolUseFailure. */
@@ -231,6 +259,7 @@ export function initTestSessionDb(): { inbound: Database; outbound: Database } {
       current_tool             TEXT,
       tool_declared_timeout_ms INTEGER,
       tool_started_at          TEXT,
+      turn                     TEXT,
       updated_at               TEXT NOT NULL
     );
   `);

--- a/container/agent-runner/src/mailbox/sqlite/index.ts
+++ b/container/agent-runner/src/mailbox/sqlite/index.ts
@@ -3,6 +3,7 @@ import {
   getInboundDb,
   sqliteClearContainerToolInFlight,
   sqliteClearStaleProcessingAcks,
+  sqliteMarkContainerTurn,
   sqliteSetContainerToolInFlight,
 } from './connection.js';
 import {
@@ -42,6 +43,7 @@ import type {
   MailboxSessionKey,
   OutboundMessage,
   ProcessingStatus,
+  TurnState,
 } from '../types.js';
 
 function inboundMessage(row: MessageInRow): InboundMessage {
@@ -217,11 +219,24 @@ export class SqliteAgentMailbox implements AgentMailbox {
       currentTool: tool,
       toolDeclaredTimeoutMs: timeout,
       toolStartedAt: new Date().toISOString(),
+      turn: null,
       updatedAt: new Date().toISOString(),
     });
     sqliteSetContainerToolInFlight(record.currentTool!, record.toolDeclaredTimeoutMs);
   }
 
   clearContainerToolInFlight = sqliteClearContainerToolInFlight;
+
+  markContainerTurn(turn: TurnState): void {
+    const record = parseContainerRecord({
+      currentTool: null,
+      toolDeclaredTimeoutMs: null,
+      toolStartedAt: null,
+      turn,
+      updatedAt: new Date().toISOString(),
+    });
+    sqliteMarkContainerTurn(record.turn!);
+  }
+
   clearStaleProcessingAcks = sqliteClearStaleProcessingAcks;
 }

--- a/container/agent-runner/src/mailbox/sqlite/sqlite.test.ts
+++ b/container/agent-runner/src/mailbox/sqlite/sqlite.test.ts
@@ -96,6 +96,8 @@ describe('SQLite runner mailbox canonical serialization', () => {
         tool_declared_timeout_ms: null,
       });
     }
+    // A tool-in-flight write leaves the turn alone.
+    expect(outbound.prepare('SELECT turn FROM container_state').get()).toEqual({ turn: null });
 
     expect(
       await mailbox.writeMessageOut({
@@ -156,5 +158,47 @@ describe('SQLite runner mailbox canonical serialization', () => {
 
     const mailbox = new SqliteAgentMailbox();
     expect(mailbox.getPendingMessages(10, false)).toEqual([]);
+  });
+});
+
+describe('SQLite runner mailbox turn state', () => {
+  test('marks the turn and stamps updated_at without touching the tool in flight', async () => {
+    const { outbound } = initTestSessionDb();
+    const mailbox = new SqliteAgentMailbox();
+    const read = () =>
+      outbound
+        .prepare('SELECT current_tool, tool_declared_timeout_ms, turn, updated_at FROM container_state')
+        .get() as {
+        current_tool: string | null;
+        tool_declared_timeout_ms: number | null;
+        turn: string | null;
+        updated_at: string;
+      };
+
+    // First write creates the row.
+    mailbox.markContainerTurn('working');
+    const first = read();
+    expect(first).toMatchObject({ current_tool: null, tool_declared_timeout_ms: null, turn: 'working' });
+    expect(new Date(first.updated_at).toISOString()).toBe(first.updated_at);
+
+    // A tool starts mid-turn; a re-mark must not clear it.
+    mailbox.setContainerToolInFlight('Bash', 30_000);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    mailbox.markContainerTurn('working');
+    const remarked = read();
+    expect(remarked).toMatchObject({ current_tool: 'Bash', tool_declared_timeout_ms: 30_000, turn: 'working' });
+    expect(Date.parse(remarked.updated_at)).toBeGreaterThan(Date.parse(first.updated_at));
+
+    // Clearing the tool keeps the turn; ending the turn keeps the (cleared) tool.
+    mailbox.clearContainerToolInFlight();
+    expect(read()).toMatchObject({ current_tool: null, turn: 'working' });
+    mailbox.markContainerTurn('idle');
+    expect(read()).toMatchObject({ current_tool: null, tool_declared_timeout_ms: null, turn: 'idle' });
+  });
+
+  test('rejects a turn outside the contract before it reaches the row', () => {
+    initTestSessionDb();
+    const mailbox = new SqliteAgentMailbox();
+    expect(() => mailbox.markContainerTurn('busy' as never)).toThrow('invalid mailbox field turn');
   });
 });

--- a/container/agent-runner/src/mailbox/types.ts
+++ b/container/agent-runner/src/mailbox/types.ts
@@ -6,6 +6,7 @@ import type {
   ProcessingStatus,
   SessionRoutingRecord,
   StateRecord,
+  TurnState,
 } from './model.generated.js';
 
 export type {
@@ -27,6 +28,7 @@ export type {
   TaskRecord,
   TaskStatus,
   TaskWrite,
+  TurnState,
 } from './model.generated.js';
 
 export interface MailboxSessionKey {
@@ -63,6 +65,12 @@ export interface MailboxOperations {
   findDestinationByRouting(channelType: string, platformId: string): Destination | undefined;
   setContainerToolInFlight(tool: string, declaredTimeoutMs: number | null): void;
   clearContainerToolInFlight(): void;
+  /**
+   * Record whether the runner is inside a turn. Writes `turn` and stamps
+   * `updated_at`; the tool-in-flight fields are left as they are. The host
+   * reads it on its delivery poll to drive the typing indicator.
+   */
+  markContainerTurn(turn: TurnState): void;
   clearStaleProcessingAcks(): void;
 }
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -7,7 +7,7 @@ import {
   type MessageInRow,
 } from './db/messages-in.js';
 import { getUndeliveredMessages, writeMessageOut } from './db/messages-out.js';
-import { clearStaleProcessingAcks } from './db/container-state.js';
+import { clearStaleProcessingAcks, markContainerTurn } from './db/container-state.js';
 import { resolveDestinationThread } from './db/session-routing.js';
 import { touchHeartbeat } from './heartbeat.js';
 import { getAgentMailbox } from './mailbox/index.js';
@@ -35,6 +35,13 @@ import type { ProviderRuntimeContract } from './provider-contracts/registry.js';
 
 const POLL_INTERVAL_MS = 1000;
 const ACTIVE_POLL_INTERVAL_MS = 500;
+/**
+ * While a turn runs, re-mark it 'working' this often so the container_state
+ * row's updated_at keeps moving through a long generation. The host treats a
+ * 'working' report as stale after three of these, so it must be well under
+ * that window.
+ */
+const WORKING_REMARK_MS = 5000;
 
 /** Consecutive driver-classified failures before a fresh runner is required. */
 const MAILBOX_FAILURE_STREAK_EXIT = 10;
@@ -427,6 +434,35 @@ export async function processQuery(
   // push order (including retries) and advance at every result, mirroring
   // archivePrompts. An empty initial prompt (a pre-warmed query) starts idle.
   let answering = initialPrompt !== '';
+  // Report the turn state to the runner-owned mailbox so the host's typing
+  // indicator follows it (working while a turn runs, idle when it ends)
+  // instead of guessing from the heartbeat file. Best-effort throughout: a
+  // failed write logs and never breaks the loop.
+  let workingRemark: ReturnType<typeof setInterval> | null = null;
+  const markTurn = (turn: 'working' | 'idle'): void => {
+    try {
+      markContainerTurn(turn);
+    } catch (err) {
+      log(`Turn-state mark (${turn}) failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+  const enterWorking = (): void => {
+    markTurn('working');
+    if (!workingRemark) {
+      workingRemark = setInterval(() => markTurn('working'), WORKING_REMARK_MS);
+      // unref so a lingering re-mark timer can't hold the process alive.
+      workingRemark.unref?.();
+    }
+  };
+  const enterIdle = (): void => {
+    if (workingRemark) {
+      clearInterval(workingRemark);
+      workingRemark = null;
+    }
+    markTurn('idle');
+  };
+  // An initial prompt means the turn is already running when we get here.
+  if (answering) enterWorking();
   type QueuedTurn = {
     routing: RoutingContext;
     unwrappedNudged: boolean;
@@ -439,6 +475,7 @@ export async function processQuery(
     taskBlockNudged = next.taskBlockNudged;
     publishReplyRoute(routing);
     answering = true;
+    enterWorking();
   };
   // A retry is another provider input, behind any follow-ups already pushed.
   // Preserve its original route, prompt and retry guards until it is answered.
@@ -698,7 +735,10 @@ export async function processQuery(
         midTurnTail = '';
         const next = queuedTurns.shift();
         if (next) adoptTurn(next);
-        else answering = false;
+        else {
+          answering = false;
+          enterIdle();
+        }
       }
     }
   } catch (err) {
@@ -713,6 +753,9 @@ export async function processQuery(
   } finally {
     done = true;
     clearInterval(pollHandle);
+    // Clean loop exit (turn finished, stream ended, or aborted): stop the
+    // re-mark timer and report idle. Idempotent with the turn-boundary idle.
+    enterIdle();
   }
 
   return { continuation: queryContinuation };

--- a/container/agent-runner/src/poll-loop.turn-state.test.ts
+++ b/container/agent-runner/src/poll-loop.turn-state.test.ts
@@ -1,0 +1,147 @@
+/**
+ * The runner reports its own turn state to container_state so the host's
+ * typing indicator can follow it: 'working' while a turn runs (re-marked so
+ * updated_at keeps moving), 'idle' the moment it returns to waiting — even
+ * when the turn produced no message.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './mailbox/sqlite/connection.js';
+import { getUndeliveredMessages } from './db/messages-out.js';
+import { MockProvider } from './providers/mock.js';
+import { runPollLoop } from './poll-loop.js';
+import type { AgentQuery, ProviderEvent, QueryInput } from './providers/types.js';
+
+const CONTRACT = { textDelivery: 'mid-turn-complete', commands: { formatting: 'xml' } } as const;
+
+beforeEach(() => {
+  initTestSessionDb();
+  getInboundDb()
+    .prepare(
+      `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+       VALUES ('slack-test', 'Slack Test', 'channel', 'slack', 'C123', NULL)`,
+    )
+    .run();
+});
+afterEach(() => closeSessionDb());
+
+function insertMessage(id: string, text: string, threadId: string) {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, kind, timestamp, status, platform_id, channel_type, thread_id, content)
+       VALUES (?, 'chat', datetime('now'), 'pending', 'C123', 'slack', ?, ?)`,
+    )
+    .run(id, threadId, JSON.stringify({ sender: 'Alice', text }));
+}
+
+function readTurn(): string | null {
+  const row = getOutboundDb().prepare('SELECT turn FROM container_state WHERE id = 1').get() as
+    | { turn: string | null }
+    | undefined;
+  return row?.turn ?? null;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+async function waitFor(cond: () => boolean, ms: number) {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > ms) throw new Error('waitFor timeout');
+    await sleep(25);
+  }
+}
+
+/** Streams a partial block, then holds the turn open until release(). */
+class HoldingProvider extends MockProvider {
+  release: () => void = () => {};
+  private gate = new Promise<void>((r) => (this.release = r));
+  query(_input: QueryInput): AgentQuery {
+    const pending: string[] = [];
+    let waiting: (() => void) | null = null;
+    let aborted = false;
+    const gate = this.gate;
+    const events: AsyncIterable<ProviderEvent> = {
+      async *[Symbol.asyncIterator]() {
+        yield { type: 'init', continuation: 'hold-session' };
+        yield { type: 'text', text: '<message to="slack-test">partial A</message>' };
+        await gate;
+        yield { type: 'text', text: '<message to="slack-test">done A</message>' };
+        yield { type: 'result', text: '<message to="slack-test">done A</message>' };
+        while (!aborted) {
+          if (pending.length > 0) {
+            pending.shift();
+            yield { type: 'text', text: '<message to="slack-test">done B</message>' };
+            yield { type: 'result', text: '<message to="slack-test">done B</message>' };
+            continue;
+          }
+          await new Promise<void>((r) => (waiting = r));
+          waiting = null;
+        }
+      },
+    };
+    return {
+      push: (m: string) => {
+        pending.push(m);
+        waiting?.();
+      },
+      end: () => {},
+      abort: () => {
+        aborted = true;
+        waiting?.();
+      },
+      events,
+    };
+  }
+}
+
+describe('runner turn state', () => {
+  it('stays working across a two-message turn and reports idle once it returns to waiting', async () => {
+    insertMessage('m-a', 'first question', 'thread-A');
+    const provider = new HoldingProvider();
+    const controller = new AbortController();
+    const loop = runPollLoop({
+      provider,
+      providerContract: CONTRACT,
+      providerName: 'mock',
+      cwd: '/tmp',
+      signal: controller.signal,
+    });
+
+    // Turn opens working while the provider holds the stream.
+    await waitFor(() => readTurn() === 'working', 3000);
+    await waitFor(() => getUndeliveredMessages().length >= 1, 3000); // "partial A" streamed
+
+    // A second message arrives mid-turn — the turn is still working.
+    insertMessage('m-b', 'second question', 'thread-B');
+    await sleep(700); // follow-up poller pushes m-b into the running turn
+    expect(readTurn()).toBe('working');
+
+    // Release: both turns answer, then the loop returns to waiting → idle.
+    provider.release();
+    await waitFor(() => getUndeliveredMessages().length >= 2, 5000);
+    await waitFor(() => readTurn() === 'idle', 3000);
+
+    controller.abort();
+    await loop.catch(() => {});
+    expect(readTurn()).toBe('idle');
+  });
+
+  it('reports idle after a quiet turn that delivers no message', async () => {
+    insertMessage('m-a', 'no reply needed', 'thread-A');
+    // Empty response: the turn runs but writes nothing user-facing.
+    const provider = new MockProvider({}, () => '');
+    const controller = new AbortController();
+    const loop = runPollLoop({
+      provider,
+      providerContract: CONTRACT,
+      providerName: 'mock',
+      cwd: '/tmp',
+      signal: controller.signal,
+    });
+
+    await waitFor(() => readTurn() === 'idle', 4000);
+    expect(getUndeliveredMessages()).toHaveLength(0);
+
+    controller.abort();
+    await loop.catch(() => {});
+  });
+});

--- a/docs/db-session.md
+++ b/docs/db-session.md
@@ -185,7 +185,10 @@ Access: `container/agent-runner/src/db/session-state.ts`.
 
 ### 4.4 `container_state`
 
-Single-row (`id=1`) tool-in-flight tracker. The container records the currently-running tool on `PreToolUse` and clears it on `PostToolUse`/`PostToolUseFailure`; the host reads it during the stale-container sweep to widen its stuck-tolerance window when `Bash` is running with a user-declared `timeout` over the normal threshold, so long-running scripts aren't killed as "stuck".
+Single-row (`id=1`) container status. Two things live here:
+
+- **Tool in flight.** The container records the currently-running tool on `PreToolUse` and clears it on `PostToolUse`/`PostToolUseFailure`; the host reads it during the stale-container sweep to widen its stuck-tolerance window when `Bash` is running with a user-declared `timeout` over the normal threshold, so long-running scripts aren't killed as "stuck".
+- **Turn state.** The poll loop writes `turn = 'working'` when it starts answering (and re-marks it every 5 s while a turn runs, so `updated_at` keeps moving) and `turn = 'idle'` when the turn ends. The host reads it on the delivery poll and drives the typing indicator from it: refresh while `working` and fresh, clear on `idle` or when the report goes stale. `NULL` means the runner never reported (a runner predating the column) — the host falls back to the heartbeat-file rule.
 
 ```sql
 CREATE TABLE container_state (
@@ -193,13 +196,14 @@ CREATE TABLE container_state (
   current_tool             TEXT,
   tool_declared_timeout_ms INTEGER,
   tool_started_at          TEXT,
+  turn                     TEXT,     -- 'working' | 'idle' | NULL (not reported)
   updated_at               TEXT NOT NULL
 );
 ```
 
-- **Writer (container):** the SQLite mailbox driver records tool state in `container/agent-runner/src/mailbox/sqlite/connection.ts`.
-- **Reader (host):** `getContainerState()` in `src/mailbox/sqlite/session-db.ts`; consumed through the mailbox contract by the sweep.
-- `CREATE TABLE IF NOT EXISTS` — forward-compatible with `outbound.db` files created before this table existed; `getContainerState()` returns `null` if the table or row is absent.
+- **Writer (container):** the SQLite mailbox driver records tool state and turn state in `container/agent-runner/src/mailbox/sqlite/connection.ts`. A turn write moves only `turn` and `updated_at`; a tool write leaves `turn` alone.
+- **Reader (host):** `getContainerState()` in `src/mailbox/sqlite/session-db.ts`; consumed through the mailbox contract by the sweep and by the delivery poll (typing).
+- `CREATE TABLE IF NOT EXISTS` — forward-compatible with `outbound.db` files created before this table existed; `getContainerState()` returns `null` if the table or row is absent. `turn` was added later: the runner adds the column on start (`ALTER TABLE … ADD COLUMN`, guarded by `PRAGMA table_info`), and the host read tolerates a table that still lacks it (an older runner owns that file), reporting `turn: null`.
 
 ---
 

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -238,9 +238,10 @@ export interface ChannelAdapter {
   ): Promise<void>;
   /**
    * Clear the typing indicator. Only implemented by platforms whose
-   * indicator does not expire on its own (e.g. Slack's assistant status,
-   * which has no TTL and is only cleared by a post or an explicit clear).
-   * Everyone else omits it and callers no-op via optional chaining.
+   * indicator does not expire on its own within a turn (e.g. Slack's
+   * assistant status, which persists until a post in the thread, an
+   * explicit clear, or a two-minute timeout). Everyone else omits it and
+   * callers no-op via optional chaining.
    */
   clearTyping?(platformId: string, threadId: string | null): Promise<void>;
   syncConversations?(): Promise<ConversationInfo[]>;

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -236,6 +236,13 @@ export interface ChannelAdapter {
     status?: string,
     statusKind?: 'auto' | 'agent',
   ): Promise<void>;
+  /**
+   * Clear the typing indicator. Only implemented by platforms whose
+   * indicator does not expire on its own (e.g. Slack's assistant status,
+   * which has no TTL and is only cleared by a post or an explicit clear).
+   * Everyone else omits it and callers no-op via optional chaining.
+   */
+  clearTyping?(platformId: string, threadId: string | null): Promise<void>;
   syncConversations?(): Promise<ConversationInfo[]>;
   /** Resolve conversation type and human-readable metadata for host UI. */
   resolveConversation?(platformId: string): Promise<ResolvedConversation | null>;

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -31,10 +31,16 @@ function now() {
 function createMockAdapter(
   channelType: string,
   instance?: string,
-): ChannelAdapter & { delivered: OutboundMessage[]; inbound: InboundMessage[]; setupTimes: number[] } {
+): ChannelAdapter & {
+  delivered: OutboundMessage[];
+  inbound: InboundMessage[];
+  setupTimes: number[];
+  clears: Array<{ platformId: string; threadId: string | null }>;
+} {
   const delivered: OutboundMessage[] = [];
   const inbound: InboundMessage[] = [];
   const setupTimes: number[] = [];
+  const clears: Array<{ platformId: string; threadId: string | null }> = [];
   let setupConfig: ChannelSetup | null = null;
 
   return {
@@ -45,6 +51,7 @@ function createMockAdapter(
     delivered,
     inbound,
     setupTimes,
+    clears,
 
     async setup(config: ChannelSetup) {
       setupTimes.push(Date.now());
@@ -69,6 +76,10 @@ function createMockAdapter(
     },
 
     async setTyping() {},
+
+    async clearTyping(platformId: string, threadId: string | null) {
+      clears.push({ platformId, threadId });
+    },
   };
 }
 
@@ -237,6 +248,21 @@ describe('channel registry — instance keying', () => {
       'slack-tester',
     );
     expect(tester.delivered).toHaveLength(1);
+  });
+
+  it('dispatches clearTyping to the exact adapter instance, like setTyping', async () => {
+    const reg = await import('./channel-registry.js');
+    const tester = createMockAdapter('slack', 'slack-tester');
+    const worker = createMockAdapter('slack', 'slack-worker');
+    reg.registerChannelAdapter('slack-tester', { factory: () => tester });
+    reg.registerChannelAdapter('slack-worker', { factory: () => worker });
+    await reg.initChannelAdapters(mockSetup);
+
+    const bridge = reg.createChannelDeliveryAdapter();
+    await bridge.clearTyping!('slack', 'slack:C1', 'T1', 'slack-tester');
+
+    expect(tester.clears).toEqual([{ platformId: 'slack:C1', threadId: 'T1' }]);
+    expect(worker.clears).toHaveLength(0);
   });
 });
 

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -124,6 +124,15 @@ export function createChannelDeliveryAdapter(): ChannelDeliveryAdapter {
       const adapter = getChannelAdapterExact(instance ?? channelType);
       await adapter?.setTyping?.(platformId, threadId, status, statusKind);
     },
+    async clearTyping(
+      channelType: string,
+      platformId: string,
+      threadId: string | null,
+      instance?: string,
+    ): Promise<void> {
+      const adapter = getChannelAdapterExact(instance ?? channelType);
+      await adapter?.clearTyping?.(platformId, threadId);
+    },
   };
 }
 

--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Adapter, AdapterPostableMessage, RawMessage } from 'chat';
 
-import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
+import { createChatSdkBridge, normalizeStatusText, splitForLimit } from './chat-sdk-bridge.js';
 
 vi.mock('../webhook-server.js', () => ({
   registerWebhookAdapter: vi.fn(),
@@ -94,6 +94,34 @@ describe('createChatSdkBridge', () => {
       supportsThreads: true,
     });
     expect(typeof bridge.subscribe).toBe('function');
+  });
+
+  it('setTyping passes a status line to startTyping, normalized to one trimmed line', async () => {
+    const typingCalls: Array<{ threadId: string; status?: string }> = [];
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({
+        startTyping: async (threadId: string, status?: string) => {
+          typingCalls.push({ threadId, status });
+        },
+      }),
+      supportsThreads: true,
+    });
+    await bridge.setTyping!('C123', 'C123:1700000000.000100');
+    await bridge.setTyping!('C123', 'C123:1700000000.000100', '  Reading\nthe   thread  ', 'agent');
+    await bridge.setTyping!('C123', 'C123:1700000000.000100', '   ');
+    expect(typingCalls).toEqual([
+      { threadId: 'C123:1700000000.000100', status: undefined },
+      { threadId: 'C123:1700000000.000100', status: 'Reading the thread' },
+      { threadId: 'C123:1700000000.000100', status: undefined },
+    ]);
+  });
+
+  it('normalizeStatusText caps an over-long line', () => {
+    const long = 'x'.repeat(500);
+    const out = normalizeStatusText(long);
+    expect(out.length).toBe(200);
+    expect(out.endsWith('…')).toBe(true);
+    expect(normalizeStatusText('short line')).toBe('short line');
   });
 
   it('clearTyping clears a Slack-shaped assistant status with an empty string', async () => {

--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -95,6 +95,48 @@ describe('createChatSdkBridge', () => {
     });
     expect(typeof bridge.subscribe).toBe('function');
   });
+
+  it('clearTyping clears a Slack-shaped assistant status with an empty string', async () => {
+    const statusCalls: Array<{ channelId: string; threadTs: string; status: string }> = [];
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({
+        decodeThreadId: (threadId: string) => {
+          const [channel, threadTs] = threadId.split(':');
+          return { channel, threadTs };
+        },
+        setAssistantStatus: async (channelId: string, threadTs: string, status: string) => {
+          statusCalls.push({ channelId, threadTs, status });
+        },
+      } as unknown as Partial<Adapter>),
+      supportsThreads: true,
+    });
+    await bridge.clearTyping!('C123', 'C123:1700000000.000100');
+    expect(statusCalls).toEqual([{ channelId: 'C123', threadTs: '1700000000.000100', status: '' }]);
+  });
+
+  it('clearTyping is a no-op when the adapter cannot clear (no setAssistantStatus)', async () => {
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({}),
+      supportsThreads: true,
+    });
+    // No throw, nothing to assert beyond "does not reject".
+    await expect(bridge.clearTyping!('C123', 'thread-1')).resolves.toBeUndefined();
+  });
+
+  it('clearTyping is a no-op when the decoded thread has no threadTs', async () => {
+    const statusCalls: string[] = [];
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({
+        decodeThreadId: (_threadId: string) => ({ channel: 'C123' }),
+        setAssistantStatus: async (_channelId: string, _threadTs: string, _status: string) => {
+          statusCalls.push('called');
+        },
+      } as unknown as Partial<Adapter>),
+      supportsThreads: true,
+    });
+    await bridge.clearTyping!('C123', 'C123');
+    expect(statusCalls).toHaveLength(0);
+  });
 });
 
 describe('createChatSdkBridge — instance identity', () => {

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -966,6 +966,25 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       await adapter.startTyping(tid);
     },
 
+    // The Chat SDK adapter contract has startTyping and no stop, so clearing
+    // is platform-specific. Slack's assistant status has no expiry and is
+    // cleared by setting it to empty; the Slack adapter exposes
+    // setAssistantStatus(channel, threadTs, status) and decodeThreadId
+    // publicly. Call it only when the adapter has both and the decoded thread
+    // carries a threadTs; otherwise there is nothing to clear.
+    async clearTyping(platformId: string, threadId: string | null) {
+      const clearable = adapter as Partial<{
+        setAssistantStatus(channelId: string, threadTs: string, status: string): Promise<void>;
+        decodeThreadId(threadId: string): { channel?: string; threadTs?: string };
+      }>;
+      if (typeof clearable.setAssistantStatus !== 'function' || typeof clearable.decodeThreadId !== 'function') return;
+      const tid = threadId ?? platformId;
+      const decoded = clearable.decodeThreadId(tid);
+      const channel = decoded?.channel ?? adapter.channelIdFromThreadId(tid);
+      if (!decoded?.threadTs || !channel) return;
+      await clearable.setAssistantStatus(channel, decoded.threadTs, '');
+    },
+
     async teardown() {
       gatewayAbort?.abort();
       await chat.shutdown();

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -38,6 +38,18 @@ interface GatewayAdapter extends Adapter {
   ): Promise<Response>;
 }
 
+/**
+ * Longest status line the bridge will hand to an adapter. Slack renders the
+ * assistant status as one line and documents no limit; the cap is defensive.
+ */
+const MAX_STATUS_TEXT_LENGTH = 200;
+
+/** One line, trimmed, capped — the shape every adapter can show. */
+export function normalizeStatusText(status: string): string {
+  const oneLine = status.replace(/\s+/g, ' ').trim();
+  return oneLine.length > MAX_STATUS_TEXT_LENGTH ? `${oneLine.slice(0, MAX_STATUS_TEXT_LENGTH - 1)}…` : oneLine;
+}
+
 /** Reply context extracted from a platform's raw message. */
 export interface ReplyContext {
   text: string;
@@ -961,14 +973,21 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       }
     },
 
-    async setTyping(platformId: string, threadId: string | null) {
+    async setTyping(platformId: string, threadId: string | null, status?: string) {
       const tid = threadId ?? platformId;
-      await adapter.startTyping(tid);
+      // The Chat SDK's startTyping takes an optional status line; the Slack
+      // adapter shows it as the thread's assistant status (a single line).
+      // Neither the adapter nor Slack documents a length limit and the
+      // adapter passes the text through untouched, so normalize here:
+      // one line, trimmed, capped.
+      const text = status ? normalizeStatusText(status) : undefined;
+      await adapter.startTyping(tid, text || undefined);
     },
 
     // The Chat SDK adapter contract has startTyping and no stop, so clearing
-    // is platform-specific. Slack's assistant status has no expiry and is
-    // cleared by setting it to empty; the Slack adapter exposes
+    // is platform-specific. Slack's assistant status persists until a post, an
+    // explicit clear, or a two-minute timeout, and is cleared by setting it to
+    // empty; the Slack adapter exposes
     // setAssistantStatus(channel, threadTs, status) and decodeThreadId
     // publicly. Call it only when the adapter has both and the decoded thread
     // carries a threadTs; otherwise there is nothing to clear.

--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -39,6 +39,7 @@ import {
 import { createChannelDeliveryAdapter } from './channels/channel-registry.js';
 import { createDestination } from './modules/agent-to-agent/db/agent-destinations.js';
 import { getAgentMailbox } from './mailbox/index.js';
+import * as typing from './modules/typing/index.js';
 import { log } from './log.js';
 
 function openInboundDb(agentGroupId: string, sessionId: string): Database.Database {
@@ -74,6 +75,16 @@ function insertOutbound(agentGroupId: string, sessionId: string, msgId: string):
     `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
      VALUES (?, datetime('now'), 'chat', 'telegram:123', 'telegram', ?)`,
   ).run(msgId, JSON.stringify({ text: 'hello' }));
+  db.close();
+}
+
+function setContainerTurn(agentGroupId: string, sessionId: string, turn: string, updatedAt: string): void {
+  const db = new Database(outboundDbPath(agentGroupId, sessionId));
+  db.prepare(
+    `INSERT INTO container_state (id, current_tool, tool_declared_timeout_ms, tool_started_at, turn, updated_at)
+     VALUES (1, NULL, NULL, NULL, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET turn = excluded.turn, updated_at = excluded.updated_at`,
+  ).run(turn, updatedAt);
   db.close();
 }
 
@@ -134,6 +145,44 @@ describe('deliverSessionMessages — concurrent invocations', () => {
     await Promise.all([deliverSessionMessages(session), deliverSessionMessages(session)]);
 
     expect(calls).toHaveLength(1);
+  });
+
+  it('reads the runner turn report on the poll and forwards it to the typing module', async () => {
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+    const updatedAt = new Date().toISOString();
+    setContainerTurn('ag-1', session.id, 'working', updatedAt);
+    setDeliveryAdapter({
+      async deliver() {
+        return undefined;
+      },
+    });
+
+    const spy = vi.spyOn(typing, 'noteTurnState');
+    try {
+      await deliverSessionMessages(session);
+      expect(spy).toHaveBeenCalledWith(session.id, { turn: 'working', updatedAtMs: Date.parse(updatedAt) });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('forwards a not-reported turn (no container_state row) as null', async () => {
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+    setDeliveryAdapter({
+      async deliver() {
+        return undefined;
+      },
+    });
+
+    const spy = vi.spyOn(typing, 'noteTurnState');
+    try {
+      await deliverSessionMessages(session);
+      expect(spy).toHaveBeenCalledWith(session.id, { turn: null, updatedAtMs: null });
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('still delivers on a subsequent call after the first finishes', async () => {

--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -78,6 +78,16 @@ function insertOutbound(agentGroupId: string, sessionId: string, msgId: string):
   db.close();
 }
 
+function setLiveStatus(agentGroupId: string, sessionId: string, text: string, updatedAt: string): void {
+  const db = new Database(outboundDbPath(agentGroupId, sessionId));
+  db.prepare('INSERT OR REPLACE INTO session_state (key, value, updated_at) VALUES (?, ?, ?)').run(
+    'live_status',
+    text,
+    updatedAt,
+  );
+  db.close();
+}
+
 function setContainerTurn(agentGroupId: string, sessionId: string, turn: string, updatedAt: string): void {
   const db = new Database(outboundDbPath(agentGroupId, sessionId));
   db.prepare(
@@ -158,10 +168,59 @@ describe('deliverSessionMessages — concurrent invocations', () => {
       },
     });
 
-    const spy = vi.spyOn(typing, 'noteTurnState');
+    const spy = vi.spyOn(typing, 'notePresence');
     try {
       await deliverSessionMessages(session);
-      expect(spy).toHaveBeenCalledWith(session.id, { turn: 'working', updatedAtMs: Date.parse(updatedAt) });
+      expect(spy).toHaveBeenCalledWith(session.id, {
+        turn: 'working',
+        updatedAtMs: Date.parse(updatedAt),
+        status: null,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('forwards the runner status line beside the turn as one presence report', async () => {
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+    const turnAt = new Date().toISOString();
+    const statusAt = new Date(Date.now() + 1).toISOString();
+    setContainerTurn('ag-1', session.id, 'working', turnAt);
+    setLiveStatus('ag-1', session.id, '  Reading the thread  ', statusAt);
+    setDeliveryAdapter({
+      async deliver() {
+        return undefined;
+      },
+    });
+
+    const spy = vi.spyOn(typing, 'notePresence');
+    try {
+      await deliverSessionMessages(session);
+      expect(spy).toHaveBeenCalledWith(session.id, {
+        turn: 'working',
+        updatedAtMs: Date.parse(turnAt),
+        status: { text: 'Reading the thread', atMs: Date.parse(statusAt) },
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('a blank status line reads as no status', async () => {
+    await seedAgentAndChannel();
+    const { session } = await resolveSession('ag-1', 'mg-1', null, 'shared');
+    setLiveStatus('ag-1', session.id, '   ', new Date().toISOString());
+    setDeliveryAdapter({
+      async deliver() {
+        return undefined;
+      },
+    });
+
+    const spy = vi.spyOn(typing, 'notePresence');
+    try {
+      await deliverSessionMessages(session);
+      expect(spy).toHaveBeenCalledWith(session.id, { turn: null, updatedAtMs: null, status: null });
     } finally {
       spy.mockRestore();
     }
@@ -176,10 +235,10 @@ describe('deliverSessionMessages — concurrent invocations', () => {
       },
     });
 
-    const spy = vi.spyOn(typing, 'noteTurnState');
+    const spy = vi.spyOn(typing, 'notePresence');
     try {
       await deliverSessionMessages(session);
-      expect(spy).toHaveBeenCalledWith(session.id, { turn: null, updatedAtMs: null });
+      expect(spy).toHaveBeenCalledWith(session.id, { turn: null, updatedAtMs: null, status: null });
     } finally {
       spy.mockRestore();
     }

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -25,7 +25,7 @@ import { fanOutboundMessage } from './modules/cross-session-context/index.js';
 import { log } from './log.js';
 import { normalizeOptions } from './channels/ask-question.js';
 import { clearOutbox, readOutboxFiles, withExistingMailboxSession } from './session-manager.js';
-import { noteTurnState, pauseTypingRefreshAfterDelivery, setTypingAdapter } from './modules/typing/index.js';
+import { notePresence, pauseTypingRefreshAfterDelivery, setTypingAdapter } from './modules/typing/index.js';
 import type { OutboundFile } from './channels/adapter.js';
 import type { PendingApproval, Session } from './types.js';
 import type { OutboundMessage } from './mailbox/index.js';
@@ -230,20 +230,26 @@ async function drainSession(session: Session): Promise<void> {
       return {
         delivered,
         pending: mailbox.getDueMessages(delivered).filter((candidate) => !delivered.has(candidate.id)),
-        // Read the runner's turn report on the same poll — no new session,
-        // no new poll. Drives the typing indicator (see noteTurnState).
+        // Read the runner's presence on the same poll — no new session, no
+        // new poll: its turn report from the container record and the
+        // optional status line it publishes under the `live_status` state
+        // key. Both drive the typing indicator (see notePresence).
         containerState: mailbox.getContainerState(),
+        liveStatus: mailbox.getState?.('live_status'),
       };
     });
     if (!existing) return;
     ({ delivered, pending } = existing);
-    // Typing follows the runner's turn state. Null-safe: a missing record or a
+    // Typing follows the runner's presence. Null-safe: a missing record or a
     // null turn (older runner) reads as "not reported" and the typing module
-    // keeps its heartbeat-file fallback for that session.
-    const containerState = existing.containerState;
-    noteTurnState(session.id, {
+    // keeps its heartbeat-file fallback for that session; no status row, or
+    // a blank one, means plain typing.
+    const { containerState, liveStatus } = existing;
+    const statusText = liveStatus?.value.trim();
+    notePresence(session.id, {
       turn: containerState?.turn ?? null,
       updatedAtMs: containerState ? Date.parse(containerState.updatedAt) : null,
+      status: liveStatus && statusText ? { text: statusText, atMs: Date.parse(liveStatus.updatedAt) } : null,
     });
   } catch (err) {
     log.error('Session mailbox delivery failed', {

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -25,7 +25,7 @@ import { fanOutboundMessage } from './modules/cross-session-context/index.js';
 import { log } from './log.js';
 import { normalizeOptions } from './channels/ask-question.js';
 import { clearOutbox, readOutboxFiles, withExistingMailboxSession } from './session-manager.js';
-import { pauseTypingRefreshAfterDelivery, setTypingAdapter } from './modules/typing/index.js';
+import { noteTurnState, pauseTypingRefreshAfterDelivery, setTypingAdapter } from './modules/typing/index.js';
 import type { OutboundFile } from './channels/adapter.js';
 import type { PendingApproval, Session } from './types.js';
 import type { OutboundMessage } from './mailbox/index.js';
@@ -109,6 +109,7 @@ export interface ChannelDeliveryAdapter {
     status?: string,
     statusKind?: 'auto' | 'agent',
   ): Promise<void>;
+  clearTyping?(channelType: string, platformId: string, threadId: string | null, instance?: string): Promise<void>;
 }
 
 let deliveryAdapter: ChannelDeliveryAdapter | null = null;
@@ -229,10 +230,21 @@ async function drainSession(session: Session): Promise<void> {
       return {
         delivered,
         pending: mailbox.getDueMessages(delivered).filter((candidate) => !delivered.has(candidate.id)),
+        // Read the runner's turn report on the same poll — no new session,
+        // no new poll. Drives the typing indicator (see noteTurnState).
+        containerState: mailbox.getContainerState(),
       };
     });
     if (!existing) return;
     ({ delivered, pending } = existing);
+    // Typing follows the runner's turn state. Null-safe: a missing record or a
+    // null turn (older runner) reads as "not reported" and the typing module
+    // keeps its heartbeat-file fallback for that session.
+    const containerState = existing.containerState;
+    noteTurnState(session.id, {
+      turn: containerState?.turn ?? null,
+      updatedAtMs: containerState ? Date.parse(containerState.updatedAt) : null,
+    });
   } catch (err) {
     log.error('Session mailbox delivery failed', {
       agentGroupId: agentGroup.id,

--- a/src/host-sweep.test.ts
+++ b/src/host-sweep.test.ts
@@ -129,6 +129,8 @@ describe('decideStuckAction', () => {
         currentTool: 'Bash',
         toolDeclaredTimeoutMs: twoHrMs,
         toolStartedAt: parseIsoTimestamp(new Date(BASE - 45 * 60 * 1000).toISOString()),
+        turn: null,
+        updatedAt: parseIsoTimestamp(new Date(BASE - 45 * 60 * 1000).toISOString()),
       },
       claims: [],
     });
@@ -180,6 +182,8 @@ describe('decideStuckAction', () => {
         currentTool: 'Bash',
         toolDeclaredTimeoutMs: tenMinMs,
         toolStartedAt: parseIsoTimestamp(new Date(BASE - 5 * 60 * 1000).toISOString()),
+        turn: null,
+        updatedAt: parseIsoTimestamp(new Date(BASE - 5 * 60 * 1000).toISOString()),
       },
       claims: [claim('msg-1', 5 * 60 * 1000)],
     });

--- a/src/mailbox/index.ts
+++ b/src/mailbox/index.ts
@@ -41,4 +41,5 @@ export type {
   TaskRecord,
   TaskStats,
   TaskUpdate,
+  TurnState,
 } from './types.js';

--- a/src/mailbox/index.ts
+++ b/src/mailbox/index.ts
@@ -37,6 +37,7 @@ export type {
   ProcessingAck,
   RecurringMessage,
   SessionRouting,
+  StateValue,
   Task,
   TaskRecord,
   TaskStats,

--- a/src/mailbox/model.test.ts
+++ b/src/mailbox/model.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createInboundRecord,
   createOutboundRecord,
+  parseContainerRecord,
   parseDestinationRecord,
   parseDirectOutboundWrite,
   parseInboundRecord,
@@ -212,5 +213,30 @@ describe('canonical mailbox model', () => {
         agentGroupId: null,
       }),
     ).toThrow('agent routing fields');
+  });
+});
+
+describe('container record turn state', () => {
+  const base = {
+    currentTool: 'Bash',
+    toolDeclaredTimeoutMs: 30_000,
+    toolStartedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:01.000Z',
+  };
+
+  it('parses a reported turn', () => {
+    expect(parseContainerRecord({ ...base, turn: 'working' }).turn).toBe('working');
+    expect(parseContainerRecord({ ...base, turn: 'idle' }).turn).toBe('idle');
+  });
+
+  it('reads a record persisted before the field existed as "not reported"', () => {
+    expect(parseContainerRecord(base)).toEqual({ ...base, turn: null });
+    expect(parseContainerRecord({ ...base, turn: null }).turn).toBeNull();
+    expect(parseContainerRecord({ ...base, turn: undefined }).turn).toBeNull();
+  });
+
+  it('rejects a turn outside the contract', () => {
+    expect(() => parseContainerRecord({ ...base, turn: 'busy' })).toThrow('invalid mailbox field turn');
+    expect(() => parseContainerRecord({ ...base, turn: 1 })).toThrow('invalid mailbox field turn');
   });
 });

--- a/src/mailbox/model.ts
+++ b/src/mailbox/model.ts
@@ -27,6 +27,16 @@ const INBOUND_KINDS = ['chat', 'chat-sdk', 'task', 'webhook', 'system'] as const
 
 export type InboundKind = (typeof INBOUND_KINDS)[number];
 
+const TURN_STATES = ['working', 'idle'] as const;
+
+/**
+ * The runner's own report of whether it is inside a turn. `working` is
+ * re-marked periodically while a turn runs; `idle` is written when the turn
+ * ends. Runners that predate the field never write it, so a record without
+ * one carries `null` — "not reported", not "idle".
+ */
+export type TurnState = (typeof TURN_STATES)[number];
+
 export interface InboundWrite {
   id: string;
   kind: InboundKind;
@@ -154,6 +164,7 @@ export interface ContainerRecord {
   currentTool: string | null;
   toolDeclaredTimeoutMs: number | null;
   toolStartedAt: IsoTimestamp | null;
+  turn: TurnState | null;
   updatedAt: IsoTimestamp;
 }
 
@@ -282,6 +293,16 @@ function oneOf<const T extends readonly string[]>(record: UnknownRecord, key: st
   if (typeof value !== 'string' || !values.includes(value))
     throw new Error(`invalid mailbox field ${key}: unexpected value`);
   return value as T[number];
+}
+
+/** A field added after records were first persisted: absent or null both read as null. */
+function optionalNullableOneOf<const T extends readonly string[]>(
+  record: UnknownRecord,
+  key: string,
+  values: T,
+): T[number] | null {
+  if (!(key in record) || record[key] === undefined || record[key] === null) return null;
+  return oneOf(record, key, values);
 }
 
 export function parseInboundWrite(value: unknown): InboundWrite {
@@ -515,12 +536,15 @@ export function parseContainerRecord(value: unknown): ContainerRecord {
     'currentTool',
     'toolDeclaredTimeoutMs',
     'toolStartedAt',
+    'turn',
     'updatedAt',
   ]);
   return {
     currentTool: nullableText(record, 'currentTool'),
     toolDeclaredTimeoutMs: nullableNonNegativeInteger(record, 'toolDeclaredTimeoutMs'),
     toolStartedAt: nullableTimestamp(record, 'toolStartedAt'),
+    // Older runners never wrote `turn`; their persisted records still parse.
+    turn: optionalNullableOneOf(record, 'turn', TURN_STATES),
     updatedAt: timestamp(record, 'updatedAt'),
   };
 }

--- a/src/mailbox/sqlite/index.ts
+++ b/src/mailbox/sqlite/index.ts
@@ -9,6 +9,7 @@ import {
   deleteOrphanProcessingClaims,
   ensureSchema,
   getContainerState,
+  getSessionState,
   getDeliveredIds,
   getDueOutboundMessages,
   getInboundSourceSessionId,
@@ -32,6 +33,7 @@ import {
   createDirectOutboundRecord,
   outboundDelivery,
   parseContainerRecord,
+  parseStateRecord,
   parseDestinationRecord,
   parseOutboundRecord,
   parseProcessingAckRecord,
@@ -348,6 +350,12 @@ export function wrapSqliteOutbound(
         turn: record.turn,
         updatedAt: record.updatedAt,
       };
+    },
+    getState: (key) => {
+      const row = getSessionState(readable(), key);
+      if (!row) return undefined;
+      const record = parseStateRecord({ key, value: row.value, updatedAt: sqliteTimestamp(row.updated_at) });
+      return { value: record.value, updatedAt: record.updatedAt };
     },
     getDueMessages: (excludeIds) =>
       getDueOutboundMessages(readable())

--- a/src/mailbox/sqlite/index.ts
+++ b/src/mailbox/sqlite/index.ts
@@ -338,12 +338,15 @@ export function wrapSqliteOutbound(
         currentTool: row.current_tool,
         toolDeclaredTimeoutMs: row.tool_declared_timeout_ms,
         toolStartedAt: row.tool_started_at === null ? null : sqliteTimestamp(row.tool_started_at),
+        turn: row.turn,
         updatedAt: sqliteTimestamp(row.updated_at),
       });
       return {
         currentTool: record.currentTool,
         toolDeclaredTimeoutMs: record.toolDeclaredTimeoutMs,
         toolStartedAt: record.toolStartedAt,
+        turn: record.turn,
+        updatedAt: record.updatedAt,
       };
     },
     getDueMessages: (excludeIds) =>

--- a/src/mailbox/sqlite/schema.ts
+++ b/src/mailbox/sqlite/schema.ts
@@ -77,6 +77,7 @@ CREATE TABLE IF NOT EXISTS container_state (
   current_tool             TEXT,
   tool_declared_timeout_ms INTEGER,
   tool_started_at          TEXT,
+  turn                     TEXT,
   updated_at               TEXT NOT NULL
 );
 `;

--- a/src/mailbox/sqlite/session-db.ts
+++ b/src/mailbox/sqlite/session-db.ts
@@ -227,6 +227,27 @@ export function getContainerState(outDb: Database.Database): ContainerState | nu
   }
 }
 
+export interface SessionStateRow {
+  value: string;
+  updated_at: string;
+}
+
+/**
+ * Read one runner-written session_state row. Returns undefined when the key
+ * is absent or the table does not exist yet (outbound.db files created
+ * before session_state shipped; the runner creates it on its next start).
+ */
+export function getSessionState(outDb: Database.Database, key: string): SessionStateRow | undefined {
+  try {
+    return outDb.prepare('SELECT value, updated_at FROM session_state WHERE key = ?').get(key) as
+      | SessionStateRow
+      | undefined;
+  } catch {
+    // Table not present on older session DBs — nothing reported.
+    return undefined;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // messages_out (read-only from host)
 // ---------------------------------------------------------------------------

--- a/src/mailbox/sqlite/session-db.ts
+++ b/src/mailbox/sqlite/session-db.ts
@@ -191,24 +191,36 @@ export interface ContainerState {
   current_tool: string | null;
   tool_declared_timeout_ms: number | null;
   tool_started_at: string | null;
+  /** Runner turn report ('working' | 'idle'); null when absent or never written. */
+  turn: string | null;
   updated_at: string;
 }
 
 /**
- * Read the container's current tool-in-flight state, if any. Returns null
- * when either the table doesn't exist yet (older session DB) or no tool is
- * active. Host sweep reads this to widen stuck-detection tolerance while
- * Bash is running with a long declared timeout.
+ * Read the container's current state row, if any: the tool in flight (the
+ * host sweep widens its stuck tolerance while Bash runs with a long declared
+ * timeout) and the runner's turn report (the typing indicator follows it).
+ * Returns null when the table doesn't exist yet (older session DB) or the
+ * row was never written.
+ *
+ * `turn` was added after the table first shipped. The runner owns this file
+ * and adds the column on its next start, but an older runner never will, so
+ * the read tolerates its absence: `SELECT *` plus a per-field pick, never a
+ * column list that fails on the old shape.
  */
 export function getContainerState(outDb: Database.Database): ContainerState | null {
   try {
-    const row = outDb
-      .prepare(
-        `SELECT current_tool, tool_declared_timeout_ms, tool_started_at, updated_at
-           FROM container_state WHERE id = 1`,
-      )
-      .get() as ContainerState | undefined;
-    return row ?? null;
+    const row = outDb.prepare('SELECT * FROM container_state WHERE id = 1').get() as
+      | (Partial<ContainerState> & { updated_at: string })
+      | undefined;
+    if (!row) return null;
+    return {
+      current_tool: row.current_tool ?? null,
+      tool_declared_timeout_ms: row.tool_declared_timeout_ms ?? null,
+      tool_started_at: row.tool_started_at ?? null,
+      turn: row.turn ?? null,
+      updated_at: row.updated_at,
+    };
   } catch {
     // Table not present on older session DBs — treat as "no tool in flight".
     return null;

--- a/src/mailbox/sqlite/sqlite.test.ts
+++ b/src/mailbox/sqlite/sqlite.test.ts
@@ -96,14 +96,16 @@ describe('SQLite mailbox canonical serialization', () => {
     outboundDb
       .prepare(
         `INSERT INTO container_state
-           (id, current_tool, tool_declared_timeout_ms, tool_started_at, updated_at)
-         VALUES (1, ?, ?, ?, ?)`,
+           (id, current_tool, tool_declared_timeout_ms, tool_started_at, turn, updated_at)
+         VALUES (1, ?, ?, ?, ?, ?)`,
       )
-      .run('Bash', 30_000, '2026-01-01 00:00:00', '2026-01-01 00:00:01');
+      .run('Bash', 30_000, '2026-01-01 00:00:00', 'working', '2026-01-01 00:00:01');
     expect(outbound.getContainerState()).toEqual({
       currentTool: 'Bash',
       toolDeclaredTimeoutMs: 30_000,
       toolStartedAt: '2026-01-01T00:00:00.000Z',
+      turn: 'working',
+      updatedAt: '2026-01-01T00:00:01.000Z',
     });
 
     await outbound.writeDirect({
@@ -171,5 +173,58 @@ describe('SQLite mailbox canonical serialization', () => {
     expect(wrapSqliteOutbound(outboundDb).getTopLevelOutbound(10)).toEqual([
       { timestamp: '2026-01-01T00:00:04.000Z', content: '{"text":"top level"}' },
     ]);
+  });
+});
+
+describe('SQLite mailbox container state', () => {
+  const databases: Database.Database[] = [];
+
+  afterEach(() => {
+    for (const database of databases.splice(0)) database.close();
+  });
+
+  it('reads a container_state row written before the turn column existed', () => {
+    // An outbound.db owned by an older runner: the table predates `turn` and
+    // that runner will never add the column. The host read must still work.
+    const outboundDb = new Database(':memory:');
+    databases.push(outboundDb);
+    outboundDb.exec(`
+      CREATE TABLE container_state (
+        id                       INTEGER PRIMARY KEY CHECK (id = 1),
+        current_tool             TEXT,
+        tool_declared_timeout_ms INTEGER,
+        tool_started_at          TEXT,
+        updated_at               TEXT NOT NULL
+      );
+    `);
+    outboundDb
+      .prepare(
+        'INSERT INTO container_state (id, current_tool, tool_declared_timeout_ms, tool_started_at, updated_at) VALUES (1, ?, ?, ?, ?)',
+      )
+      .run('Bash', null, '2026-01-01 00:00:00', '2026-01-01 00:00:01');
+    const outbound = wrapSqliteOutbound(
+      () => outboundDb,
+      () => outboundDb,
+      () => 2,
+    );
+    expect(outbound.getContainerState()).toEqual({
+      currentTool: 'Bash',
+      toolDeclaredTimeoutMs: null,
+      toolStartedAt: '2026-01-01T00:00:00.000Z',
+      turn: null,
+      updatedAt: '2026-01-01T00:00:01.000Z',
+    });
+  });
+
+  it('returns null when the row was never written', () => {
+    const outboundDb = new Database(':memory:');
+    databases.push(outboundDb);
+    outboundDb.exec(OUTBOUND_SCHEMA);
+    const outbound = wrapSqliteOutbound(
+      () => outboundDb,
+      () => outboundDb,
+      () => 2,
+    );
+    expect(outbound.getContainerState()).toBeNull();
   });
 });

--- a/src/mailbox/sqlite/sqlite.test.ts
+++ b/src/mailbox/sqlite/sqlite.test.ts
@@ -228,3 +228,48 @@ describe('SQLite mailbox container state', () => {
     expect(outbound.getContainerState()).toBeNull();
   });
 });
+
+describe('SQLite mailbox session state read', () => {
+  const databases: Database.Database[] = [];
+
+  afterEach(() => {
+    for (const database of databases.splice(0)) database.close();
+  });
+
+  it('reads a runner-written state row with its stamp normalized', () => {
+    const outboundDb = new Database(':memory:');
+    databases.push(outboundDb);
+    outboundDb.exec(OUTBOUND_SCHEMA);
+    outboundDb
+      .prepare('INSERT INTO session_state (key, value, updated_at) VALUES (?, ?, ?)')
+      .run('live_status', 'Reading the thread', '2026-01-01 00:00:05');
+    const outbound = wrapSqliteOutbound(
+      () => outboundDb,
+      () => outboundDb,
+      () => 2,
+    );
+    expect(outbound.getState!('live_status')).toEqual({
+      value: 'Reading the thread',
+      updatedAt: '2026-01-01T00:00:05.000Z',
+    });
+    expect(outbound.getState!('other')).toBeUndefined();
+  });
+
+  it('returns undefined on an outbound DB created before session_state existed', () => {
+    const outboundDb = new Database(':memory:');
+    databases.push(outboundDb);
+    outboundDb.exec(`
+      CREATE TABLE messages_out (
+        id TEXT PRIMARY KEY, seq INTEGER UNIQUE, in_reply_to TEXT, timestamp TEXT NOT NULL,
+        deliver_after TEXT, recurrence TEXT, kind TEXT NOT NULL, platform_id TEXT, channel_type TEXT,
+        thread_id TEXT, content TEXT NOT NULL
+      );
+    `);
+    const outbound = wrapSqliteOutbound(
+      () => outboundDb,
+      () => outboundDb,
+      () => 2,
+    );
+    expect(outbound.getState!('live_status')).toBeUndefined();
+  });
+});

--- a/src/mailbox/types.ts
+++ b/src/mailbox/types.ts
@@ -28,6 +28,7 @@ export type {
   StateRecord,
   TaskStatus,
   TaskWrite,
+  TurnState,
 } from './model.js';
 
 export interface MailboxSessionKey {
@@ -52,7 +53,11 @@ export interface ProcessingClaim {
   statusChanged: string;
 }
 
-export type ContainerState = Omit<ContainerRecord, 'updatedAt'>;
+/**
+ * The container's state row as the host reads it: tool in flight (sweep
+ * tolerance) plus the runner's turn report and its stamp (typing indicator).
+ */
+export type ContainerState = ContainerRecord;
 export type OutboundMessage = OutboundDelivery;
 export type Task = TaskWrite;
 

--- a/src/mailbox/types.ts
+++ b/src/mailbox/types.ts
@@ -6,6 +6,7 @@ import type {
   OutboundDelivery,
   ProcessingAckRecord,
   SessionRoutingRecord,
+  StateRecord,
   TaskRecord as CanonicalTaskRecord,
   TaskWrite,
 } from './model.js';
@@ -58,6 +59,8 @@ export interface ProcessingClaim {
  * tolerance) plus the runner's turn report and its stamp (typing indicator).
  */
 export type ContainerState = ContainerRecord;
+/** One runner-written `session_state` row as the host reads it (the key is the lookup). */
+export type StateValue = Omit<StateRecord, 'key'>;
 export type OutboundMessage = OutboundDelivery;
 export type Task = TaskWrite;
 
@@ -143,6 +146,14 @@ export interface OutboundMailbox {
   getProcessingClaims(): ProcessingClaim[];
   deleteOrphanProcessingClaims(): number;
   getContainerState(): ContainerState | null;
+  /**
+   * Read one runner-written session_state row (the runner's generic
+   * per-session state, e.g. its `live_status` text). Undefined when the key
+   * is absent or the table does not exist yet (older session DB). Optional
+   * so mailbox implementations that carry no runner state still conform;
+   * readers call it as `getState?.(key)`.
+   */
+  getState?(key: string): StateValue | undefined;
   getDueMessages(excludeIds?: ReadonlySet<string>): OutboundMessage[];
   writeDirect(message: DirectOutboundMessage): Promise<void>;
   getOutboundHistory(limit: number): MailboxHistoryMessage[];

--- a/src/modules/typing/index.test.ts
+++ b/src/modules/typing/index.test.ts
@@ -19,14 +19,21 @@ import path from 'path';
 
 import { heartbeatPath } from '../../session-manager.js';
 import {
-  noteTurnState,
+  notePresence,
   pauseTypingRefreshAfterDelivery,
   setTypingAdapter,
   startTypingRefresh,
   stopTypingRefresh,
 } from './index.js';
 
-type Call = { channelType: string; platformId: string; threadId: string | null; instance?: string };
+type Call = {
+  channelType: string;
+  platformId: string;
+  threadId: string | null;
+  instance?: string;
+  status?: string;
+  statusKind?: 'auto' | 'agent';
+};
 
 function captureAdapter() {
   const calls: Call[] = [];
@@ -43,8 +50,8 @@ function captureSetAndClear() {
   const sets: Call[] = [];
   const clears: Call[] = [];
   setTypingAdapter({
-    async setTyping(channelType, platformId, threadId, instance) {
-      sets.push({ channelType, platformId, threadId, instance });
+    async setTyping(channelType, platformId, threadId, instance, status, statusKind) {
+      sets.push({ channelType, platformId, threadId, instance, status, statusKind });
     },
     async clearTyping(channelType, platformId, threadId, instance) {
       clears.push({ channelType, platformId, threadId, instance });
@@ -166,7 +173,7 @@ describe('typing follows the runner turn state', () => {
   /** Advance past the 15s grace, keeping a working report live throughout. */
   async function advancePastGraceWorking(): Promise<void> {
     for (let elapsed = 0; elapsed < 20_000; elapsed += 4_000) {
-      noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+      notePresence(SESS, { turn: 'working', updatedAtMs: Date.now(), status: null });
       await vi.advanceTimersByTimeAsync(4_000);
     }
   }
@@ -181,7 +188,7 @@ describe('typing follows the runner turn state', () => {
     expect(setsWhileWorking).toBeGreaterThan(1); // still refreshing past grace
 
     // Turn ends without delivering anything.
-    noteTurnState(SESS, { turn: 'idle', updatedAtMs: Date.now() });
+    notePresence(SESS, { turn: 'idle', updatedAtMs: Date.now(), status: null });
     await vi.advanceTimersByTimeAsync(4_000);
 
     expect(clears).toHaveLength(1);
@@ -203,27 +210,27 @@ describe('typing follows the runner turn state', () => {
     // First delivery pauses the refresh; ticks inside the pause skip setTyping.
     pauseTypingRefreshAfterDelivery(SESS);
     let before = sets.length;
-    noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+    notePresence(SESS, { turn: 'working', updatedAtMs: Date.now(), status: null });
     await vi.advanceTimersByTimeAsync(8_000); // inside the 10s pause
     expect(sets.length).toBe(before); // no refresh while paused
 
     // Pause expires; a live working report resumes refreshing.
-    noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+    notePresence(SESS, { turn: 'working', updatedAtMs: Date.now(), status: null });
     await vi.advanceTimersByTimeAsync(4_000);
     expect(sets.length).toBeGreaterThan(before);
 
     // Second delivery pauses again.
     pauseTypingRefreshAfterDelivery(SESS);
     before = sets.length;
-    noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+    notePresence(SESS, { turn: 'working', updatedAtMs: Date.now(), status: null });
     await vi.advanceTimersByTimeAsync(8_000);
     expect(sets.length).toBe(before);
-    noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+    notePresence(SESS, { turn: 'working', updatedAtMs: Date.now(), status: null });
     await vi.advanceTimersByTimeAsync(4_000);
     expect(sets.length).toBeGreaterThan(before);
 
     // Turn ends: exactly one clear across the whole turn.
-    noteTurnState(SESS, { turn: 'idle', updatedAtMs: Date.now() });
+    notePresence(SESS, { turn: 'idle', updatedAtMs: Date.now(), status: null });
     await vi.advanceTimersByTimeAsync(4_000);
     expect(clears).toHaveLength(1);
   });
@@ -237,7 +244,7 @@ describe('typing follows the runner turn state', () => {
     // The runner dies: the last working report stops advancing. It stays live
     // for TURN_STALE_MS, then the next tick ends the refresh.
     const setsBeforeDeath = sets.length;
-    noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+    notePresence(SESS, { turn: 'working', updatedAtMs: Date.now(), status: null });
     // Under the stale window: still refreshing.
     await vi.advanceTimersByTimeAsync(12_000);
     expect(sets.length).toBeGreaterThan(setsBeforeDeath);
@@ -257,7 +264,7 @@ describe('typing follows the runner turn state', () => {
     startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
     await vi.advanceTimersByTimeAsync(0);
 
-    // Never call noteTurnState. Past grace, a fresh heartbeat keeps typing on.
+    // Never call notePresence. Past grace, a fresh heartbeat keeps typing on.
     for (let elapsed = 0; elapsed < 20_000; elapsed += 4_000) {
       touchHeartbeat(AG, SESS);
       await vi.advanceTimersByTimeAsync(4_000);
@@ -286,10 +293,143 @@ describe('typing follows the runner turn state', () => {
     expect(clears).toHaveLength(1);
   });
 
-  it('noteTurnState with no active refresher creates none', async () => {
+  it('notePresence with no active refresher creates none', async () => {
     const { sets } = captureSetAndClear();
-    noteTurnState('sess-never', { turn: 'working', updatedAtMs: Date.now() });
+    notePresence('sess-never', { turn: 'working', updatedAtMs: Date.now(), status: null });
     await vi.advanceTimersByTimeAsync(8_000);
     expect(sets).toHaveLength(0);
+  });
+});
+
+describe('presence: runner status text rides on the typing indicator', () => {
+  const SESS = 'sess-turn';
+  const AG = 'ag-turn';
+  const working = (text: string | null) => {
+    notePresence(SESS, {
+      turn: 'working',
+      updatedAtMs: Date.now(),
+      status: text === null ? null : { text, atMs: Date.now() },
+    });
+  };
+  /** Ticks from a fresh refresher until the grace window is behind us. */
+  async function runPastGrace(text: string | null): Promise<void> {
+    for (let elapsed = 0; elapsed < 20_000; elapsed += 4_000) {
+      working(text);
+      await vi.advanceTimersByTimeAsync(4_000);
+    }
+  }
+  const withText = (sets: Call[]) => sets.filter((c) => c.status !== undefined);
+  const plain = (sets: Call[]) => sets.filter((c) => c.status === undefined);
+
+  it('sends the status text (statusKind agent) while working, instead of plain typing', async () => {
+    const { sets } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+    const plainAtStart = plain(sets).length; // the immediate inbound tick is plain
+
+    await runPastGrace('Reading the thread');
+    const texted = withText(sets);
+    expect(texted.length).toBeGreaterThanOrEqual(1);
+    expect(texted[0]).toEqual({
+      channelType: 'slack',
+      platformId: 'C1',
+      threadId: 'T1',
+      instance: 'slack-inst',
+      status: 'Reading the thread',
+      statusKind: 'agent',
+    });
+    // Once text is showing, no plain typing calls are interleaved.
+    expect(plain(sets).length).toBe(plainAtStart);
+  });
+
+  it("re-sends unchanged text on every tick — the cadence is plain typing's", async () => {
+    const { sets } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+    await runPastGrace('Reading the thread');
+    const before = withText(sets).length;
+
+    working('Reading the thread');
+    await vi.advanceTimersByTimeAsync(8_000); // two 4s ticks
+    const after = withText(sets);
+    expect(after.length).toBe(before + 2);
+    for (const c of after) expect(c.status).toBe('Reading the thread');
+  });
+
+  it('changed text shows on the next tick', async () => {
+    const { sets } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+    await runPastGrace('Reading the thread');
+    const before = withText(sets).length;
+
+    working('Drafting a reply');
+    await vi.advanceTimersByTimeAsync(4_000);
+    const texted = withText(sets);
+    expect(texted).toHaveLength(before + 1);
+    expect(texted[texted.length - 1].status).toBe('Drafting a reply');
+  });
+
+  it('pauses after a delivery and sends the text again once the pause ends', async () => {
+    const { sets } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+    await runPastGrace('Reading the thread');
+    const before = withText(sets).length;
+
+    // A reply goes out: the platform drops the status; ticks pause for 10s.
+    pauseTypingRefreshAfterDelivery(SESS);
+    working('Reading the thread');
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(withText(sets)).toHaveLength(before); // paused: nothing sent
+
+    // Pause over: the next tick shows the text again.
+    working('Reading the thread');
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(withText(sets)).toHaveLength(before + 1);
+  });
+
+  it('with no text, plain typing fires every tick as before', async () => {
+    const { sets } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+    await runPastGrace(null);
+    expect(withText(sets)).toHaveLength(0);
+    const before = plain(sets).length;
+    working(null);
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(plain(sets).length).toBe(before + 2);
+    for (const c of sets) expect(c.statusKind).toBeUndefined();
+  });
+
+  it('idle ends the refresh with one clear even while text is showing', async () => {
+    const { sets, clears } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+    await runPastGrace('Reading the thread');
+    expect(withText(sets).length).toBeGreaterThanOrEqual(1);
+
+    notePresence(SESS, {
+      turn: 'idle',
+      updatedAtMs: Date.now(),
+      status: { text: 'Reading the thread', atMs: 0 },
+    });
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(clears).toHaveLength(1);
+    const setsAtEnd = sets.length;
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(sets.length).toBe(setsAtEnd);
+    expect(clears).toHaveLength(1);
+  });
+
+  it('text is not shown before the runner is provably in the turn (grace with no working report)', async () => {
+    const { sets } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+    // A stale status row from an earlier turn arrives before any turn report.
+    notePresence(SESS, { turn: null, updatedAtMs: null, status: { text: 'Old line', atMs: 0 } });
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(withText(sets)).toHaveLength(0);
+    expect(plain(sets).length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/src/modules/typing/index.test.ts
+++ b/src/modules/typing/index.test.ts
@@ -14,7 +14,17 @@ vi.mock('../../config.js', async () => {
   return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-typing' };
 });
 
-import { setTypingAdapter, startTypingRefresh, stopTypingRefresh } from './index.js';
+import fs from 'fs';
+import path from 'path';
+
+import { heartbeatPath } from '../../session-manager.js';
+import {
+  noteTurnState,
+  pauseTypingRefreshAfterDelivery,
+  setTypingAdapter,
+  startTypingRefresh,
+  stopTypingRefresh,
+} from './index.js';
 
 type Call = { channelType: string; platformId: string; threadId: string | null; instance?: string };
 
@@ -28,12 +38,39 @@ function captureAdapter() {
   return calls;
 }
 
+/** Adapter that records both set and clear calls. */
+function captureSetAndClear() {
+  const sets: Call[] = [];
+  const clears: Call[] = [];
+  setTypingAdapter({
+    async setTyping(channelType, platformId, threadId, instance) {
+      sets.push({ channelType, platformId, threadId, instance });
+    },
+    async clearTyping(channelType, platformId, threadId, instance) {
+      clears.push({ channelType, platformId, threadId, instance });
+    },
+  });
+  return { sets, clears };
+}
+
+/** Write a heartbeat file with an mtime at the current (fake) clock. */
+function touchHeartbeat(agentGroupId: string, sessionId: string): void {
+  const hbPath = heartbeatPath(agentGroupId, sessionId);
+  fs.mkdirSync(path.dirname(hbPath), { recursive: true });
+  fs.writeFileSync(hbPath, '');
+  const seconds = Date.now() / 1000;
+  fs.utimesSync(hbPath, seconds, seconds);
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
 });
 
 afterEach(() => {
   stopTypingRefresh('sess-1');
+  stopTypingRefresh('sess-turn');
+  if (fs.existsSync('/tmp/nanoclaw-test-typing'))
+    fs.rmSync('/tmp/nanoclaw-test-typing', { recursive: true, force: true });
   vi.useRealTimers();
 });
 
@@ -119,5 +156,140 @@ describe('startTypingRefresh — instance forwarding', () => {
         instance: 'telegram',
       });
     }
+  });
+});
+
+describe('typing follows the runner turn state', () => {
+  const SESS = 'sess-turn';
+  const AG = 'ag-turn';
+
+  /** Advance past the 15s grace, keeping a working report live throughout. */
+  async function advancePastGraceWorking(): Promise<void> {
+    for (let elapsed = 0; elapsed < 20_000; elapsed += 4_000) {
+      noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+      await vi.advanceTimersByTimeAsync(4_000);
+    }
+  }
+
+  it('quiet turn: an idle report with no delivery stops the refresh and clears exactly once', async () => {
+    const { sets, clears } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+
+    await advancePastGraceWorking();
+    const setsWhileWorking = sets.length;
+    expect(setsWhileWorking).toBeGreaterThan(1); // still refreshing past grace
+
+    // Turn ends without delivering anything.
+    noteTurnState(SESS, { turn: 'idle', updatedAtMs: Date.now() });
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    expect(clears).toHaveLength(1);
+    expect(clears[0]).toEqual({ channelType: 'slack', platformId: 'C1', threadId: 'T1', instance: 'slack-inst' });
+
+    // No more refreshes and no second clear once the refresher has ended.
+    const setsAfterEnd = sets.length;
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(sets.length).toBe(setsAfterEnd);
+    expect(clears).toHaveLength(1);
+  });
+
+  it('multi-message turn: two deliveries pause and resume, then a single clear at idle', async () => {
+    const { sets, clears } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+    await advancePastGraceWorking();
+
+    // First delivery pauses the refresh; ticks inside the pause skip setTyping.
+    pauseTypingRefreshAfterDelivery(SESS);
+    let before = sets.length;
+    noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+    await vi.advanceTimersByTimeAsync(8_000); // inside the 10s pause
+    expect(sets.length).toBe(before); // no refresh while paused
+
+    // Pause expires; a live working report resumes refreshing.
+    noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(sets.length).toBeGreaterThan(before);
+
+    // Second delivery pauses again.
+    pauseTypingRefreshAfterDelivery(SESS);
+    before = sets.length;
+    noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(sets.length).toBe(before);
+    noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(sets.length).toBeGreaterThan(before);
+
+    // Turn ends: exactly one clear across the whole turn.
+    noteTurnState(SESS, { turn: 'idle', updatedAtMs: Date.now() });
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(clears).toHaveLength(1);
+  });
+
+  it('dead runner: a working report that stops advancing clears after it goes stale', async () => {
+    const { sets, clears } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+    await advancePastGraceWorking();
+
+    // The runner dies: the last working report stops advancing. It stays live
+    // for TURN_STALE_MS, then the next tick ends the refresh.
+    const setsBeforeDeath = sets.length;
+    noteTurnState(SESS, { turn: 'working', updatedAtMs: Date.now() });
+    // Under the stale window: still refreshing.
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(sets.length).toBeGreaterThan(setsBeforeDeath);
+    expect(clears).toHaveLength(0);
+
+    // Past the 15s stale window with no new report: clear once.
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(clears).toHaveLength(1);
+    const setsAtClear = sets.length;
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(sets.length).toBe(setsAtClear);
+    expect(clears).toHaveLength(1);
+  });
+
+  it('old runner: with no turn ever reported, the heartbeat file still gates the refresh', async () => {
+    const { sets, clears } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Never call noteTurnState. Past grace, a fresh heartbeat keeps typing on.
+    for (let elapsed = 0; elapsed < 20_000; elapsed += 4_000) {
+      touchHeartbeat(AG, SESS);
+      await vi.advanceTimersByTimeAsync(4_000);
+    }
+    const setsWhileFresh = sets.length;
+    expect(setsWhileFresh).toBeGreaterThan(1);
+    expect(clears).toHaveLength(0);
+
+    // Heartbeat goes stale (no more touches): the refresh ends.
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(clears).toHaveLength(1);
+    const setsAtEnd = sets.length;
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(sets.length).toBe(setsAtEnd);
+  });
+
+  it('stopTypingRefresh clears the indicator once', async () => {
+    const { clears } = captureSetAndClear();
+    startTypingRefresh(SESS, AG, 'slack', 'C1', 'T1', 'slack-inst');
+    await vi.advanceTimersByTimeAsync(0);
+
+    stopTypingRefresh(SESS);
+    expect(clears).toHaveLength(1);
+    // A second stop finds no refresher — no double clear.
+    stopTypingRefresh(SESS);
+    expect(clears).toHaveLength(1);
+  });
+
+  it('noteTurnState with no active refresher creates none', async () => {
+    const { sets } = captureSetAndClear();
+    noteTurnState('sess-never', { turn: 'working', updatedAtMs: Date.now() });
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(sets).toHaveLength(0);
   });
 });

--- a/src/modules/typing/index.ts
+++ b/src/modules/typing/index.ts
@@ -6,19 +6,28 @@
  * thinking. This module keeps it alive by re-firing `setTyping` on a
  * short interval while the agent is actually working.
  *
- * "Working" is decided from the runner's own turn report, read on the
- * delivery poll (`noteTurnState`). The runner writes `working` while a
- * turn runs and `idle` when it ends, so the host no longer has to guess
- * from a heartbeat FILE — which is invisible when the delivering process
- * doesn't share a filesystem with the runner, and never says "stop". A
- * runner that predates the turn report never calls `noteTurnState`, so
- * those sessions keep the old heartbeat-file behaviour unchanged.
+ * "Working" is decided from the runner's own presence report, read on the
+ * delivery poll (`notePresence`): the turn state the runner writes to its
+ * container record (`working` while a turn runs, `idle` when it ends) plus
+ * an optional status line it may publish under the `live_status` state key.
+ * The host no longer has to guess from a heartbeat FILE — which is
+ * invisible when the delivering process doesn't share a filesystem with
+ * the runner, and never says "stop". A runner that predates the turn
+ * report never reaches `notePresence` with a turn, so those sessions keep
+ * the old heartbeat-file behaviour unchanged.
+ *
+ * Status text: while the turn is `working` and fresh, a reported status
+ * line rides on the same refresh — every tick sends `setTyping` exactly as
+ * plain typing does, and the text only changes the payload
+ * (`setTyping(..., text, 'agent')`). On platforms with a sticky status
+ * (Slack's assistant status) it replaces the generic "typing" line;
+ * platforms that cannot show text ignore it and keep their usual cadence.
  *
  * When a turn ends (idle, or a `working` report that has gone stale) the
  * refresh ENDS: the interval is cleared and the adapter's optional
  * `clearTyping` fires once, for platforms whose indicator does not expire
- * on its own (Slack's assistant status has no TTL and is only cleared by
- * a post or an explicit clear).
+ * on its own within a turn (Slack's assistant status persists until a post,
+ * an explicit clear, or a two-minute timeout).
  *
  * After delivering a user-facing message, the refresh is paused for
  * POST_DELIVERY_PAUSE_MS so the client-side indicator can visually
@@ -44,7 +53,7 @@ const TYPING_GRACE_MS = 15000;
 /**
  * After the grace window, a heartbeat must be mtimed within this
  * many ms of now to count as "agent is working." Only used for older
- * runners that never report a turn (see noteTurnState).
+ * runners that never report a turn (see notePresence).
  */
 const HEARTBEAT_FRESH_MS = 6000;
 /**
@@ -63,7 +72,14 @@ const TURN_STALE_MS = 15000;
 const POST_DELIVERY_PAUSE_MS = 10000;
 
 interface TypingAdapter {
-  setTyping?(channelType: string, platformId: string, threadId: string | null, instance?: string): Promise<void>;
+  setTyping?(
+    channelType: string,
+    platformId: string,
+    threadId: string | null,
+    instance?: string,
+    status?: string,
+    statusKind?: 'auto' | 'agent',
+  ): Promise<void>;
   /**
    * Clear the typing indicator. Only platforms whose indicator does not
    * expire on its own implement it (e.g. Slack's assistant status); others
@@ -72,12 +88,21 @@ interface TypingAdapter {
   clearTyping?(channelType: string, platformId: string, threadId: string | null, instance?: string): Promise<void>;
 }
 
-/** The runner's latest turn report, as read on the delivery poll. */
-interface TurnReport {
+/** A runner-authored status line, as read from the `live_status` state key. */
+export interface PresenceStatus {
+  text: string;
+  /** session_state.updated_at in epoch ms. */
+  atMs: number;
+}
+
+/** The runner's latest presence report, as read on the delivery poll. */
+export interface PresenceReport {
   /** 'working' | 'idle', or null when the runner never reported (older runner). */
   turn: 'working' | 'idle' | null;
   /** container_state.updated_at in epoch ms, or null when there is no record. */
   updatedAtMs: number | null;
+  /** Status text, or null when none is published. */
+  status: PresenceStatus | null;
 }
 
 interface TypingTarget {
@@ -90,8 +115,8 @@ interface TypingTarget {
   interval: NodeJS.Timeout;
   startedAt: number;
   pausedUntil: number; // epoch ms; 0 = not paused
-  /** Latest runner turn report; undefined until the first noteTurnState. */
-  turnReport?: TurnReport;
+  /** Latest runner presence report; undefined until the first notePresence. */
+  presence?: PresenceReport;
 }
 
 let adapter: TypingAdapter | null = null;
@@ -113,9 +138,11 @@ async function triggerTyping(
   platformId: string,
   threadId: string | null,
   instance?: string,
+  status?: string,
+  statusKind?: 'auto' | 'agent',
 ): Promise<void> {
   try {
-    await adapter?.setTyping?.(channelType, platformId, threadId, instance);
+    await adapter?.setTyping?.(channelType, platformId, threadId, instance, status, statusKind);
   } catch {
     // Typing is best-effort — don't let it fail delivery or routing.
   }
@@ -132,6 +159,21 @@ async function triggerClear(
   } catch {
     // Best-effort — a failed clear must never affect delivery or routing.
   }
+}
+
+/**
+ * One refresh tick: the same setTyping call plain typing has always made,
+ * carrying the status text (and `statusKind: 'agent'`) when there is one to
+ * show. The cadence never depends on the text, so channels that cannot
+ * show it keep their indicator alive exactly as before.
+ */
+function refresh(entry: TypingTarget, showStatus: boolean): void {
+  const text = showStatus ? entry.presence?.status?.text : undefined;
+  if (text) {
+    triggerTyping(entry.channelType, entry.platformId, entry.threadId, entry.instance, text, 'agent').catch(() => {});
+    return;
+  }
+  triggerTyping(entry.channelType, entry.platformId, entry.threadId, entry.instance).catch(() => {});
 }
 
 /**
@@ -195,6 +237,13 @@ export function startTypingRefresh(
     if (!entry) return; // stopped externally since this tick was scheduled
 
     const now = Date.now();
+    const report = entry.presence;
+    const reported = report !== undefined && report.turn !== null;
+    // Status text is shown only while the runner is provably inside this
+    // turn: a `working` report with a fresh stamp. Anywhere else (grace on a
+    // cold start, the heartbeat fallback) the text could be last turn's.
+    const workingFresh =
+      reported && report.turn === 'working' && report.updatedAtMs !== null && now - report.updatedAtMs < TURN_STALE_MS;
 
     // Inside a post-delivery pause: skip setTyping but keep the
     // interval running so we resume automatically once the pause
@@ -205,19 +254,16 @@ export function startTypingRefresh(
     // unconditionally, covering container spawn/wake latency before the
     // first turn report lands.
     if (now - entry.startedAt < TYPING_GRACE_MS) {
-      triggerTyping(entry.channelType, entry.platformId, entry.threadId, entry.instance).catch(() => {});
+      refresh(entry, workingFresh);
       return;
     }
 
     // The runner reported a turn: follow it. 'working' with a fresh stamp
     // keeps refreshing; 'idle', or a 'working' report gone stale (runner
     // stopped re-marking), ends the refresh and clears the indicator.
-    const report = entry.turnReport;
-    if (report && report.turn !== null) {
-      const working =
-        report.turn === 'working' && report.updatedAtMs !== null && now - report.updatedAtMs < TURN_STALE_MS;
-      if (working) {
-        triggerTyping(entry.channelType, entry.platformId, entry.threadId, entry.instance).catch(() => {});
+    if (reported) {
+      if (workingFresh) {
+        refresh(entry, true);
         return;
       }
       endRefresh(sessionId, entry);
@@ -226,7 +272,7 @@ export function startTypingRefresh(
 
     // No turn ever reported (older runner): fall back to the heartbeat file.
     if (isHeartbeatFresh(entry.agentGroupId, sessionId)) {
-      triggerTyping(entry.channelType, entry.platformId, entry.threadId, entry.instance).catch(() => {});
+      refresh(entry, false);
       return;
     }
     endRefresh(sessionId, entry);
@@ -246,16 +292,17 @@ export function startTypingRefresh(
 }
 
 /**
- * Record the runner's latest turn report for a session, read on the
- * delivery poll. Stores it on the active refresher entry; creates no entry
- * if none is active (typing is only ever started by an inbound message). A
- * missing record or a null turn (older runner) reads as "not reported" and
- * leaves the heartbeat-file fallback in charge.
+ * Record the runner's latest presence report for a session, read on the
+ * delivery poll: turn state plus optional status text. Stores it on the
+ * active refresher entry; creates no entry if none is active (typing is
+ * only ever started by an inbound message). A missing record or a null turn
+ * (older runner) reads as "not reported" and leaves the heartbeat-file
+ * fallback in charge.
  */
-export function noteTurnState(sessionId: string, state: TurnReport): void {
+export function notePresence(sessionId: string, report: PresenceReport): void {
   const entry = typingRefreshers.get(sessionId);
   if (!entry) return;
-  entry.turnReport = state;
+  entry.presence = report;
 }
 
 /**
@@ -263,6 +310,8 @@ export function noteTurnState(sessionId: string, state: TurnReport): void {
  * a user-facing message is delivered so the client-side indicator
  * has a chance to visually clear before the agent's next SDK event
  * pushes it back on. No-op if no refresh is active for this session.
+ * (A delivered reply also clears a sticky status on the platform; the
+ * first tick after the pause simply sends it again.)
  */
 export function pauseTypingRefreshAfterDelivery(sessionId: string): void {
   const entry = typingRefreshers.get(sessionId);

--- a/src/modules/typing/index.ts
+++ b/src/modules/typing/index.ts
@@ -4,8 +4,21 @@
  * Most platforms expire a typing indicator after 5–10s, so a one-shot
  * call on message arrival goes stale long before the agent finishes
  * thinking. This module keeps it alive by re-firing `setTyping` on a
- * short interval — but only while the agent is actually WORKING, gated
- * on the heartbeat file's mtime after an initial grace period.
+ * short interval while the agent is actually working.
+ *
+ * "Working" is decided from the runner's own turn report, read on the
+ * delivery poll (`noteTurnState`). The runner writes `working` while a
+ * turn runs and `idle` when it ends, so the host no longer has to guess
+ * from a heartbeat FILE — which is invisible when the delivering process
+ * doesn't share a filesystem with the runner, and never says "stop". A
+ * runner that predates the turn report never calls `noteTurnState`, so
+ * those sessions keep the old heartbeat-file behaviour unchanged.
+ *
+ * When a turn ends (idle, or a `working` report that has gone stale) the
+ * refresh ENDS: the interval is cleared and the adapter's optional
+ * `clearTyping` fires once, for platforms whose indicator does not expire
+ * on its own (Slack's assistant status has no TTL and is only cleared by
+ * a post or an explicit clear).
  *
  * After delivering a user-facing message, the refresh is paused for
  * POST_DELIVERY_PAUSE_MS so the client-side indicator can visually
@@ -24,18 +37,23 @@ import { heartbeatPath } from '../../session-manager.js';
 const TYPING_REFRESH_MS = 4000;
 /**
  * Grace window from startTypingRefresh: fire typing unconditionally
- * for this long regardless of heartbeat state. Covers container
- * spawn/wake latency (5–12s on cold start before first heartbeat).
+ * for this long regardless of turn/heartbeat state. Covers container
+ * spawn/wake latency (5–12s on cold start before the first turn report).
  */
 const TYPING_GRACE_MS = 15000;
 /**
  * After the grace window, a heartbeat must be mtimed within this
- * many ms of now to count as "agent is working." Heartbeats land
- * every few hundred ms during active work, so 6s is well above
- * the working floor and small enough to stop typing quickly when
- * the agent goes idle.
+ * many ms of now to count as "agent is working." Only used for older
+ * runners that never report a turn (see noteTurnState).
  */
 const HEARTBEAT_FRESH_MS = 6000;
+/**
+ * A `working` turn report counts as live only if its stamp is within this
+ * many ms of now. The runner re-marks `working` every 5s, so this is three
+ * re-marks: a report older than that means the runner stopped moving (turn
+ * ended without an idle write, or the runner died) and we stop refreshing.
+ */
+const TURN_STALE_MS = 15000;
 /**
  * After we deliver a user-facing message, pause typing for this
  * long so the client-side indicator has time to visually clear.
@@ -46,6 +64,20 @@ const POST_DELIVERY_PAUSE_MS = 10000;
 
 interface TypingAdapter {
   setTyping?(channelType: string, platformId: string, threadId: string | null, instance?: string): Promise<void>;
+  /**
+   * Clear the typing indicator. Only platforms whose indicator does not
+   * expire on its own implement it (e.g. Slack's assistant status); others
+   * omit it and the module no-ops via optional chaining.
+   */
+  clearTyping?(channelType: string, platformId: string, threadId: string | null, instance?: string): Promise<void>;
+}
+
+/** The runner's latest turn report, as read on the delivery poll. */
+interface TurnReport {
+  /** 'working' | 'idle', or null when the runner never reported (older runner). */
+  turn: 'working' | 'idle' | null;
+  /** container_state.updated_at in epoch ms, or null when there is no record. */
+  updatedAtMs: number | null;
 }
 
 interface TypingTarget {
@@ -58,6 +90,8 @@ interface TypingTarget {
   interval: NodeJS.Timeout;
   startedAt: number;
   pausedUntil: number; // epoch ms; 0 = not paused
+  /** Latest runner turn report; undefined until the first noteTurnState. */
+  turnReport?: TurnReport;
 }
 
 let adapter: TypingAdapter | null = null;
@@ -65,8 +99,8 @@ const typingRefreshers = new Map<string, TypingTarget>();
 
 /**
  * Bind the typing module to the channel delivery adapter so it can
- * call `setTyping`. Called once by `src/delivery.ts` inside
- * `setDeliveryAdapter`. Passing a fresh adapter replaces the prior
+ * call `setTyping` and `clearTyping`. Called once by `src/delivery.ts`
+ * inside `setDeliveryAdapter`. Passing a fresh adapter replaces the prior
  * binding and leaves active refreshers in place (they'll use the
  * new adapter on their next tick).
  */
@@ -85,6 +119,31 @@ async function triggerTyping(
   } catch {
     // Typing is best-effort — don't let it fail delivery or routing.
   }
+}
+
+async function triggerClear(
+  channelType: string,
+  platformId: string,
+  threadId: string | null,
+  instance?: string,
+): Promise<void> {
+  try {
+    await adapter?.clearTyping?.(channelType, platformId, threadId, instance);
+  } catch {
+    // Best-effort — a failed clear must never affect delivery or routing.
+  }
+}
+
+/**
+ * End a refresher: stop the interval, drop the entry, and clear the
+ * indicator once. Idempotent per session — the entry is removed first, so a
+ * later tick or a stopTypingRefresh call finds nothing and does not clear
+ * twice.
+ */
+function endRefresh(sessionId: string, entry: TypingTarget): void {
+  clearInterval(entry.interval);
+  typingRefreshers.delete(sessionId);
+  triggerClear(entry.channelType, entry.platformId, entry.threadId, entry.instance).catch(() => {});
 }
 
 function isHeartbeatFresh(agentGroupId: string, sessionId: string): boolean {
@@ -135,20 +194,42 @@ export function startTypingRefresh(
     const entry = typingRefreshers.get(sessionId);
     if (!entry) return; // stopped externally since this tick was scheduled
 
+    const now = Date.now();
+
     // Inside a post-delivery pause: skip setTyping but keep the
     // interval running so we resume automatically once the pause
     // expires.
-    if (entry.pausedUntil > Date.now()) return;
+    if (entry.pausedUntil > now) return;
 
-    const withinGrace = Date.now() - entry.startedAt < TYPING_GRACE_MS;
-    if (withinGrace || isHeartbeatFresh(entry.agentGroupId, sessionId)) {
+    // Within the grace window since the last inbound: fire
+    // unconditionally, covering container spawn/wake latency before the
+    // first turn report lands.
+    if (now - entry.startedAt < TYPING_GRACE_MS) {
       triggerTyping(entry.channelType, entry.platformId, entry.threadId, entry.instance).catch(() => {});
       return;
     }
 
-    // Out of grace AND heartbeat stale — agent is idle, stop refreshing.
-    clearInterval(entry.interval);
-    typingRefreshers.delete(sessionId);
+    // The runner reported a turn: follow it. 'working' with a fresh stamp
+    // keeps refreshing; 'idle', or a 'working' report gone stale (runner
+    // stopped re-marking), ends the refresh and clears the indicator.
+    const report = entry.turnReport;
+    if (report && report.turn !== null) {
+      const working =
+        report.turn === 'working' && report.updatedAtMs !== null && now - report.updatedAtMs < TURN_STALE_MS;
+      if (working) {
+        triggerTyping(entry.channelType, entry.platformId, entry.threadId, entry.instance).catch(() => {});
+        return;
+      }
+      endRefresh(sessionId, entry);
+      return;
+    }
+
+    // No turn ever reported (older runner): fall back to the heartbeat file.
+    if (isHeartbeatFresh(entry.agentGroupId, sessionId)) {
+      triggerTyping(entry.channelType, entry.platformId, entry.threadId, entry.instance).catch(() => {});
+      return;
+    }
+    endRefresh(sessionId, entry);
   }, TYPING_REFRESH_MS);
   // unref so a stale refresher can't hold the event loop alive.
   interval.unref();
@@ -162,6 +243,19 @@ export function startTypingRefresh(
     startedAt,
     pausedUntil: 0,
   });
+}
+
+/**
+ * Record the runner's latest turn report for a session, read on the
+ * delivery poll. Stores it on the active refresher entry; creates no entry
+ * if none is active (typing is only ever started by an inbound message). A
+ * missing record or a null turn (older runner) reads as "not reported" and
+ * leaves the heartbeat-file fallback in charge.
+ */
+export function noteTurnState(sessionId: string, state: TurnReport): void {
+  const entry = typingRefreshers.get(sessionId);
+  if (!entry) return;
+  entry.turnReport = state;
 }
 
 /**
@@ -179,6 +273,5 @@ export function pauseTypingRefreshAfterDelivery(sessionId: string): void {
 export function stopTypingRefresh(sessionId: string): void {
   const entry = typingRefreshers.get(sessionId);
   if (!entry) return;
-  clearInterval(entry.interval);
-  typingRefreshers.delete(sessionId);
+  endRefresh(sessionId, entry);
 }


### PR DESCRIPTION
## What

The typing indicator now follows the runner's own turn state instead of guessing liveness from a heartbeat file, and it can carry a short status line the runner publishes.

- **Mailbox model.** `ContainerRecord` gains `turn: 'working' | 'idle' | null` (null = not reported). `container_state` gains a `turn` column. The runner adds the column on start behind a `PRAGMA table_info` guard; the host read tolerates a table that still lacks it.
- **Runner report.** The runner's SQLite mailbox gains `markContainerTurn(turn)`, which writes `turn` and stamps `updated_at` and leaves the tool-in-flight fields alone. The poll loop marks `working` when a turn starts, re-marks every 5s while it runs (so `updated_at` keeps moving through long generations), and marks `idle` when the turn ends and on clean loop exit. Every write is best-effort: a failure logs and never breaks the loop.
- **Delivery poll → presence.** The host reads `getContainerState()` and `getState('live_status')` on the same poll it already runs and hands one presence report (turn, its stamp, optional status text) to the typing module (`notePresence`). No new session, no new poll. The host mailbox contract gains an optional `getState(key)` read of the runner's generic `session_state` rows.
- **Typing module.** Tick rule, in order: inside the post-delivery pause skip; within the 15s grace since the last inbound refresh; a reported turn exists refresh while `working` and its stamp is within `TURN_STALE_MS` (three 5s re-marks) else end; no turn ever reported keep the heartbeat-file fallback. Ending a refresh clears the interval and fires the adapter's new optional `clearTyping` once.
- **Status text.** A runner may publish a short activity line under the `live_status` state key. While the turn is `working` and fresh, every refresh tick sends `setTyping` exactly as plain typing does and the text only changes the payload (`setTyping(..., text, 'agent')`), so the cadence is unchanged and channels that cannot show text keep their indicator alive as before. With no text, plain typing as before. Text is shown only once the runner is provably in this turn, so a line left over from an earlier turn is not shown during a cold-start grace window.
- **Clear verb.** `clearTyping` is added to the channel adapter contract, dispatched to the exact adapter instance by the registry, and implemented in the Chat SDK bridge: a Slack-shaped adapter (one exposing `setAssistantStatus` and `decodeThreadId`) is cleared with `setAssistantStatus(channel, threadTs, '')`; anything else is a no-op. The bridge's `setTyping` now passes the status line to `startTyping(threadId, status)`, normalized to one trimmed line and capped at 200 characters (neither the adapter nor the platform documents a limit).

## Why

Driving typing from a heartbeat file breaks in two ways:

1. **No shared filesystem.** Where the process that delivers messages does not share a filesystem with the runner (any remote or containerized runtime), the heartbeat file is never visible. The indicator then either dies at the end of the grace window or, if the deployment answers "fresh" by default, never stops.
2. **Indicators that outlive the turn.** On Slack, `setTyping` maps to `assistant.threads.setStatus`, which persists until a post in the thread, an explicit clear, or a two-minute timeout. A turn that ends without posting leaves the agent "typing" for two minutes after it finished, because the module never sent an explicit clear.

The runner is the one component that knows exactly when a turn starts and ends, and it already keeps a per-session record in the outbound mailbox that the host reads on every delivery poll. Typing should follow that. The same read path carries the runner's status line: the indicator is the natural place to show "what the agent is doing right now", and a channel-side reconstruction of turn boundaries from deliveries is unnecessary once the runner reports them directly.

## Compatibility

- **Older runners.** A runner that predates this change never writes `turn`, so its records parse with `turn: null` and the delivery poll reports "not reported". Those sessions keep the exact heartbeat-file behaviour they have today.
- **Older session DBs.** The `turn` column is added with a guarded `ALTER TABLE ... ADD COLUMN` on the runner side; the host read uses `SELECT *` with per-field picks, so a `container_state` table that still lacks the column reads as `turn: null` rather than erroring. A `session_state` table that does not exist yet reads as no status.
- **Older persisted records.** `parseContainerRecord` treats a missing or null `turn` as null, so records written before the field existed still parse.
- **No status published.** Runners that never write `live_status`, and channels that cannot show text, get plain typing exactly as before.

## Tests

- **Model:** a reported turn parses; a record without the field reads as null; a turn outside the contract is rejected.
- **SQLite, both sides:** the host reads a `container_state` row written before the `turn` column existed; `markContainerTurn` moves only `turn` and `updated_at` and survives a tool starting mid-turn; `getState` reads a runner-written row with its stamp normalized and returns undefined for a missing key or a DB without `session_state`.
- **Runner poll loop:** a two-message turn stays `working` until the loop returns to waiting; a quiet turn that delivers nothing still ends `idle`.
- **Delivery poll:** the turn report is read on the poll and forwarded to the typing module; a `live_status` row rides along as the status (trimmed); a blank line reads as no status; a missing record forwards as null.
- **Typing module scenarios:** quiet turn (idle report, no delivery → refresh stops, exactly one clear); multi-message turn (two deliveries pause and resume, one clear at idle); dead runner (`working` stops advancing → clear after `TURN_STALE_MS`); old runner (no turn ever reported → heartbeat-file behaviour, existing tests keep passing).
- **Status text:** text present → sent with `statusKind: 'agent'` and no plain calls interleaved; unchanged text is re-sent on every tick; changed text shows on the next tick; after a post-delivery pause the next tick sends it again; no text → plain typing every tick; idle → one clear while text is showing; a stale line is not shown before the runner reports `working`.
- **Channels:** the registry dispatches `clearTyping` to the exact instance; the bridge passes a normalized status line to `startTyping` (whitespace collapsed, blank → none, over-long capped) and clears a Slack-shaped adapter with `setAssistantStatus(..., '')`, no-op when it cannot clear or the thread has no `threadTs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
