### PR TITLE
fix(drivers): a watch feed that cannot subscribe must never break arming

### DIFF
--- a/src/drivers/session-events.test.ts
+++ b/src/drivers/session-events.test.ts
@@ -370,3 +370,63 @@ describe('wrapper shape', () => {
     expect(wrapped.kind).toBe('fake');
   });
 });
+
+describe('a watch feed that cannot run is inert, never fatal', () => {
+  it('does not invent watchSessions for a driver that lacks it', () => {
+    const driver = new FakeDriver();
+    (driver as { watchSessions?: unknown }).watchSessions = undefined;
+    const wrapped = withSessionEvents(driver);
+
+    // host-sweep's feed arming probes the driver with `typeof` — a wrapper that
+    // advertises a method the inner driver has not got sends that probe
+    // straight into a TypeError.
+    expect(wrapped.watchSessions).toBeUndefined();
+  });
+
+  it('keeps arming when the watch backend refuses to subscribe', async () => {
+    const driver = new FakeDriver();
+    driver.watchSessions = () => {
+      throw new Error('events stream unavailable');
+    };
+    const { inner, handle, hub } = await prepared(driver, 's1');
+    const terminal = vi.fn();
+
+    // Arming rides the adoption path (`adoptRunningSessions`) and the spawn
+    // path (`armSessionLifecycle`); a throw here would take down host startup
+    // over a feed that only ever buys latency.
+    expect(() => handle.onTerminal(terminal)).not.toThrow();
+
+    // And the session stays supervised: the end still reaches the host through
+    // the source that never needed the stream.
+    driver.snapshots = [{ handle: inner, phase: 'terminal' }];
+    await hub.resync('spike');
+    expect(terminal).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+
+  it('re-attempts the subscription on the next arm instead of caching the failure', async () => {
+    const driver = new FakeDriver();
+    const subscribe = driver.watchSessions.bind(driver);
+    let failNext = true;
+    driver.watchSessions = (installSlug, onEvent) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('events stream unavailable');
+      }
+      return subscribe(installSlug, onEvent);
+    };
+
+    const first = await prepared(driver, 's1');
+    first.handle.onTerminal(vi.fn()); // subscribe throws — nothing cached
+
+    const secondInner = new FakeHandle(makeKey('s2'));
+    driver.nextPrepared = secondInner;
+    const handle = await first.hub.prepare(fixtureSpec());
+    const terminal = vi.fn();
+    handle.onTerminal(terminal); // second arm subscribes for real
+
+    secondInner.statusValue = { phase: 'stopped' };
+    driver.emit({ key: secondInner.key, kind: 'terminal' });
+    await settled();
+    expect(terminal).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+});

--- a/src/drivers/session-events.ts
+++ b/src/drivers/session-events.ts
@@ -22,6 +22,8 @@
  *   buffered per key and delivered on registration, so adoption cannot lose
  *   an end that lands between `listSessions()` and arming.
  */
+import { log } from '../log.js';
+
 import type {
   SessionDriver,
   SessionEvent,
@@ -145,10 +147,19 @@ class SessionEventsHub {
     if (this.#watches.has(installSlug)) return;
     // Minimal test fakes may lack watchSessions; the hub must not crash on them.
     if (typeof this.driver.watchSessions !== 'function') return;
-    this.#watches.set(
-      installSlug,
-      this.driver.watchSessions(installSlug, (event) => this.#onEvent(event)),
-    );
+    /* eslint-disable no-catch-all/no-catch-all -- a watch backend that cannot subscribe costs latency (adoption's resync and the sweep's floor cover it), never the arming that keeps a session supervised */
+    try {
+      this.#watches.set(
+        installSlug,
+        this.driver.watchSessions(installSlug, (event) => this.#onEvent(event)),
+      );
+    } catch (err) {
+      // Deliberately not cached: the next arm for this install re-attempts the
+      // subscription, and until one succeeds terminals still reach the host
+      // through handle-observed ends and adoption's resync.
+      log.warn('Session watch feed unavailable — terminals fall back to resync', { installSlug, err });
+    }
+    /* eslint-enable no-catch-all/no-catch-all */
   }
 
   #onEvent(event: SessionEvent): void {
@@ -250,6 +261,11 @@ export function withSessionEvents(driver: SessionDriver): SessionEventsDriver {
     watchSessions: (installSlug, onEvent) => driver.watchSessions(installSlug, onEvent),
     resync: (installSlug) => hub.resync(installSlug),
   };
+  // `watchSessions` is contract-required, so it is mirrored inline above — but
+  // a minimal fake may still lack it, and consumers probe with `typeof`
+  // (host-sweep's feed arming, the hub itself). Mirror its absence too, or the
+  // probe passes on the wrapper and calls straight into `undefined`.
+  if (typeof driver.watchSessions !== 'function') delete (wrapped as Partial<SessionEventsDriver>).watchSessions;
   if (driver.ensureReady) wrapped.ensureReady = (): Promise<void> => driver.ensureReady!();
   if (driver.reapResidue) wrapped.reapResidue = (installSlug): Promise<void> => driver.reapResidue!(installSlug);
   return wrapped;

--- a/src/host-sweep.feeds.test.ts
+++ b/src/host-sweep.feeds.test.ts
@@ -103,6 +103,40 @@ describe('runtime terminal-event feed', () => {
     expect(watchHandler).toBeNull();
   });
 
+  it('keeps sweeping when the selected driver has no watch feed', async () => {
+    vi.mocked(peekSessionDriver).mockReturnValue({} as ReturnType<typeof peekSessionDriver>);
+    vi.mocked(getActiveSessions).mockResolvedValue([{ id: 's-4' } as never]);
+
+    await startAndDrainFirstTick();
+
+    expect(watchHandler).toBeNull();
+    await vi.waitFor(() => {
+      expect(reconcileSession).toHaveBeenCalledWith('s-4');
+    });
+  });
+
+  it('keeps sweeping when the watch backend refuses to subscribe', async () => {
+    vi.mocked(peekSessionDriver).mockReturnValue({
+      watchSessions: () => {
+        throw new Error('events stream unavailable');
+      },
+    } as unknown as ReturnType<typeof peekSessionDriver>);
+    vi.mocked(getActiveSessions).mockResolvedValue([{ id: 's-5' } as never]);
+
+    // The resync floor is the point: a feed that cannot subscribe costs
+    // latency, never the tick — and never the boot.
+    await startAndDrainFirstTick();
+    await vi.waitFor(() => {
+      expect(reconcileSession).toHaveBeenCalledWith('s-5');
+    });
+
+    enqueueSessionReconcile('s-6');
+    await vi.waitFor(() => {
+      expect(reconcileSession).toHaveBeenCalledWith('s-6');
+    });
+    expect(() => stopHostSweep()).not.toThrow();
+  });
+
   it('stops the watch and drops feed enqueues once the sweep stops', async () => {
     vi.mocked(peekSessionDriver).mockReturnValue(fakeWatchingDriver());
     await startAndDrainFirstTick();


### PR DESCRIPTION
# fix(drivers): a watch feed that cannot subscribe must never break arming

<!-- nanoclaw-pr-template:v2 -->

## Summary

Stops an optional, best-effort watch feed from taking down the thing it was supposed to help.

- **Issue mapping**: #1454 is filed against `sidecar/src/main.py` (`_run_docker_watcher` / `_run_config_watcher`, `asyncio.wait(return_when=FIRST_COMPLETED)`). No such file exists in v2 — `contents/sidecar` on the trunk repo is a 404 and a code search for `WATCH_CONTAINER` returns nothing — so this fixes the same defect at the seam that plays the sidecar's role in v2: the session-events hub, which owns the single install-wide runtime watch behind every supervised handle's `onTerminal`.
- **Problem**: `SessionEventsHub.#ensureWatch` called `driver.watchSessions()` unguarded. That call is reached from `handle.onTerminal()`, which is armed in `adoptRunningSessions` (`src/container-runner.ts:681`, awaited by `main()` step 2 — a throw there becomes `log.fatal('Startup failed')` + `process.exit(1)`, plus a circuit-breaker strike on the restart) and in `armSessionLifecycle` before every session `start()`. A watch backend that cannot subscribe therefore cost the boot and every spawn — the same shape as the issue's sidecar, which shut down within a second because a watcher it did not need could not run.
- **Fix — subscribe failures are inert**: the subscribe is wrapped, warned, and left uncached, so the next arm re-attempts. Terminals keep arriving through the two sources that never needed the stream: handle-observed ends (the `start --attach` exit) and adoption's `resync`. This is the promise `host-sweep.ts` already makes for its own copy of the same call — *"a watch backend that cannot subscribe costs latency (the resync floor covers it), never the boot"* — now made by the hub too.
- **Fix — honest capability probe**: `withSessionEvents` no longer advertises `watchSessions` when the wrapped driver has none. Consumers probe with `typeof` (`host-sweep.armRuntimeWatch`, the hub itself); the wrapper already mirrors `ensureReady` / `reapResidue` conditionally for exactly that reason, and `watchSessions` was the one that lied — the probe passed on the wrapper and then called into `undefined`.
- **Unchanged**: a healthy watch behaves identically — one lazy subscription per install, hints re-read against truth, at-most-once delivery, stop-intent suppression. The docker driver's own reconnect-with-bounded-backoff is untouched; this is about the *first* subscribe failing, which no backoff covers.

## Related work

Closes #1454

## Change kind

- [x] `kind/bug`
- [ ] `kind/feature`
- [ ] `kind/documentation`
- [ ] `kind/cleanup`
- [x] `kind/hardening`

## Validation

- `pnpm test` (host, vitest) → 2380 pass, 1 skip (2375 + the 5 added here).
- `pnpm exec tsc -p tsconfig.json --noEmit` → clean.
- `pnpm exec eslint` on the three changed files → 0 errors; the one `no-catch-all` warning at `session-events.ts:194` is pre-existing (the truth-read catch in `#verify`), unchanged by this PR. The new catch carries a scoped disable with its rationale.
- Container tests not run: no `container/agent-runner/` files are touched.
- New tests — `src/drivers/session-events.test.ts`, describe `a watch feed that cannot run is inert, never fatal` (all three fail on the parent commit, verified by stashing the source change):
  - `does not invent watchSessions for a driver that lacks it` — the wrapper mirrors absence, so the downstream `typeof` probe stays honest.
  - `keeps arming when the watch backend refuses to subscribe` — `onTerminal` does not throw, and the session still reaches its terminal through `resync`.
  - `re-attempts the subscription on the next arm instead of caching the failure` — first arm throws, second subscribes for real and delivers a streamed terminal.
- New tests — `src/host-sweep.feeds.test.ts` (floor tests: these pin the guarantee on the sweep side, which already held):
  - `keeps sweeping when the selected driver has no watch feed`.
  - `keeps sweeping when the watch backend refuses to subscribe` — the tick still reconciles, the explicit-enqueue feed still works, and `stopHostSweep()` stays clean.

- [x] Tests cover the changed behavior (or Validation says why not)

## User and release impact

- [ ] No user-visible behavior change
- [x] User-visible change — release note below
- [ ] Breaking change — release note below covers detect, why, fix/migration, rollback

```release-note
A container runtime whose event stream cannot be subscribed to no longer fails host startup or session spawns — the watch feed is skipped, logged, and retried, and session ends are still detected through the periodic resync.
```

## Security and trust boundaries

None. No changes to permissions, credentials, claims, or fencing. Adoption's claim-first, fail-closed path is untouched; this only stops a best-effort observability feed from throwing into it.

## Skill delivery

- [x] Not a skill
- [ ] Skill: apply/remove footprint and fresh-clone verification are described above

## AI assistance

- [x] AI tools or agents helped produce this change

<!-- Required. -->
- [ ] A human has reviewed this PR and stands behind every change