### PR TITLE
fix(setup): restore the agent provider picker for fresh installs

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -1508,17 +1508,17 @@ async function askAgentProviderChoice(): Promise<string> {
       hint: note(prov.value, `${prov.hint} — installs now`),
     })),
   ];
+  // Only an explicit preset skips the picker (packaged flows). Every
+  // interactive install — fresh or re-run — is asked, so a non-Claude runtime
+  // is discoverable rather than something only a re-run with env vars reaches.
   const preset = process.env.NANOCLAW_AGENT_PROVIDER?.trim().toLowerCase();
-  // Fresh installs use Claude without another setup prompt. Explicit presets
-  // still win, and an existing non-Claude default keeps its provider picker.
-  const automatic = preset || (DEFAULT_AGENT_PROVIDER === 'claude' ? 'claude' : undefined);
-  if (automatic) {
-    if (!options.some((option) => option.value === automatic)) {
+  if (preset) {
+    if (!options.some((option) => option.value === preset)) {
       throw new Error(`NANOCLAW_AGENT_PROVIDER=${preset} is not available in this NanoClaw install`);
     }
-    setupLog.userInput('agent_provider', automatic);
-    phEmit('agent_provider_chosen', { provider: automatic, preset: Boolean(preset) });
-    return automatic;
+    setupLog.userInput('agent_provider', preset);
+    phEmit('agent_provider_chosen', { provider: preset, preset: true });
+    return preset;
   }
   // The pick is persisted as the instance default (DEFAULT_AGENT_PROVIDER), so
   // pre-select the current default — a re-run Enter-through then preserves it


### PR DESCRIPTION
## Summary

PR #3729 (community portal) changed \`askAgentProviderChoice\` in \`setup/auto.ts\` to skip the runtime picker whenever \`DEFAULT_AGENT_PROVIDER\` resolved to \`claude\`. That is every fresh install, so first-time users never saw the "Which agent runtime should power your assistant?" step and could not pick Codex/OpenCode during setup.

This restores the previous contract, already documented in the file header: only an explicit \`NANOCLAW_AGENT_PROVIDER\` preset skips the picker. Interactive installs, fresh or re-run, are asked, pre-selected to the current default.

## Test plan

- [x] \`pnpm test\` — full suite passes (213 files, 2522 tests)
- [x] \`tsc --noEmit\` — no errors in \`setup/\` (pre-existing unrelated errors in \`src/webhook-server.ts\`)
- [ ] Fresh \`/setup\` run shows the provider select; \`NANOCLAW_AGENT_PROVIDER=claude\` still skips it

🤖 Generated with [Claude Code](https://claude.com/claude-code)