### PR TITLE
fix(setup): restore provider picker on fresh installs

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -1509,16 +1509,13 @@ async function askAgentProviderChoice(): Promise<string> {
     })),
   ];
   const preset = process.env.NANOCLAW_AGENT_PROVIDER?.trim().toLowerCase();
-  // Fresh installs use Claude without another setup prompt. Explicit presets
-  // still win, and an existing non-Claude default keeps its provider picker.
-  const automatic = preset || (DEFAULT_AGENT_PROVIDER === 'claude' ? 'claude' : undefined);
-  if (automatic) {
-    if (!options.some((option) => option.value === automatic)) {
+  if (preset) {
+    if (!options.some((option) => option.value === preset)) {
       throw new Error(`NANOCLAW_AGENT_PROVIDER=${preset} is not available in this NanoClaw install`);
     }
-    setupLog.userInput('agent_provider', automatic);
-    phEmit('agent_provider_chosen', { provider: automatic, preset: Boolean(preset) });
-    return automatic;
+    setupLog.userInput('agent_provider', preset);
+    phEmit('agent_provider_chosen', { provider: preset, preset: true });
+    return preset;
   }
   // The pick is persisted as the instance default (DEFAULT_AGENT_PROVIDER), so
   // pre-select the current default — a re-run Enter-through then preserves it

--- a/setup/providers/registry.test.ts
+++ b/setup/providers/registry.test.ts
@@ -33,6 +33,10 @@ describe('setup flow consumes the registry (structural)', () => {
     expect(src).toContain('listSetupProviders()');
     expect(src).toContain("import './providers/index.js'");
     expect(src).toContain('NANOCLAW_AGENT_PROVIDER');
+    // The instance default controls the highlighted option. Only an explicit
+    // per-run preset may bypass the interactive picker.
+    expect(src).toMatch(/if \(preset\) \{/);
+    expect(src).not.toContain("DEFAULT_AGENT_PROVIDER === 'claude'");
     // The capability-keyed branch — a provider's own auth runs iff it declares one.
     expect(src).toMatch(/providerEntry\?\.runAuth/);
   });


### PR DESCRIPTION
## Summary

Restores the agent-provider picker during fresh interactive setup.

- **Problem**: the normal Claude instance default caused setup to return `claude` before rendering the provider picker, so fresh installs could not choose an installable provider such as Codex.
- **Fix**: only an explicit `NANOCLAW_AGENT_PROVIDER` preset bypasses the picker. The persisted instance default now controls the highlighted option.
- **Out of scope**: the Codex host-CLI bootstrap failure reproduced in the same setup journey belongs to the provider payload and is being coordinated separately.

## Related work

Part of #3787.

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [ ] `kind/hardening`

## Validation

- `pnpm exec vitest run setup/providers/registry.test.ts setup/providers/skill-descriptor.test.ts` -> 13/13 tests passed.
- `pnpm run build` -> passed.
- `REGISTRY_PROVIDERS_SHA=749c6ed1e764fd2b65f525315d7dba1892a596e9 pnpm exec tsx scripts/test-registry-skills.ts --combined-providers` -> provider install, refresh, build, host tests, container typecheck, Bun tests, and contract parity passed.
- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
Fresh setup once again asks which agent provider should power the assistant.
```

## Security and trust boundaries

None.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

- [ ] A human has reviewed this PR and stands behind every change
